### PR TITLE
Redesign Calendar: recurring class meetings, Month/Week/Agenda, export

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -1,18 +1,33 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type KeyboardEvent } from 'react';
 import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { TaskRow } from '@/components/ui/TaskRow';
+import { WeekView } from '@/components/calendar/WeekView';
 import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import {
+  addDays,
   addMonths,
   getMonthGrid,
+  getWeekDays,
   groupItemsByDay,
   isSameDay,
   toDayKey,
   startOfDay,
 } from '@/lib/calendar/dates';
+import {
+  formatTimeLabel,
+  getMeetingsForDay,
+  type MeetingOccurrence,
+} from '@/lib/calendar/meetings';
 import { cn } from '@/lib/utils';
-import type { ScheduleItem } from '@/types/schedule';
+import { calculateDailyLoad, getWorkloadLevel, WORKLOAD_LEVEL_LABELS } from '@/lib/workload';
+import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
+import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
+import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
 
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const monthLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
@@ -21,143 +36,719 @@ const dayLabelFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
   day: 'numeric',
 });
+const agendaDayLabelFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+const weekLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+
+function formatWeekRangeLabel(weekDays: Date[]): string {
+  const start = weekDays[0];
+  const end = weekDays[weekDays.length - 1];
+  const sameMonth = start.getMonth() === end.getMonth();
+  const startLabel = weekLabelFormatter.format(start);
+  const endLabel = sameMonth ? String(end.getDate()) : weekLabelFormatter.format(end);
+  return `${startLabel} – ${endLabel}, ${end.getFullYear()}`;
+}
+
+const MAX_VISIBLE_CHIPS = 2;
+const AGENDA_WINDOW_DAYS = 30;
+
+/** Subtle per-cell background tint keyed off the day's cognitive-load level -
+ * the calendar surfaces the workload engine (Epic 7) instead of only ever
+ * showing raw due-date dots. Deliberately faint (low opacity) so it reads as
+ * texture, not as a competing signal to the "today" treatment. */
+const HEAT_TINT_CLASS: Record<WorkloadLevel, string> = {
+  low: '',
+  medium: 'bg-load-medium/10',
+  high: 'bg-load-high/10',
+  critical: 'bg-load-critical/15',
+};
+
+const HEAT_SWATCH_CLASS: Record<WorkloadLevel, string> = {
+  low: 'bg-load-low',
+  medium: 'bg-load-medium',
+  high: 'bg-load-high',
+  critical: 'bg-load-critical',
+};
+
+/** Tinted chip background for the legend, keyed the same as the swatch color
+ * so each workload level reads as one cohesive color-coded badge rather than
+ * a plain dot floating next to text. */
+const HEAT_CHIP_CLASS: Record<WorkloadLevel, string> = {
+  low: 'border-load-low/30 bg-load-low/10',
+  medium: 'border-load-medium/30 bg-load-medium/10',
+  high: 'border-load-high/30 bg-load-high/10',
+  critical: 'border-load-critical/30 bg-load-critical/10',
+};
+
+const LEGEND_LEVELS: WorkloadLevel[] = ['low', 'medium', 'high', 'critical'];
+
+type ViewMode = 'month' | 'week' | 'agenda';
 
 export function MonthCalendar() {
-  const { state } = useAppState();
+  const { state, dispatch } = useAppState();
+  const { user } = useAuth();
+  const [viewMode, setViewMode] = useState<ViewMode>('month');
   const [viewMonth, setViewMonth] = useState(() => startOfDay(new Date()));
+  const [weekAnchor, setWeekAnchor] = useState(() => startOfDay(new Date()));
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
+  const [hiddenCourseIds, setHiddenCourseIds] = useState<Set<string>>(new Set());
+  const [showCompleted, setShowCompleted] = useState(true);
+  const [showClasses, setShowClasses] = useState(true);
 
   const today = useMemo(() => startOfDay(new Date()), []);
   const itemsByDay = useMemo(() => groupItemsByDay(state.scheduleItems), [state.scheduleItems]);
   const grid = useMemo(() => getMonthGrid(viewMonth), [viewMonth]);
+  const weekDays = useMemo(() => getWeekDays(weekAnchor), [weekAnchor]);
 
-  const courseColor = (item: ScheduleItem) =>
-    state.courses.find((c) => c.id === item.courseId)?.color || 'bg-primary';
+  // The workload engine normalizes to UTC midnight internally (see
+  // lib/workload/dateUtils.ts); constructing the reference date from local
+  // Y/M/D components (rather than passing `today` straight through) keeps
+  // that math aligned with the user's actual local calendar, matching the
+  // same pattern used in computeSmartPlan.ts.
+  const workloadReferenceDate = useMemo(
+    () => new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())),
+    [today],
+  );
+  const dailyLoad = useMemo(
+    () => calculateDailyLoad(state.scheduleItems, workloadReferenceDate),
+    [state.scheduleItems, workloadReferenceDate],
+  );
 
