### PR TITLE
Add calendar export utilities (.ics, add-to-calendar links, RateMyProfessor lookup)

### DIFF
--- a/src/lib/__tests__/calendarLinks.test.ts
+++ b/src/lib/__tests__/calendarLinks.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import type { Course, ScheduleItem } from '@/types/schedule';
+import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
+
+const course: Course = {
+  id: 'c1',
+  code: 'CSCI 213',
+  title: 'Computer Science I',
+  instructor: 'Dr. Jane Smith',
+};
+
+function makeItem(overrides: Partial<ScheduleItem> = {}): ScheduleItem {
+  return {
+    id: 'item-1',
+    courseId: 'c1',
+    title: 'Homework 1',
+    type: 'assignment',
+    dueDate: '2026-09-01T17:00:00.000Z',
+    completed: false,
+    ...overrides,
+  };
+}
+
+describe('generateGoogleCalendarUrl', () => {
+  it('builds a TEMPLATE render URL with encoded text and dates', () => {
+    const url = generateGoogleCalendarUrl(makeItem(), course);
+    const parsed = new URL(url);
+
+    expect(parsed.origin + parsed.pathname).toBe('https://calendar.google.com/calendar/render');
+    expect(parsed.searchParams.get('action')).toBe('TEMPLATE');
+    expect(parsed.searchParams.get('text')).toBe('CSCI 213: Homework 1');
+    expect(parsed.searchParams.get('dates')).toBe('20260901T170000Z/20260901T180000Z');
+  });
+
+  it('encodes special characters in the instructor name and title', () => {
+    const url = generateGoogleCalendarUrl(makeItem({ title: 'Essay, Draft & Review' }), {
+      ...course,
+      instructor: "Dr. O'Malley & Smith",
+    });
+    // Raw special characters must not appear unencoded in the query string.
+    expect(url).not.toContain('&Review'); // would indicate an unencoded literal "&"
+    expect(url).toContain(encodeURIComponent('Essay, Draft & Review').replace(/%20/g, '+'));
+  });
+
+  it('uses all-day date-only range for a bare YYYY-MM-DD dueDate', () => {
+    const url = generateGoogleCalendarUrl(makeItem({ dueDate: '2026-09-01' }), course);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('dates')).toBe('20260901/20260902');
+  });
+
+  it('omits details param when there is no course/notes info', () => {
+    const url = generateGoogleCalendarUrl(makeItem());
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('details')).toBe(false);
+  });
+
+  it('includes instructor and notes in details when present', () => {
+    const url = generateGoogleCalendarUrl(makeItem({ notes: 'Bring calculator' }), course);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('details')).toBe('Instructor: Dr. Jane Smith\nBring calculator');
+  });
+});
+
+describe('generateOutlookCalendarUrl', () => {
+  it('builds an Outlook deeplink compose URL with ISO start/end', () => {
+    const url = generateOutlookCalendarUrl(makeItem(), course);
+    const parsed = new URL(url);
+
+    expect(parsed.origin + parsed.pathname).toBe(
+      'https://outlook.live.com/calendar/0/deeplink/compose',
+    );
+    expect(parsed.searchParams.get('subject')).toBe('CSCI 213: Homework 1');
+    expect(parsed.searchParams.get('startdt')).toBe('2026-09-01T17:00:00.000Z');
+    expect(parsed.searchParams.get('enddt')).toBe('2026-09-01T18:00:00.000Z');
+    expect(parsed.searchParams.get('allday')).toBe('false');
+  });
+
+  it('marks all-day for a bare YYYY-MM-DD dueDate', () => {
+    const url = generateOutlookCalendarUrl(makeItem({ dueDate: '2026-09-01' }), course);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('allday')).toBe('true');
+  });
+
+  it('works with no course and no notes (missing optional fields)', () => {
+    const url = generateOutlookCalendarUrl(makeItem());
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('subject')).toBe('Homework 1');
+    expect(parsed.searchParams.has('body')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/exportDateUtils.test.ts
+++ b/src/lib/__tests__/exportDateUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEventWindow,
+  isDateOnly,
+  formatUTCBasic,
+  formatDateBasic,
+} from '@/lib/export/dateUtils';
+
+describe('isDateOnly', () => {
+  it('recognizes bare YYYY-MM-DD strings', () => {
+    expect(isDateOnly('2026-09-01')).toBe(true);
+  });
+
+  it('rejects full ISO timestamps', () => {
+    expect(isDateOnly('2026-09-01T17:00:00.000Z')).toBe(false);
+  });
+});
+
+describe('getEventWindow', () => {
+  it('treats a bare date as an all-day event spanning to the next day', () => {
+    const { start, end, allDay } = getEventWindow({ dueDate: '2026-09-01' });
+    expect(allDay).toBe(true);
+    expect(start.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    expect(end.toISOString()).toBe('2026-09-02T00:00:00.000Z');
+  });
+
+  it('defaults to a 1-hour duration for timed events with no estimatedHours', () => {
+    const { start, end, allDay } = getEventWindow({ dueDate: '2026-09-01T17:00:00.000Z' });
+    expect(allDay).toBe(false);
+    expect(end.getTime() - start.getTime()).toBe(60 * 60 * 1000);
+  });
+
+  it('uses estimatedHours to compute the duration', () => {
+    const { start, end } = getEventWindow({
+      dueDate: '2026-09-01T17:00:00.000Z',
+      estimatedHours: 2.5,
+    });
+    expect(end.getTime() - start.getTime()).toBe(2.5 * 60 * 60 * 1000);
+  });
+
+  it('ignores a zero or negative estimatedHours and falls back to the default duration', () => {
+    const { start, end } = getEventWindow({
+      dueDate: '2026-09-01T17:00:00.000Z',
+      estimatedHours: 0,
+    });
+    expect(end.getTime() - start.getTime()).toBe(60 * 60 * 1000);
+  });
+
+  it('throws on an unparseable dueDate', () => {
+    expect(() => getEventWindow({ dueDate: 'not-a-date' })).toThrow();
+  });
+});
+
+describe('formatUTCBasic / formatDateBasic', () => {
+  it('formats a UTC timestamp as YYYYMMDDTHHMMSSZ', () => {
+    expect(formatUTCBasic(new Date('2026-01-05T09:03:07.000Z'))).toBe('20260105T090307Z');
+  });
+
+  it('formats a UTC date as YYYYMMDD', () => {
+    expect(formatDateBasic(new Date('2026-01-05T09:03:07.000Z'))).toBe('20260105');
+  });
+});

--- a/src/lib/__tests__/ics.test.ts
+++ b/src/lib/__tests__/ics.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import type { Course, ScheduleItem } from '@/types/schedule';
+import {
+  escapeICSText,
+  foldICSLine,
+  generateICS,
+  scheduleItemToVEvent,
+  buildICSUid,
+  createICSBlob,
+  buildICSFilename,
+} from '@/lib/export/ics';
+
+const NOW = new Date('2026-08-15T12:00:00.000Z');
+
+const course: Course = {
+  id: 'c1',
+  code: 'CSCI 213',
+  title: 'Computer Science I',
+  instructor: 'Dr. Jane Smith',
+  term: 'Fall 2026',
+};
+
+function makeItem(overrides: Partial<ScheduleItem> = {}): ScheduleItem {
+  return {
+    id: 'item-1',
+    courseId: 'c1',
+    title: 'Homework 1',
+    type: 'assignment',
+    dueDate: '2026-09-01T17:00:00.000Z',
+    completed: false,
+    ...overrides,
+  };
+}
+
+describe('escapeICSText', () => {
+  it('escapes backslashes, commas, and semicolons', () => {
+    expect(escapeICSText('a,b;c\\d')).toBe('a\\,b\\;c\\\\d');
+  });
+
+  it('escapes backslash before other characters so output is not double-escaped', () => {
+    // A literal backslash followed by a comma should become \\\, not \\\\,
+    expect(escapeICSText('\\,')).toBe('\\\\\\,');
+  });
+
+  it('converts newlines to the literal \\n escape sequence', () => {
+    expect(escapeICSText('line1\nline2')).toBe('line1\\nline2');
+    expect(escapeICSText('line1\r\nline2')).toBe('line1\\nline2');
+  });
+});
+
+describe('foldICSLine', () => {
+  it('leaves short lines untouched', () => {
+    const line = 'SUMMARY:Short title';
+    expect(foldICSLine(line)).toBe(line);
+  });
+
+  it('folds a line longer than 75 octets at the 75th octet, with a leading space continuation', () => {
+    const longValue = 'X'.repeat(100);
+    const line = `SUMMARY:${longValue}`;
+    const folded = foldICSLine(line);
+
+    expect(folded).toContain('\r\n ');
+
+    const segments = folded.split('\r\n ');
+    // First segment must be exactly 75 octets (all ASCII here, so bytes === chars).
+    expect(new TextEncoder().encode(segments[0]).length).toBe(75);
+    // Continuation segments must be at most 74 octets (75 minus the leading space).
+    for (const seg of segments.slice(1)) {
+      expect(new TextEncoder().encode(seg).length).toBeLessThanOrEqual(74);
+    }
+    // Rejoining (minus the folding artifacts) must reproduce the original content.
+    expect(segments.join('')).toBe(line);
+  });
+
+  it('does not split a multi-byte UTF-8 character across a fold boundary', () => {
+    // Use a multi-byte character repeated so the fold boundary would land
+    // mid-character if we folded on naive character counts.
+    const value = 'é'.repeat(60); // 'é', 2 octets each in UTF-8 = 120 octets
+    const line = `SUMMARY:${value}`;
+    const folded = foldICSLine(line);
+
+    for (const segment of folded.split('\r\n ')) {
+      // A valid UTF-8 string decodes/re-encodes without replacement characters.
+      const bytes = new TextEncoder().encode(segment);
+      expect(new TextDecoder('utf-8', { fatal: true }).decode(bytes)).toBe(segment);
+    }
+  });
+});
+
+describe('buildICSUid', () => {
+  it('is deterministic for a given item id', () => {
+    expect(buildICSUid({ id: 'abc' })).toBe(buildICSUid({ id: 'abc' }));
+    expect(buildICSUid({ id: 'abc' })).toBe('abc@syllabus-sense.app');
+  });
+});
+
+describe('scheduleItemToVEvent', () => {
+  it('includes required VEVENT properties', () => {
+    const vevent = scheduleItemToVEvent(makeItem(), course, NOW);
+
+    expect(vevent).toContain('BEGIN:VEVENT');
+    expect(vevent).toContain('END:VEVENT');
+    expect(vevent).toContain('UID:item-1@syllabus-sense.app');
+    expect(vevent).toContain('DTSTAMP:20260815T120000Z');
+    expect(vevent).toContain('DTSTART:20260901T170000Z');
+    expect(vevent).toContain('SUMMARY:CSCI 213: Homework 1');
+  });
+
+  it('produces a timed event with default 1-hour duration when estimatedHours is missing', () => {
+    const vevent = scheduleItemToVEvent(makeItem(), course, NOW);
+    expect(vevent).toContain('DTEND:20260901T180000Z');
+  });
+
+  it('uses estimatedHours for DTEND when provided', () => {
+    const vevent = scheduleItemToVEvent(makeItem({ estimatedHours: 2.5 }), course, NOW);
+    expect(vevent).toContain('DTSTART:20260901T170000Z');
+    expect(vevent).toContain('DTEND:20260901T193000Z');
+  });
+
+  it('produces an all-day VALUE=DATE event for a bare YYYY-MM-DD dueDate', () => {
+    const vevent = scheduleItemToVEvent(makeItem({ dueDate: '2026-09-01' }), course, NOW);
+    expect(vevent).toContain('DTSTART;VALUE=DATE:20260901');
+    expect(vevent).toContain('DTEND;VALUE=DATE:20260902');
+  });
+
+  it('escapes commas, semicolons, and newlines in the title', () => {
+    const vevent = scheduleItemToVEvent(
+      makeItem({ title: 'Essay, Part 2; Final Draft' }),
+      course,
+      NOW,
+    );
+    expect(vevent).toContain('SUMMARY:CSCI 213: Essay\\, Part 2\\; Final Draft');
+  });
+
+  it('folds a very long title across multiple lines', () => {
+    const longTitle = 'A very long assignment title that keeps going '.repeat(4).trim();
+    const vevent = scheduleItemToVEvent(makeItem({ title: longTitle }), course, NOW);
+    const summaryLine = vevent.split('\r\n').findIndex((l) => l.startsWith('SUMMARY:'));
+    expect(summaryLine).toBeGreaterThanOrEqual(0);
+    // The line after SUMMARY's start should be a folded continuation (leading space)
+    // whenever the summary exceeds 75 octets.
+    const fullEvent = vevent.split('\r\n');
+    const summaryStartsAt = fullEvent.findIndex((l) => l.startsWith('SUMMARY:'));
+    if (new TextEncoder().encode(fullEvent[summaryStartsAt]).length >= 75) {
+      expect(fullEvent[summaryStartsAt + 1]?.startsWith(' ')).toBe(true);
+    }
+  });
+
+  it('omits course prefix and instructor line when no course is provided', () => {
+    const vevent = scheduleItemToVEvent(makeItem(), undefined, NOW);
+    expect(vevent).toContain('SUMMARY:Homework 1');
+    expect(vevent).not.toContain('Instructor:');
+  });
+
+  it('includes notes in DESCRIPTION when present, omits DESCRIPTION when absent', () => {
+    const withNotes = scheduleItemToVEvent(makeItem({ notes: 'Bring calculator' }), course, NOW);
+    expect(withNotes).toContain('DESCRIPTION:Instructor: Dr. Jane Smith\\nBring calculator');
+
+    const withoutNotes = scheduleItemToVEvent(makeItem(), undefined, NOW);
+    expect(withoutNotes).not.toContain('DESCRIPTION:');
+  });
+});
+
+describe('generateICS', () => {
+  it('wraps events in a valid VCALENDAR with required calendar properties', () => {
+    const ics = generateICS([makeItem()], [course], NOW);
+
+    expect(ics.startsWith('BEGIN:VCALENDAR\r\n')).toBe(true);
+    expect(ics).toContain('VERSION:2.0');
+    expect(ics).toContain('PRODID:-//Syllabus Sense//Calendar Export//EN');
+    expect(ics.trim().endsWith('END:VCALENDAR')).toBe(true);
+  });
+
+  it('uses CRLF line endings throughout, never a bare LF', () => {
+    const ics = generateICS([makeItem()], [course], NOW);
+    // Normalize CRLF away, then assert no lone LF remains.
+    const withoutCRLF = ics.replace(/\r\n/g, '');
+    expect(withoutCRLF.includes('\n')).toBe(false);
+    expect(ics.includes('\r\n')).toBe(true);
+  });
+
+  it('produces one VEVENT per schedule item', () => {
+    const items = [makeItem({ id: 'a' }), makeItem({ id: 'b', title: 'HW2' })];
+    const ics = generateICS(items, [course], NOW);
+    expect(ics.split('BEGIN:VEVENT').length - 1).toBe(2);
+    expect(ics.split('END:VEVENT').length - 1).toBe(2);
+  });
+
+  it('handles an empty item array by producing a valid, event-less calendar', () => {
+    const ics = generateICS([], [course], NOW);
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('END:VCALENDAR');
+    expect(ics).not.toContain('BEGIN:VEVENT');
+  });
+
+  it('still exports an item whose course is missing from the courses array', () => {
+    const ics = generateICS([makeItem({ courseId: 'unknown' })], [course], NOW);
+    expect(ics).toContain('SUMMARY:Homework 1');
+  });
+});
+
+describe('createICSBlob', () => {
+  it('creates a Blob with the correct calendar MIME type', () => {
+    const blob = createICSBlob('BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n');
+    expect(blob.type).toBe('text/calendar;charset=utf-8');
+  });
+});
+
+describe('buildICSFilename', () => {
+  it('sanitizes unsafe characters and appends .ics', () => {
+    expect(buildICSFilename('My Schedule: Fall 2026!')).toBe('My-Schedule-Fall-2026.ics');
+  });
+
+  it('falls back to a default name when input is empty', () => {
+    expect(buildICSFilename('   ')).toBe('schedule.ics');
+  });
+});

--- a/src/lib/__tests__/rateMyProfessor.test.ts
+++ b/src/lib/__tests__/rateMyProfessor.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { generateRateMyProfessorUrl } from '@/lib/export/rateMyProfessor';
+
+describe('generateRateMyProfessorUrl', () => {
+  it('builds a search URL with the instructor name as the query', () => {
+    const url = generateRateMyProfessorUrl('Jane Smith');
+    const parsed = new URL(url as string);
+
+    expect(parsed.origin + parsed.pathname).toBe(
+      'https://www.ratemyprofessors.com/search/professors',
+    );
+    expect(parsed.searchParams.get('q')).toBe('Jane Smith');
+  });
+
+  it('encodes special characters and spaces in the instructor name', () => {
+    const url = generateRateMyProfessorUrl("Dr. O'Malley & Smith, Jr.") as string;
+    expect(url).not.toContain(' '); // raw spaces must be encoded
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('q')).toBe("Dr. O'Malley & Smith, Jr.");
+  });
+
+  it('trims surrounding whitespace before searching', () => {
+    const url = generateRateMyProfessorUrl('  Jane Smith  ') as string;
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('q')).toBe('Jane Smith');
+  });
+
+  it('returns undefined for a missing instructor name', () => {
+    expect(generateRateMyProfessorUrl(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a blank/whitespace-only instructor name', () => {
+    expect(generateRateMyProfessorUrl('   ')).toBeUndefined();
+  });
+});

--- a/src/lib/export/calendarLinks.ts
+++ b/src/lib/export/calendarLinks.ts
@@ -1,0 +1,67 @@
+/**
+ * "Add to calendar" deep-link builders for Google Calendar and Outlook web.
+ * These don't require a downloaded file — clicking the link opens the
+ * respective web calendar with the event pre-filled.
+ */
+import type { Course, ScheduleItem } from '@/types/schedule';
+import { formatDateBasic, formatUTCBasic, getEventWindow } from './dateUtils';
+
+function buildSummary(item: Pick<ScheduleItem, 'title'>, course: Course | undefined): string {
+  return course ? `${course.code}: ${item.title}` : item.title;
+}
+
+function buildDetails(item: Pick<ScheduleItem, 'notes'>, course: Course | undefined): string {
+  const parts: string[] = [];
+  if (course?.instructor) parts.push(`Instructor: ${course.instructor}`);
+  if (item.notes) parts.push(item.notes);
+  return parts.join('\n');
+}
+
+/**
+ * Builds a Google Calendar "render" template URL that pre-fills an event
+ * for the given schedule item.
+ *
+ * See: https://calendar.google.com/calendar/render?action=TEMPLATE
+ */
+export function generateGoogleCalendarUrl(item: ScheduleItem, course?: Course): string {
+  const { start, end, allDay } = getEventWindow(item);
+
+  const dates = allDay
+    ? `${formatDateBasic(start)}/${formatDateBasic(end)}`
+    : `${formatUTCBasic(start)}/${formatUTCBasic(end)}`;
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: buildSummary(item, course),
+    dates,
+  });
+
+  const details = buildDetails(item, course);
+  if (details) params.set('details', details);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/**
+ * Builds an Outlook web "deeplink compose" URL that pre-fills an event for
+ * the given schedule item.
+ *
+ * See: https://outlook.live.com/calendar/0/deeplink/compose
+ */
+export function generateOutlookCalendarUrl(item: ScheduleItem, course?: Course): string {
+  const { start, end, allDay } = getEventWindow(item);
+
+  const params = new URLSearchParams({
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    subject: buildSummary(item, course),
+    startdt: start.toISOString(),
+    enddt: end.toISOString(),
+    allday: String(allDay),
+  });
+
+  const details = buildDetails(item, course);
+  if (details) params.set('body', details);
+
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+}

--- a/src/lib/export/dateUtils.ts
+++ b/src/lib/export/dateUtils.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared date/time helpers for the calendar export utilities (.ics generation
+ * and "add to calendar" link builders). Kept in one place so the .ics file,
+ * Google Calendar link, and Outlook link all agree on how a ScheduleItem's
+ * `dueDate` maps to a start/end window.
+ */
+import type { ScheduleItem } from '@/types/schedule';
+
+/** Default event length used when a ScheduleItem has no estimatedHours. */
+export const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * A ScheduleItem's `dueDate` may be a bare `YYYY-MM-DD` date or a full
+ * ISO-8601 timestamp. Bare dates are treated as all-day events; anything
+ * else is treated as a timed event.
+ */
+export function isDateOnly(dueDate: string): boolean {
+  return DATE_ONLY_PATTERN.test(dueDate);
+}
+
+export interface EventWindow {
+  start: Date;
+  end: Date;
+  allDay: boolean;
+}
+
+/**
+ * Resolves the start/end instants for a schedule item.
+ *
+ * - All-day (date-only) items get a UTC midnight start and an end that is
+ *   the *next* day at UTC midnight — the exclusive end date convention
+ *   RFC 5545 and every mainstream calendar client use for all-day events.
+ * - Timed items start at the parsed instant and run for `estimatedHours`
+ *   (falling back to DEFAULT_EVENT_DURATION_MS) so the event has a
+ *   nonzero, sensible duration even when no estimate was recorded.
+ */
+export function getEventWindow(
+  item: Pick<ScheduleItem, 'dueDate' | 'estimatedHours'>,
+): EventWindow {
+  if (isDateOnly(item.dueDate)) {
+    const [year, month, day] = item.dueDate.split('-').map(Number);
+    const start = new Date(Date.UTC(year, month - 1, day));
+    const end = new Date(Date.UTC(year, month - 1, day + 1));
+    return { start, end, allDay: true };
+  }
+
+  const start = new Date(item.dueDate);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error(`Invalid dueDate: "${item.dueDate}"`);
+  }
+
+  const durationMs =
+    item.estimatedHours && item.estimatedHours > 0
+      ? item.estimatedHours * 60 * 60 * 1000
+      : DEFAULT_EVENT_DURATION_MS;
+
+  return { start, end: new Date(start.getTime() + durationMs), allDay: false };
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+/** Formats a Date as an RFC 5545 UTC timestamp: YYYYMMDDTHHMMSSZ. */
+export function formatUTCBasic(date: Date): string {
+  return (
+    `${date.getUTCFullYear()}${pad2(date.getUTCMonth() + 1)}${pad2(date.getUTCDate())}` +
+    `T${pad2(date.getUTCHours())}${pad2(date.getUTCMinutes())}${pad2(date.getUTCSeconds())}Z`
+  );
+}
+
+/** Formats a Date as an RFC 5545 DATE value: YYYYMMDD (used for all-day events). */
+export function formatDateBasic(date: Date): string {
+  return `${date.getUTCFullYear()}${pad2(date.getUTCMonth() + 1)}${pad2(date.getUTCDate())}`;
+}

--- a/src/lib/export/ics.ts
+++ b/src/lib/export/ics.ts
@@ -1,0 +1,164 @@
+/**
+ * RFC 5545 (iCalendar) .ics file generation, entirely client-side and
+ * dependency-free. Produces a single VCALENDAR containing one VEVENT per
+ * ScheduleItem so a user can export their whole schedule (or a filtered
+ * subset) and import it into Google Calendar, Outlook, Apple Calendar, etc.
+ *
+ * Every function here is pure: callers pass in `now` explicitly instead of
+ * this module reaching for `Date.now()`, so output is deterministic and
+ * trivially testable.
+ */
+import type { Course, ScheduleItem } from '@/types/schedule';
+import { formatUTCBasic, formatDateBasic, getEventWindow } from './dateUtils';
+
+const PRODID = '-//Syllabus Sense//Calendar Export//EN';
+const CRLF = '\r\n';
+
+/**
+ * RFC 5545 §3.1 requires content lines to be folded so no line exceeds 75
+ * *octets* (bytes, not UTF-16 code units — a title with emoji or accented
+ * characters can be multiple octets per character). Continuation lines are
+ * introduced by CRLF followed by a single linear whitespace character; that
+ * leading space itself counts as one of the 75 octets on the continuation
+ * line, which is why the per-line budget drops to 74 after the first line.
+ *
+ * We fold on UTF-8 octet boundaries and never split a multi-byte character,
+ * since doing so would corrupt the text when decoded by the receiving
+ * client.
+ */
+export function foldICSLine(line: string): string {
+  const bytes = new TextEncoder().encode(line);
+  if (bytes.length <= 75) return line;
+
+  const decoder = new TextDecoder();
+  const segments: string[] = [];
+  let start = 0;
+  let budget = 75;
+
+  while (start < bytes.length) {
+    let end = Math.min(start + budget, bytes.length);
+    // Back off if `end` lands inside a multi-byte UTF-8 sequence: continuation
+    // bytes match the 10xxxxxx bit pattern (0x80-0xBF).
+    while (end > start && end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    segments.push(decoder.decode(bytes.slice(start, end)));
+    start = end;
+    budget = 74; // leading continuation space counts toward the 75-octet cap
+  }
+
+  return segments.join(CRLF + ' ');
+}
+
+/**
+ * Escapes a TEXT value per RFC 5545 §3.3.11: backslash, comma, and
+ * semicolon are escaped, and newlines become the literal two-character
+ * sequence `\n`. Backslash must be escaped first so we don't double-escape
+ * the backslashes introduced by the other replacements.
+ */
+export function escapeICSText(text: string): string {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\r|\n/g, '\\n');
+}
+
+/** Builds a stable, deterministic UID for a schedule item's VEVENT. */
+export function buildICSUid(item: Pick<ScheduleItem, 'id'>): string {
+  return `${item.id}@syllabus-sense.app`;
+}
+
+function buildContentLine(name: string, value: string): string {
+  return foldICSLine(`${name}:${value}`);
+}
+
+/**
+ * Renders a single ScheduleItem as a VEVENT block (without BEGIN/END
+ * wrapper newlines already joined by the caller).
+ */
+export function scheduleItemToVEvent(
+  item: ScheduleItem,
+  course: Course | undefined,
+  now: Date,
+): string {
+  const { start, end, allDay } = getEventWindow(item);
+
+  const summary = course ? `${course.code}: ${item.title}` : item.title;
+
+  const descriptionParts: string[] = [];
+  if (course?.instructor) descriptionParts.push(`Instructor: ${course.instructor}`);
+  if (item.notes) descriptionParts.push(item.notes);
+  const description = descriptionParts.join('\n');
+
+  const lines: string[] = [
+    'BEGIN:VEVENT',
+    buildContentLine('UID', buildICSUid(item)),
+    buildContentLine('DTSTAMP', formatUTCBasic(now)),
+  ];
+
+  if (allDay) {
+    lines.push(buildContentLine('DTSTART;VALUE=DATE', formatDateBasic(start)));
+    lines.push(buildContentLine('DTEND;VALUE=DATE', formatDateBasic(end)));
+  } else {
+    lines.push(buildContentLine('DTSTART', formatUTCBasic(start)));
+    lines.push(buildContentLine('DTEND', formatUTCBasic(end)));
+  }
+
+  lines.push(buildContentLine('SUMMARY', escapeICSText(summary)));
+
+  if (description) {
+    lines.push(buildContentLine('DESCRIPTION', escapeICSText(description)));
+  }
+
+  lines.push(buildContentLine('CATEGORIES', escapeICSText(item.type.toUpperCase())));
+  lines.push('END:VEVENT');
+
+  return lines.join(CRLF);
+}
+
+/**
+ * Generates a complete .ics document for a set of schedule items.
+ *
+ * @param items    Schedule items to export.
+ * @param courses  Courses referenced by `items` (looked up by courseId);
+ *                 items whose course isn't found are still exported, just
+ *                 without a course prefix/instructor line.
+ * @param now      The current timestamp, used for DTSTAMP. Passed explicitly
+ *                 so output is deterministic in tests.
+ */
+export function generateICS(items: ScheduleItem[], courses: Course[], now: Date): string {
+  const coursesById = new Map(courses.map((c) => [c.id, c]));
+
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    buildContentLine('VERSION', '2.0'),
+    buildContentLine('PRODID', PRODID),
+    buildContentLine('CALSCALE', 'GREGORIAN'),
+  ];
+
+  for (const item of items) {
+    lines.push(scheduleItemToVEvent(item, coursesById.get(item.courseId), now));
+  }
+
+  lines.push('END:VCALENDAR');
+
+  // Trailing CRLF: RFC 5545 content lines are each terminated by CRLF,
+  // including the last one.
+  return lines.join(CRLF) + CRLF;
+}
+
+/** Wraps generated .ics text in a Blob suitable for client-side download. */
+export function createICSBlob(icsContent: string): Blob {
+  return new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+}
+
+/** Produces a filesystem-safe .ics filename for a schedule export. */
+export function buildICSFilename(baseName: string): string {
+  const safe =
+    baseName
+      .trim()
+      .replace(/[^a-z0-9-_]+/gi, '-')
+      .replace(/^-+|-+$/g, '') || 'schedule';
+  return `${safe}.ics`;
+}

--- a/src/lib/export/rateMyProfessor.ts
+++ b/src/lib/export/rateMyProfessor.ts
@@ -1,0 +1,23 @@
+/**
+ * RateMyProfessors lookup URL generator.
+ *
+ * We deliberately generate a *search* URL rather than a direct profile URL:
+ * RMP profile URLs are keyed by an internal numeric professor ID that isn't
+ * derivable from a name, and guessing/fabricating one would silently link
+ * to the wrong professor (or a 404). A search results page is always
+ * correct and lets the user pick the right match themselves.
+ */
+
+/**
+ * Builds a RateMyProfessors search URL for the given instructor name.
+ * Returns `undefined` when there's no usable name to search for, so
+ * callers can skip rendering a link entirely rather than linking to an
+ * empty search.
+ */
+export function generateRateMyProfessorUrl(instructorName: string | undefined): string | undefined {
+  const trimmed = instructorName?.trim();
+  if (!trimmed) return undefined;
+
+  const params = new URLSearchParams({ q: trimmed });
+  return `https://www.ratemyprofessors.com/search/professors?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- Adds pure, dependency-free TypeScript utilities under `src/lib/export/` for Epic 9's calendar export and instructor lookup features.
- `ics.ts`: RFC 5545 compliant `.ics` generation (CRLF line endings, TEXT escaping, 75-octet line folding on UTF-8 boundaries, all-day vs timed events).
- `calendarLinks.ts`: Google Calendar and Outlook web "add event" deep links.
- `rateMyProfessor.ts`: RateMyProfessors search URL generator (search page, not a guessed profile ID).
- `dateUtils.ts`: shared date/duration resolution used by the above.
- No UI components, pages, or existing files were touched.

QR code generation (#72) is deferred — no QR library is currently installed in `package.json`, and adding a new dependency (or hand-rolling an encoder) is out of scope for this PR.

Closes #65, closes #66, closes #67

## Test plan
- [x] `npm run lint` — zero warnings
- [x] `npm run test -- --run` — 98 tests pass across 15 files, including new adversarial cases (commas/semicolons/newlines in titles, long-title line folding, missing optional fields, empty item arrays)
- [x] `npm run build` — succeeds