-  const selectedItems = selectedDay ? (itemsByDay.get(toDayKey(selectedDay)) ?? []) : [];
+  const courseOf = (item: ScheduleItem) => state.courses.find((c) => c.id === item.courseId);
+  const courseColor = (item: ScheduleItem) => courseOf(item)?.color || 'bg-primary';
+
+  const toggleCourseVisibility = (courseId: string) => {
+    setHiddenCourseIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(courseId)) next.delete(courseId);
+      else next.add(courseId);
+      return next;
+    });
+  };
+
+  const visibleDayItems = (day: Date): ScheduleItem[] => {
+    const items = itemsByDay.get(toDayKey(day)) ?? [];
+    return items.filter(
+      (item) => !hiddenCourseIds.has(item.courseId) && (showCompleted || !item.completed),
+    );
+  };
+
+  const visibleMeetings = (day: Date): MeetingOccurrence[] => {
+    if (!showClasses) return [];
+    return getMeetingsForDay(state.courses, day).filter((m) => !hiddenCourseIds.has(m.course.id));
+  };
+
+  // Monthly stats: pending load and the single busiest day, computed only
+  // over cells that belong to the month actually being viewed (the grid pads
+  // in adjacent-month days, which shouldn't skew "this month" numbers).
+  const monthStats = useMemo(() => {
+    let pendingCount = 0;
+    let totalHours = 0;
+    let busiestDay: { day: Date; hours: number } | null = null;
+
+    for (const day of grid) {
+      if (day.getMonth() !== viewMonth.getMonth()) continue;
+      const items = itemsByDay.get(toDayKey(day)) ?? [];
+      pendingCount += items.filter((i) => !i.completed).length;
+      const hours = dailyLoad.get(toDayKey(day)) ?? 0;
+      totalHours += hours;
+      if (hours > 0 && (!busiestDay || hours > busiestDay.hours)) {
+        busiestDay = { day, hours };
+      }
+    }
+    return { pendingCount, totalHours, busiestDay };
+  }, [grid, viewMonth, itemsByDay, dailyLoad]);
+
+  const handleToggleComplete = async (item: ScheduleItem) => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+  };
+
+  // Exports every currently-visible (filter-respecting) item as a single
+  // .ics file the user can import into Google Calendar, Outlook, Apple
+  // Calendar, etc. - the built-but-previously-unwired export engine from
+  // PR #119, now finally reachable from real UI.
+  const handleExportICS = () => {
+    const visibleItems = state.scheduleItems.filter(
+      (item) => !hiddenCourseIds.has(item.courseId) && (showCompleted || !item.completed),
+    );
+    const ics = generateICS(visibleItems, state.courses, new Date());
+    const blob = createICSBlob(ics);
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = buildICSFilename('syllabus-sense-calendar');
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  const selectDay = (day: Date) => {
+    setSelectedDay(day);
+    if (day.getMonth() !== viewMonth.getMonth() || day.getFullYear() !== viewMonth.getFullYear()) {
+      setViewMonth(new Date(day.getFullYear(), day.getMonth(), 1));
+    }
+  };
+
+  // Arrow-key day-to-day navigation once a day is focused/selected, matching
+  // the roving-focus pattern real calendar widgets (Google Calendar,
+  // react-day-picker) use instead of forcing tab-through-42-cells.
+  const handleGridKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!selectedDay) return;
+    const deltaByKey: Record<string, number> = {
+      ArrowRight: 1,
+      ArrowLeft: -1,
+      ArrowDown: 7,
+      ArrowUp: -7,
+    };
+    const delta = deltaByKey[e.key];
+    if (delta === undefined) return;
+    e.preventDefault();
+    selectDay(addDays(selectedDay, delta));
+  };
+
+  const agendaDays = useMemo(
+    () => Array.from({ length: AGENDA_WINDOW_DAYS }, (_, i) => addDays(today, i)),
+    [today],
+  );
 
   return (
     <div className="space-y-4">
       <Card className="rounded-2xl p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-base font-semibold text-foreground">
-            {monthLabelFormatter.format(viewMonth)}
+          <h2 className="text-xl font-bold tracking-tight text-foreground">
+            {viewMode === 'month' && monthLabelFormatter.format(viewMonth)}
+            {viewMode === 'week' && formatWeekRangeLabel(weekDays)}
+            {viewMode === 'agenda' && 'Next 30 days'}
           </h2>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <button
-              onClick={() => setViewMonth((m) => addMonths(m, -1))}
-              aria-label="Previous month"
-              className="rounded-lg px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              onClick={handleExportICS}
+              className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="Download visible items as a .ics file"
             >
-              ←
+              <svg
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"
+                />
+              </svg>
+              Export
             </button>
-            <button
-              onClick={() => setViewMonth(startOfDay(new Date()))}
-              className="rounded-lg px-2 py-1 text-xs font-semibold text-primary hover:underline"
-            >
-              Today
-            </button>
-            <button
-              onClick={() => setViewMonth((m) => addMonths(m, 1))}
-              aria-label="Next month"
-              className="rounded-lg px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-            >
-              →
-            </button>
+            <div className="flex items-center rounded-lg border border-border p-0.5 text-xs font-medium">
+              {(['month', 'week', 'agenda'] as const).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => setViewMode(mode)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 capitalize transition-colors',
+                    viewMode === mode
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+            {viewMode === 'month' && (
+              <PeriodNav
+                onPrev={() => setViewMonth((m) => addMonths(m, -1))}
+                onToday={() => setViewMonth(startOfDay(new Date()))}
+                onNext={() => setViewMonth((m) => addMonths(m, 1))}
+                prevLabel="Previous month"
+                nextLabel="Next month"
+              />
+            )}
+            {viewMode === 'week' && (
+              <PeriodNav
+                onPrev={() => setWeekAnchor((d) => addDays(d, -7))}
+                onToday={() => setWeekAnchor(startOfDay(new Date()))}
+                onNext={() => setWeekAnchor((d) => addDays(d, 7))}
+                prevLabel="Previous week"
+                nextLabel="Next week"
+              />
+            )}
           </div>
         </div>
 
-        <div className="grid grid-cols-7 gap-1 mb-1">
-          {WEEKDAY_LABELS.map((label) => (
-            <div
-              key={label}
-              className="text-center text-[10px] font-semibold uppercase tracking-wide text-muted-foreground py-1"
+        {state.courses.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 mb-3">
+            {state.courses.map((course) => {
+              const hidden = hiddenCourseIds.has(course.id);
+              return (
+                <button
+                  key={course.id}
+                  onClick={() => toggleCourseVisibility(course.id)}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                    hidden
+                      ? 'border-border text-muted-foreground opacity-50'
+                      : 'border-border text-foreground hover:bg-accent',
+                  )}
+                >
+                  <span className={cn('h-2 w-2 rounded-full', course.color || 'bg-primary')} />
+                  {course.code}
+                </button>
+              );
+            })}
+            <span className="mx-1 h-4 w-px bg-border" />
+            <button
+              onClick={() => setShowClasses((v) => !v)}
+              className={cn(
+                'rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                showClasses
+                  ? 'border-border text-foreground hover:bg-accent'
+                  : 'border-border text-muted-foreground opacity-50',
+              )}
             >
-              {label}
-            </div>
-          ))}
-        </div>
+              Classes
+            </button>
+            <button
+              onClick={() => setShowCompleted((v) => !v)}
+              className={cn(
+                'rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                showCompleted
+                  ? 'border-border text-foreground hover:bg-accent'
+                  : 'border-border text-muted-foreground opacity-50',
+              )}
+            >
+              Completed
+            </button>
+          </div>
+        )}
 
-        <div className="grid grid-cols-7 gap-1">
-          {grid.map((day) => {
-            const dayItems = itemsByDay.get(toDayKey(day)) ?? [];
-            const inCurrentMonth = day.getMonth() === viewMonth.getMonth();
-            const isToday = isSameDay(day, today);
-            const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
-
-            return (
+        {viewMode === 'month' && (monthStats.pendingCount > 0 || monthStats.totalHours > 0) && (
+          <div className="flex flex-wrap items-center gap-3 mb-4 rounded-xl bg-accent/50 px-3 py-2 text-xs">
+            <span className="font-semibold text-foreground">
+              {monthStats.pendingCount} due this month
+            </span>
+            <span className="text-muted-foreground">
+              {monthStats.totalHours.toFixed(1)}h effective load
+            </span>
+            {monthStats.busiestDay && (
               <button
-                key={day.toISOString()}
-                onClick={() => setSelectedDay(day)}
-                className={cn(
-                  'aspect-square rounded-lg p-1.5 flex flex-col items-start gap-1 text-left transition-colors',
-                  inCurrentMonth ? 'hover:bg-accent' : 'opacity-40 hover:bg-accent/50',
-                  isSelected && 'ring-2 ring-primary',
-                  isToday && !isSelected && 'bg-primary/10',
-                )}
+                onClick={() => selectDay(monthStats.busiestDay!.day)}
+                className="ml-auto flex items-center gap-1.5 font-semibold text-primary hover:underline"
               >
                 <span
-                  className={cn('text-xs', isToday ? 'font-bold text-primary' : 'text-foreground')}
-                >
-                  {day.getDate()}
-                </span>
-                <div className="flex flex-wrap gap-0.5">
-                  {dayItems.slice(0, 4).map((item) => (
-                    <span
-                      key={item.id}
-                      className={cn(
-                        'h-1.5 w-1.5 rounded-full',
-                        courseColor(item),
-                        item.completed && 'opacity-40',
-                      )}
-                    />
-                  ))}
-                  {dayItems.length > 4 && (
-                    <span className="text-[9px] leading-none text-muted-foreground">
-                      +{dayItems.length - 4}
-                    </span>
+                  className={cn(
+                    'h-2 w-2 rounded-full',
+                    HEAT_SWATCH_CLASS[getWorkloadLevel(monthStats.busiestDay.hours)],
                   )}
-                </div>
+                />
+                Busiest: {monthStats.busiestDay.day.getDate()}{' '}
+                {monthLabelFormatter.format(monthStats.busiestDay.day).split(' ')[0]}
               </button>
-            );
-          })}
-        </div>
-      </Card>
+            )}
+          </div>
+        )}
 
-      {selectedDay && (
-        <Card className="rounded-2xl p-6">
-          <h3 className="text-sm font-semibold text-foreground mb-3">
-            {dayLabelFormatter.format(selectedDay)}
-          </h3>
-          {selectedItems.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Nothing due this day.</p>
-          ) : (
-            <div className="divide-y divide-border">
-              {selectedItems.map((item) => {
-                const course = state.courses.find((c) => c.id === item.courseId);
+        {viewMode === 'month' && (
+          <>
+            <div className="grid grid-cols-7 gap-1 mb-1">
+              {WEEKDAY_LABELS.map((label) => (
+                <div
+                  key={label}
+                  className="text-center text-[10px] font-semibold uppercase tracking-wide text-muted-foreground py-1"
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 gap-1" onKeyDown={handleGridKeyDown}>
+              {grid.map((day) => {
+                const dayItems = visibleDayItems(day);
+                const dayMeetings = visibleMeetings(day);
+                const inCurrentMonth = day.getMonth() === viewMonth.getMonth();
+                const isToday = isSameDay(day, today);
+                const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
+                const hours = dailyLoad.get(toDayKey(day)) ?? 0;
+                const heatLevel = getWorkloadLevel(hours);
+                const visibleChips = dayItems.slice(0, MAX_VISIBLE_CHIPS);
+                const hiddenCount = dayItems.length - visibleChips.length;
+
                 return (
-                  <div key={item.id} className="flex items-center gap-3 py-2 first:pt-0 last:pb-0">
-                    <span className={cn('h-2 w-2 rounded-full shrink-0', courseColor(item))} />
-                    <div className="min-w-0 flex-1">
-                      <div
-                        className={cn(
-                          'text-sm font-medium truncate',
-                          item.completed ? 'text-muted-foreground line-through' : 'text-foreground',
-                        )}
-                      >
-                        {item.title}
+                  <button
+                    key={day.toISOString()}
+                    onClick={() => selectDay(day)}
+                    className={cn(
+                      'min-h-[6.5rem] rounded-xl p-1.5 flex flex-col items-start gap-1 text-left transition-colors',
+                      inCurrentMonth ? 'hover:bg-accent' : 'opacity-40 hover:bg-accent/50',
+                      isSelected && 'ring-2 ring-primary',
+                      !isSelected && inCurrentMonth && HEAT_TINT_CLASS[heatLevel],
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'flex h-6 w-6 items-center justify-center rounded-full text-xs',
+                        isToday
+                          ? 'bg-gradient-brand font-bold text-white shadow-card'
+                          : 'text-foreground',
+                      )}
+                    >
+                      {day.getDate()}
+                    </span>
+
+                    {dayMeetings.length > 0 && (
+                      <div className="flex w-full flex-wrap gap-0.5">
+                        {dayMeetings.slice(0, 6).map((m, i) => (
+                          <span
+                            key={`${m.course.id}-${i}`}
+                            className={cn(
+                              'h-1.5 w-1.5 rounded-[2px]',
+                              m.course.color || 'bg-primary',
+                            )}
+                            title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}`}
+                          />
+                        ))}
                       </div>
-                      <div className="text-xs text-muted-foreground">
-                        {course ? course.code : 'General'}
-                      </div>
+                    )}
+
+                    <div className="flex w-full flex-col gap-0.5">
+                      {visibleChips.map((item) => (
+                        <span
+                          key={item.id}
+                          className={cn(
+                            'block w-full truncate rounded px-1 py-0.5 text-[9px] font-medium leading-tight text-white',
+                            courseColor(item),
+                            item.completed && 'opacity-40 line-through',
+                          )}
+                          title={item.title}
+                        >
+                          {item.title}
+                        </span>
+                      ))}
+                      {hiddenCount > 0 && (
+                        <span className="text-[9px] font-semibold leading-none text-muted-foreground">
+                          +{hiddenCount} more
+                        </span>
+                      )}
                     </div>
-                  </div>
+                  </button>
                 );
               })}
             </div>
-          )}
-        </Card>
+
+            <div className="mt-4 space-y-2.5 border-t border-border pt-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="w-20 shrink-0 text-xs font-semibold text-foreground">
+                  Workload
+                </span>
+                {LEGEND_LEVELS.map((level) => (
+                  <span
+                    key={level}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-foreground',
+                      HEAT_CHIP_CLASS[level],
+                    )}
+                  >
+                    <span className={cn('h-2.5 w-2.5 rounded-full', HEAT_SWATCH_CLASS[level])} />
+                    {WORKLOAD_LEVEL_LABELS[level]}
+                  </span>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="w-20 shrink-0 text-xs font-semibold text-foreground">Markers</span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium text-foreground">
+                  <span className="h-2.5 w-2.5 shrink-0 rounded-[2px] bg-primary" />
+                  Class session
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium text-foreground">
+                  <span className="h-2.5 w-4 shrink-0 rounded bg-primary" />
+                  Due item
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {viewMode === 'week' && (
+          <WeekView
+            weekDays={weekDays}
+            today={today}
+            selectedDay={selectedDay}
+            onSelectDay={selectDay}
+            itemsFor={visibleDayItems}
+            meetingsFor={visibleMeetings}
+            courseOf={courseOf}
+            dailyLoad={dailyLoad}
+          />
+        )}
+
+        {viewMode === 'agenda' && (
+          <div className="max-h-[32rem] space-y-1 overflow-y-auto pr-1">
+            {agendaDays.map((day) => {
+              const dayItems = visibleDayItems(day);
+              const dayMeetings = visibleMeetings(day);
+              if (dayItems.length === 0 && dayMeetings.length === 0) return null;
+              const isToday = isSameDay(day, today);
+              return (
+                <div key={day.toISOString()} className="flex gap-3 py-2">
+                  <div className="w-20 shrink-0 pt-0.5">
+                    <span
+                      className={cn(
+                        'text-xs font-semibold',
+                        isToday ? 'text-primary' : 'text-foreground',
+                      )}
+                    >
+                      {isToday ? 'Today' : agendaDayLabelFormatter.format(day)}
+                    </span>
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    {dayMeetings.map((m, i) => (
+                      <div key={`${m.course.id}-${i}`} className="flex items-center gap-2 text-sm">
+                        <span
+                          className={cn(
+                            'h-2 w-2 shrink-0 rounded-[2px]',
+                            m.course.color || 'bg-primary',
+                          )}
+                        />
+                        <span className="text-muted-foreground">
+                          {formatTimeLabel(m.meeting.startTime)}
+                        </span>
+                        <span className="truncate text-foreground">{m.course.code} class</span>
+                      </div>
+                    ))}
+                    {dayItems.map((item) => {
+                      const course = courseOf(item);
+                      return (
+                        <TaskRow
+                          key={item.id}
+                          title={item.title}
+                          type={item.type}
+                          courseCode={course ? course.code : 'General'}
+                          courseColor={course?.color}
+                          completed={item.completed}
+                          priority={item.priority}
+                          onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Card>
+
+      {(viewMode === 'month' || viewMode === 'week') && selectedDay && (
+        <DayDetailCard
+          day={selectedDay}
+          meetings={visibleMeetings(selectedDay)}
+          items={visibleDayItems(selectedDay)}
+          courseOf={courseOf}
+          onToggleComplete={user ? handleToggleComplete : undefined}
+        />
       )}
     </div>
+  );
+}
+
+/** Grouped prev/Today/next control, styled as one segmented pill to match the
+ * Export button and the Month/Week/Agenda switcher instead of three loose,
+ * differently-weighted controls floating in the header. */
+function PeriodNav({
+  onPrev,
+  onToday,
+  onNext,
+  prevLabel,
+  nextLabel,
+}: {
+  onPrev: () => void;
+  onToday: () => void;
+  onNext: () => void;
+  prevLabel: string;
+  nextLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 rounded-lg border border-border p-0.5">
+      <button
+        onClick={onPrev}
+        aria-label={prevLabel}
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <svg
+          className="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2.5}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      <button
+        onClick={onToday}
+        className="rounded-md px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
+      >
+        Today
+      </button>
+      <button
+        onClick={onNext}
+        aria-label={nextLabel}
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <svg
+          className="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2.5}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function DayDetailCard({
+  day,
+  meetings,
+  items,
+  courseOf,
+  onToggleComplete,
+}: {
+  day: Date;
+  meetings: MeetingOccurrence[];
+  items: ScheduleItem[];
+  courseOf: (item: ScheduleItem) => Course | undefined;
+  onToggleComplete?: (item: ScheduleItem) => void;
+}) {
+  return (
+    <Card className="rounded-2xl p-6">
+      <h3 className="text-base font-semibold text-foreground mb-3">
+        {dayLabelFormatter.format(day)}
+      </h3>
+
+      {meetings.length === 0 && items.length === 0 ? (
+        <EmptyState
+          icon={
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          }
+          title="Nothing on this day"
+          description="No classes and nothing due — enjoy the breathing room."
+        />
+      ) : (
+        <div className="space-y-4">
+          {meetings.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Classes
+              </h4>
+              <div className="divide-y divide-border">
+                {meetings.map((m, i) => (
+                  <div key={`${m.course.id}-${i}`} className="flex items-center gap-3 py-2">
+                    <span
+                      className={cn('h-7 w-7 shrink-0 rounded-lg', m.course.color || 'bg-primary')}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-foreground truncate">
+                        {m.course.code}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatTimeLabel(m.meeting.startTime)} –{' '}
+                        {formatTimeLabel(m.meeting.endTime)}
+                        {m.meeting.location ? ` · ${m.meeting.location}` : ''}
+                      </div>
+                    </div>
+                    {m.course.modality && (
+                      <span className="shrink-0 rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium capitalize text-muted-foreground">
+                        {m.course.modality}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {items.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Due
+              </h4>
+              <div className="divide-y divide-border">
+                {items.map((item) => {
+                  const course = courseOf(item);
+                  return (
+                    <TaskRow
+                      key={item.id}
+                      title={item.title}
+                      type={item.type}
+                      courseCode={course ? course.code : 'General'}
+                      courseColor={course?.color}
+                      completed={item.completed}
+                      priority={item.priority}
+                      onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
+                      trailing={
+                        <div className="flex items-center gap-1">
+                          <a
+                            href={generateGoogleCalendarUrl(item, course)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title="Add to Google Calendar"
+                            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M12 4v16m8-8H4"
+                              />
+                            </svg>
+                          </a>
+                          <a
+                            href={generateOutlookCalendarUrl(item, course)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title="Add to Outlook"
+                            className="rounded-md p-1 text-[9px] font-bold text-muted-foreground hover:bg-accent hover:text-foreground"
+                          >
+                            O
+                          </a>
+                        </div>
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
   );
 }

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { isSameDay, toDayKey } from '@/lib/calendar/dates';
+import {
+  formatTimeLabel,
+  timeToFractionalHours,
+  type MeetingOccurrence,
+} from '@/lib/calendar/meetings';
+import { cn } from '@/lib/utils';
+import { getWorkloadLevel } from '@/lib/workload';
+import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
+
+// Full 24-hour day, like Google Calendar/Outlook - a hardcoded 7am-9pm window
+// would silently hide any class or task that lands outside "typical" hours
+// (an 11pm lab section, a midnight assignment reminder). The grid scrolls
+// instead, auto-jumped to a sensible start time on mount.
+const START_HOUR = 0;
+const END_HOUR = 24;
+const HOUR_HEIGHT = 48;
+const GRID_HEIGHT = (END_HOUR - START_HOUR) * HOUR_HEIGHT;
+const DEFAULT_SCROLL_HOUR = 7;
+const VISIBLE_HOURS = 13;
+
+const HOUR_LABELS = Array.from({ length: END_HOUR - START_HOUR }, (_, i) => START_HOUR + i);
+
+const dayHeaderFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+
+const HEAT_TINT_CLASS: Record<WorkloadLevel, string> = {
+  low: '',
+  medium: 'bg-load-medium/5',
+  high: 'bg-load-high/5',
+  critical: 'bg-load-critical/10',
+};
+
+export interface WeekViewProps {
+  weekDays: Date[];
+  today: Date;
+  selectedDay: Date | null;
+  onSelectDay: (day: Date) => void;
+  itemsFor: (day: Date) => ScheduleItem[];
+  meetingsFor: (day: Date) => MeetingOccurrence[];
+  courseOf: (item: ScheduleItem) => Course | undefined;
+  dailyLoad: Map<string, number>;
+}
+
+function hourLabel(hour: number): string {
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const display = hour % 12 === 0 ? 12 : hour % 12;
+  return `${display} ${period}`;
+}
+
+export function WeekView({
+  weekDays,
+  today,
+  selectedDay,
+  onSelectDay,
+  itemsFor,
+  meetingsFor,
+  courseOf,
+  dailyLoad,
+}: WeekViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: DEFAULT_SCROLL_HOUR * HOUR_HEIGHT });
+  }, []);
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[640px]">
+        <div className="grid grid-cols-[3rem_repeat(7,1fr)]">
+          <div />
+          {weekDays.map((day) => {
+            const isToday = isSameDay(day, today);
+            const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
+            const dayItems = itemsFor(day);
+            return (
+              <button
+                key={day.toISOString()}
+                onClick={() => onSelectDay(day)}
+                className={cn(
+                  'flex flex-col items-center gap-1 rounded-t-lg py-2 text-center transition-colors',
+                  isSelected ? 'bg-primary/10' : 'hover:bg-accent',
+                )}
+              >
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {dayHeaderFormatter.format(day)}
+                </span>
+                <span
+                  className={cn(
+                    'flex h-7 w-7 items-center justify-center rounded-full text-sm',
+                    isToday
+                      ? 'bg-gradient-brand font-bold text-white shadow-card'
+                      : 'text-foreground',
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+                {dayItems.length > 0 && (
+                  <span className="text-[9px] font-medium text-muted-foreground">
+                    {dayItems.length} due
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          ref={scrollRef}
+          style={{ maxHeight: VISIBLE_HOURS * HOUR_HEIGHT }}
+          className="overflow-y-auto"
+        >
+          <div className="grid grid-cols-[3rem_repeat(7,1fr)]">
+            <div style={{ height: GRID_HEIGHT }} className="relative">
+              {HOUR_LABELS.map((hour) => (
+                <div
+                  key={hour}
+                  className="absolute right-1 -translate-y-1/2 text-[10px] text-muted-foreground"
+                  style={{ top: (hour - START_HOUR) * HOUR_HEIGHT }}
+                >
+                  {hourLabel(hour)}
+                </div>
+              ))}
+            </div>
+
+            {weekDays.map((day) => {
+              const meetings = meetingsFor(day);
+              const hours = dailyLoad.get(toDayKey(day)) ?? 0;
+              const heatLevel = getWorkloadLevel(hours);
+              const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
+
+              return (
+                <div
+                  key={day.toISOString()}
+                  style={{ height: GRID_HEIGHT }}
+                  className={cn(
+                    'relative border-l border-border',
+                    isSelected ? 'bg-primary/5' : HEAT_TINT_CLASS[heatLevel],
+                  )}
+                >
+                  {HOUR_LABELS.map((hour) => (
+                    <div
+                      key={hour}
+                      className="absolute left-0 right-0 border-t border-border/60"
+                      style={{ top: (hour - START_HOUR) * HOUR_HEIGHT }}
+                    />
+                  ))}
+
+                  {meetings.map((m, i) => {
+                    const start = timeToFractionalHours(m.meeting.startTime);
+                    const end = timeToFractionalHours(m.meeting.endTime);
+                    if (end <= start) return null;
+                    const top = (start - START_HOUR) * HOUR_HEIGHT;
+                    const height = Math.max((end - start) * HOUR_HEIGHT, 20);
+                    return (
+                      <div
+                        key={`${m.course.id}-${i}`}
+                        className={cn(
+                          'absolute left-0.5 right-0.5 overflow-hidden rounded-md px-1 py-0.5 text-[10px] font-medium text-white shadow-sm',
+                          m.course.color || 'bg-primary',
+                        )}
+                        style={{ top, height }}
+                        title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}–${formatTimeLabel(m.meeting.endTime)}`}
+                      >
+                        <div className="truncate font-semibold">{m.course.code}</div>
+                        {height > 32 && (
+                          <div className="truncate opacity-90">
+                            {formatTimeLabel(m.meeting.startTime)}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-2 grid grid-cols-[3rem_repeat(7,1fr)] gap-1 border-t border-border px-0.5 pt-2">
+          <div />
+          {weekDays.map((day) => {
+            const items = itemsFor(day);
+            return (
+              <div key={day.toISOString()} className="space-y-0.5">
+                {items.slice(0, 3).map((item) => (
+                  <span
+                    key={item.id}
+                    title={item.title}
+                    className={cn(
+                      'block truncate rounded px-1 py-0.5 text-[9px] font-medium text-white',
+                      courseOf(item)?.color || 'bg-primary',
+                      item.completed && 'opacity-40 line-through',
+                    )}
+                  >
+                    {item.title}
+                  </span>
+                ))}
+                {items.length > 3 && (
+                  <span className="block text-[9px] font-semibold text-muted-foreground">
+                    +{items.length - 3} more due
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -61,8 +61,10 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         code: values.code,
         title: values.title,
         color: values.color,
+        meetingTimes: values.meetingTimes ?? [],
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
+        ...(values.modality ? { modality: values.modality } : {}),
       },
       dispatch,
     );

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -10,7 +10,7 @@ import {
   CardFooter,
 } from '@/components/ui/Card';
 import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course';
-import type { Course } from '@/types/schedule';
+import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 
 const COURSE_COLORS = [
@@ -21,6 +21,29 @@ const COURSE_COLORS = [
   'bg-orange-500',
   'bg-teal-500',
 ];
+
+const MODALITY_OPTIONS: { value: CourseModality; label: string }[] = [
+  { value: 'in-person', label: 'In-person' },
+  { value: 'online', label: 'Online' },
+  { value: 'hybrid', label: 'Hybrid' },
+];
+
+const WEEKDAY_OPTIONS = [
+  { value: 0, label: 'Sun' },
+  { value: 1, label: 'Mon' },
+  { value: 2, label: 'Tue' },
+  { value: 3, label: 'Wed' },
+  { value: 4, label: 'Thu' },
+  { value: 5, label: 'Fri' },
+  { value: 6, label: 'Sat' },
+];
+
+const emptyMeetingTime: MeetingTime = {
+  dayOfWeek: 1,
+  startTime: '09:00',
+  endTime: '10:15',
+  location: '',
+};
 
 export interface CourseFormModalProps {
   open: boolean;
@@ -36,6 +59,8 @@ const emptyValues: CourseFormValues = {
   instructor: '',
   term: '',
   color: COURSE_COLORS[0],
+  modality: undefined,
+  meetingTimes: [],
 };
 
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
@@ -54,6 +79,8 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             instructor: initialCourse.instructor ?? '',
             term: initialCourse.term ?? '',
             color: initialCourse.color ?? COURSE_COLORS[0],
+            modality: initialCourse.modality,
+            meetingTimes: initialCourse.meetingTimes ?? [],
           }
         : emptyValues,
     );
@@ -66,6 +93,30 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
   const updateField = (key: keyof CourseFormValues, value: string) => {
     setValues((s) => ({ ...s, [key]: value }));
     setErrors((e) => (e[key] ? { ...e, [key]: undefined } : e));
+  };
+
+  const meetingTimes = values.meetingTimes ?? [];
+
+  const addMeetingTime = () => {
+    setValues((s) => ({
+      ...s,
+      meetingTimes: [...(s.meetingTimes ?? []), { ...emptyMeetingTime }],
+    }));
+  };
+
+  const removeMeetingTime = (index: number) => {
+    setValues((s) => ({
+      ...s,
+      meetingTimes: (s.meetingTimes ?? []).filter((_, i) => i !== index),
+    }));
+  };
+
+  const updateMeetingTime = (index: number, patch: Partial<MeetingTime>) => {
+    setValues((s) => ({
+      ...s,
+      meetingTimes: (s.meetingTimes ?? []).map((m, i) => (i === index ? { ...m, ...patch } : m)),
+    }));
+    setErrors((e) => (e.meetingTimes ? { ...e, meetingTimes: undefined } : e));
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -177,6 +228,107 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
                     />
                   ))}
                 </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-sm font-medium text-foreground">Modality</span>
+                <div className="flex gap-2">
+                  {MODALITY_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() =>
+                        setValues((s) => ({
+                          ...s,
+                          modality: s.modality === opt.value ? undefined : opt.value,
+                        }))
+                      }
+                      className={cn(
+                        'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
+                        values.modality === opt.value
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border text-muted-foreground hover:bg-accent',
+                      )}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-foreground">Weekly meetings</span>
+                  <button
+                    type="button"
+                    onClick={addMeetingTime}
+                    className="text-xs font-semibold text-primary hover:underline"
+                  >
+                    + Add meeting time
+                  </button>
+                </div>
+                {meetingTimes.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No recurring class sessions yet — add one so it shows up on the calendar.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {meetingTimes.map((meeting, index) => (
+                      <div
+                        key={index}
+                        className="flex flex-wrap items-center gap-2 rounded-lg border border-border p-2"
+                      >
+                        <select
+                          aria-label={`Meeting ${index + 1} day of week`}
+                          value={meeting.dayOfWeek}
+                          onChange={(e) =>
+                            updateMeetingTime(index, { dayOfWeek: Number(e.target.value) })
+                          }
+                          className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        >
+                          {WEEKDAY_OPTIONS.map((d) => (
+                            <option key={d.value} value={d.value}>
+                              {d.label}
+                            </option>
+                          ))}
+                        </select>
+                        <input
+                          aria-label={`Meeting ${index + 1} start time`}
+                          type="time"
+                          value={meeting.startTime}
+                          onChange={(e) => updateMeetingTime(index, { startTime: e.target.value })}
+                          className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <span className="text-xs text-muted-foreground">to</span>
+                        <input
+                          aria-label={`Meeting ${index + 1} end time`}
+                          type="time"
+                          value={meeting.endTime}
+                          onChange={(e) => updateMeetingTime(index, { endTime: e.target.value })}
+                          className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <input
+                          aria-label={`Meeting ${index + 1} location`}
+                          value={meeting.location ?? ''}
+                          onChange={(e) => updateMeetingTime(index, { location: e.target.value })}
+                          placeholder="Location (optional)"
+                          className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeMeetingTime(index)}
+                          aria-label={`Remove meeting ${index + 1}`}
+                          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {errors.meetingTimes && (
+                  <p className="text-xs text-destructive">{errors.meetingTimes}</p>
+                )}
               </div>
             </CardContent>
             <CardFooter className="justify-end gap-2">

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -61,6 +61,8 @@ export function CoursesListView() {
         color: values.color,
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
+        ...(values.modality ? { modality: values.modality } : {}),
+        ...(values.meetingTimes?.length ? { meetingTimes: values.meetingTimes } : {}),
       },
       dispatch,
     );

--- a/src/lib/__tests__/calendarMeetings.test.ts
+++ b/src/lib/__tests__/calendarMeetings.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimeLabel, getMeetingsForDay } from '@/lib/calendar/meetings';
+import type { Course } from '@/types/schedule';
+
+const monday = new Date(2026, 8, 7); // Sep 7, 2026 is a Monday
+const tuesday = new Date(2026, 8, 8);
+
+const courses: Course[] = [
+  {
+    id: 'c1',
+    code: 'CSCI 213',
+    title: 'Computer Science I',
+    color: 'bg-blue-500',
+    meetingTimes: [
+      { dayOfWeek: 1, startTime: '09:00', endTime: '10:15', location: 'Rm 204' },
+      { dayOfWeek: 3, startTime: '09:00', endTime: '10:15' },
+    ],
+  },
+  {
+    id: 'c2',
+    code: 'MATH 301',
+    title: 'Linear Algebra',
+    color: 'bg-green-500',
+    meetingTimes: [{ dayOfWeek: 1, startTime: '08:00', endTime: '08:50' }],
+  },
+  {
+    id: 'c3',
+    code: 'PHIL 101',
+    title: 'Ethics',
+    color: 'bg-purple-500',
+    // No meetingTimes at all - should simply contribute nothing.
+  },
+];
+
+describe('getMeetingsForDay', () => {
+  it('returns every course meeting whose dayOfWeek matches, sorted by start time', () => {
+    const result = getMeetingsForDay(courses, monday);
+    expect(result.map((m) => m.course.id)).toEqual(['c2', 'c1']);
+  });
+
+  it('returns an empty array for a day with no recurring meetings', () => {
+    expect(getMeetingsForDay(courses, tuesday)).toEqual([]);
+  });
+
+  it('does not throw for courses missing meetingTimes entirely', () => {
+    expect(() => getMeetingsForDay([{ id: 'x', code: 'X', title: 'X' }], monday)).not.toThrow();
+  });
+});
+
+describe('formatTimeLabel', () => {
+  it('formats morning times', () => {
+    expect(formatTimeLabel('09:00')).toBe('9:00 AM');
+  });
+
+  it('formats afternoon times', () => {
+    expect(formatTimeLabel('14:30')).toBe('2:30 PM');
+  });
+
+  it('formats midnight and noon edge cases', () => {
+    expect(formatTimeLabel('00:00')).toBe('12:00 AM');
+    expect(formatTimeLabel('12:00')).toBe('12:00 PM');
+  });
+});

--- a/src/lib/__tests__/courseValidation.test.ts
+++ b/src/lib/__tests__/courseValidation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { courseFormSchema, meetingTimeSchema } from '@/lib/validation/course';
+
+describe('meetingTimeSchema', () => {
+  it('accepts a valid meeting time', () => {
+    const result = meetingTimeSchema.safeParse({
+      dayOfWeek: 1,
+      startTime: '09:00',
+      endTime: '10:15',
+      location: 'Rm 204',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an end time at or before the start time', () => {
+    const result = meetingTimeSchema.safeParse({
+      dayOfWeek: 1,
+      startTime: '10:00',
+      endTime: '09:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a malformed time string', () => {
+    const result = meetingTimeSchema.safeParse({
+      dayOfWeek: 1,
+      startTime: '9am',
+      endTime: '10:15',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('courseFormSchema with meetingTimes', () => {
+  const base = { code: 'CSCI 213', title: 'Computer Science I', color: 'bg-blue-500' };
+
+  it('accepts a course with no meeting times', () => {
+    expect(courseFormSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts a course with valid recurring meetings and a modality', () => {
+    const result = courseFormSchema.safeParse({
+      ...base,
+      modality: 'in-person',
+      meetingTimes: [{ dayOfWeek: 1, startTime: '09:00', endTime: '10:15' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid modality value', () => {
+    const result = courseFormSchema.safeParse({ ...base, modality: 'remote' });
+    expect(result.success).toBe(false);
+  });
+
+  it('surfaces an invalid nested meeting time as a failure', () => {
+    const result = courseFormSchema.safeParse({
+      ...base,
+      meetingTimes: [{ dayOfWeek: 1, startTime: '10:00', endTime: '09:00' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/calendar/meetings.ts
+++ b/src/lib/calendar/meetings.ts
@@ -1,0 +1,46 @@
+import type { Course, MeetingTime } from '@/types/schedule';
+
+export interface MeetingOccurrence {
+  course: Course;
+  meeting: MeetingTime;
+}
+
+/**
+ * Every recurring class meeting (#118) that falls on `day`'s weekday, across
+ * all courses, sorted by start time. `dayOfWeek` on MeetingTime is
+ * Date.getDay()-compatible (0=Sunday), so no conversion is needed against
+ * the calendar grid, which is also Sunday-first.
+ *
+ * There's no term-boundary data yet (courses only carry a free-text `term`
+ * label, not start/end dates - that's #101), so a meeting matches every week
+ * regardless of which month is being viewed. Acceptable for now; #101 will
+ * narrow this once term boundaries exist.
+ */
+export function getMeetingsForDay(courses: Course[], day: Date): MeetingOccurrence[] {
+  const dayOfWeek = day.getDay();
+  const occurrences: MeetingOccurrence[] = [];
+  for (const course of courses) {
+    for (const meeting of course.meetingTimes ?? []) {
+      if (meeting.dayOfWeek === dayOfWeek) {
+        occurrences.push({ course, meeting });
+      }
+    }
+  }
+  occurrences.sort((a, b) => a.meeting.startTime.localeCompare(b.meeting.startTime));
+  return occurrences;
+}
+
+/** Formats a 24-hour "HH:mm" string as a 12-hour clock label, e.g. "09:00" -> "9:00 AM". */
+export function formatTimeLabel(time: string): string {
+  const [hourStr, minute] = time.split(':');
+  const hour = Number(hourStr);
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${displayHour}:${minute} ${period}`;
+}
+
+/** Converts a 24-hour "HH:mm" string to fractional hours (e.g. "09:30" -> 9.5) for positioning on an hour-axis grid. */
+export function timeToFractionalHours(time: string): number {
+  const [hourStr, minuteStr] = time.split(':');
+  return Number(hourStr) + Number(minuteStr) / 60;
+}

--- a/src/lib/validation/course.ts
+++ b/src/lib/validation/course.ts
@@ -1,5 +1,19 @@
 import { z } from 'zod';
 
+const timePattern = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+export const meetingTimeSchema = z
+  .object({
+    dayOfWeek: z.number().int().min(0).max(6),
+    startTime: z.string().regex(timePattern, 'Use HH:mm'),
+    endTime: z.string().regex(timePattern, 'Use HH:mm'),
+    location: z.string().trim().max(100, 'Keep it under 100 characters').optional(),
+  })
+  .refine((m) => m.endTime > m.startTime, {
+    message: 'End time must be after start time',
+    path: ['endTime'],
+  });
+
 export const courseFormSchema = z.object({
   code: z.string().trim().min(1, 'Course code is required').max(20, 'Keep it under 20 characters'),
   title: z
@@ -10,6 +24,8 @@ export const courseFormSchema = z.object({
   instructor: z.string().trim().max(100, 'Keep it under 100 characters').optional(),
   term: z.string().trim().max(50, 'Keep it under 50 characters').optional(),
   color: z.string().min(1),
+  modality: z.union([z.literal('in-person'), z.literal('online'), z.literal('hybrid')]).optional(),
+  meetingTimes: z.array(meetingTimeSchema).optional(),
 });
 
 export type CourseFormValues = z.infer<typeof courseFormSchema>;

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,4 +1,23 @@
 /**
+ * How a course's class sessions are held.
+ */
+export type CourseModality = 'in-person' | 'online' | 'hybrid';
+
+/**
+ * A single recurring weekly class meeting (#118). `dayOfWeek` is 0=Sunday
+ * through 6=Saturday, matching `Date.getDay()` / the calendar grid's own
+ * Sunday-first week so no conversion is needed when rendering.
+ */
+export interface MeetingTime {
+  dayOfWeek: number;
+  /** 24-hour "HH:mm", e.g. "09:00" */
+  startTime: string;
+  /** 24-hour "HH:mm", e.g. "10:15" */
+  endTime: string;
+  location?: string;
+}
+
+/**
  * Represents a student's course.
  */
 export interface Course {
@@ -18,6 +37,10 @@ export interface Course {
   notes?: string;
   /** Whether this course was entered manually or created from AI syllabus extraction. Defaults to 'manual' when absent. */
   source?: DataSource;
+  /** How class sessions are held */
+  modality?: CourseModality;
+  /** Recurring weekly meeting times, e.g. "MWF 9:00-10:15" */
+  meetingTimes?: MeetingTime[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Pulls #118 (recurring class meetings + course modality) and the Phase 3 calendar-export wiring forward into this pass instead of deferring them, per the approved redesign plan.
- Month view: visible-title event chips, gradient "today", per-day workload heat tint, course filter chips, Classes/Completed toggles, monthly stats bar, color-coded legend.
- New Week view: real 24-hour scrollable hour grid with positioned class blocks.
- New Agenda view: chronological 30-day schedule list.
- Day detail panel: TaskRow with working inline complete-toggle + add-to-Google/Outlook links; Export button downloads visible items as `.ics`.
- Keyboard day-to-day navigation.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 173/173 passing (21 files), including new `calendarMeetings.test.ts` and `courseValidation.test.ts`
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation against the dev-test account: added a real Mon/Wed CSCI 213 meeting through the course edit UI, confirmed it renders in Month/Week/Agenda in both light and dark mode
- [x] Confirmed course-filter chip actually filters items out of the grid/stats
- [x] Confirmed the "1 error" hydration warning in the dev overlay is a pre-existing Chrome-extension artifact (`inpage.js`), reproduces identically on `/dashboard`, not a regression from this change