### PR TITLE
Fix app-wide font fallback; redesign Planner; Dashboard consistency fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,7 @@
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    @apply font-sans;
   }
 }
 

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -24,7 +24,14 @@ import {
   type MeetingOccurrence,
 } from '@/lib/calendar/meetings';
 import { cn } from '@/lib/utils';
-import { calculateDailyLoad, getWorkloadLevel, WORKLOAD_LEVEL_LABELS } from '@/lib/workload';
+import {
+  calculateDailyLoad,
+  getWorkloadLevel,
+  WORKLOAD_LEVEL_LABELS,
+  WORKLOAD_CHIP_CLASS,
+  WORKLOAD_SWATCH_CLASS,
+  WORKLOAD_TINT_CLASS,
+} from '@/lib/workload';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
 import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
@@ -54,34 +61,6 @@ function formatWeekRangeLabel(weekDays: Date[]): string {
 
 const MAX_VISIBLE_CHIPS = 2;
 const AGENDA_WINDOW_DAYS = 30;
-
-/** Subtle per-cell background tint keyed off the day's cognitive-load level -
- * the calendar surfaces the workload engine (Epic 7) instead of only ever
- * showing raw due-date dots. Deliberately faint (low opacity) so it reads as
- * texture, not as a competing signal to the "today" treatment. */
-const HEAT_TINT_CLASS: Record<WorkloadLevel, string> = {
-  low: '',
-  medium: 'bg-load-medium/10',
-  high: 'bg-load-high/10',
-  critical: 'bg-load-critical/15',
-};
-
-const HEAT_SWATCH_CLASS: Record<WorkloadLevel, string> = {
-  low: 'bg-load-low',
-  medium: 'bg-load-medium',
-  high: 'bg-load-high',
-  critical: 'bg-load-critical',
-};
-
-/** Tinted chip background for the legend, keyed the same as the swatch color
- * so each workload level reads as one cohesive color-coded badge rather than
- * a plain dot floating next to text. */
-const HEAT_CHIP_CLASS: Record<WorkloadLevel, string> = {
-  low: 'border-load-low/30 bg-load-low/10',
-  medium: 'border-load-medium/30 bg-load-medium/10',
-  high: 'border-load-high/30 bg-load-high/10',
-  critical: 'border-load-critical/30 bg-load-critical/10',
-};
 
 const LEGEND_LEVELS: WorkloadLevel[] = ['low', 'medium', 'high', 'critical'];
 
@@ -345,7 +324,7 @@ export function MonthCalendar() {
                 <span
                   className={cn(
                     'h-2 w-2 rounded-full',
-                    HEAT_SWATCH_CLASS[getWorkloadLevel(monthStats.busiestDay.hours)],
+                    WORKLOAD_SWATCH_CLASS[getWorkloadLevel(monthStats.busiestDay.hours)],
                   )}
                 />
                 Busiest: {monthStats.busiestDay.day.getDate()}{' '}
@@ -388,7 +367,7 @@ export function MonthCalendar() {
                       'min-h-[6.5rem] rounded-xl p-1.5 flex flex-col items-start gap-1 text-left transition-colors',
                       inCurrentMonth ? 'hover:bg-accent' : 'opacity-40 hover:bg-accent/50',
                       isSelected && 'ring-2 ring-primary',
-                      !isSelected && inCurrentMonth && HEAT_TINT_CLASS[heatLevel],
+                      !isSelected && inCurrentMonth && WORKLOAD_TINT_CLASS[heatLevel],
                     )}
                   >
                     <span
@@ -452,10 +431,12 @@ export function MonthCalendar() {
                     key={level}
                     className={cn(
                       'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-foreground',
-                      HEAT_CHIP_CLASS[level],
+                      WORKLOAD_CHIP_CLASS[level],
                     )}
                   >
-                    <span className={cn('h-2.5 w-2.5 rounded-full', HEAT_SWATCH_CLASS[level])} />
+                    <span
+                      className={cn('h-2.5 w-2.5 rounded-full', WORKLOAD_SWATCH_CLASS[level])}
+                    />
                     {WORKLOAD_LEVEL_LABELS[level]}
                   </span>
                 ))}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -122,12 +122,12 @@ export function DashboardView() {
 
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex flex-row md:flex-col gap-3 md:w-40 shrink-0">
-          <Card className="rounded-xl bg-primary/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-primary">{termProgressPct}%</div>
-            <div className="text-xs text-muted-foreground mt-0.5">Term Progress</div>
+          <Card className="rounded-xl bg-gradient-brand border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
+            <div className="text-2xl font-bold text-white">{termProgressPct}%</div>
+            <div className="text-xs text-white/80 mt-0.5">Term Progress</div>
           </Card>
-          <Card className="rounded-xl bg-muted/60 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-foreground">{courses.length}</div>
+          <Card className="rounded-xl bg-primary/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
+            <div className="text-2xl font-bold text-primary">{courses.length}</div>
             <div className="text-xs text-muted-foreground mt-0.5">Courses</div>
           </Card>
           <Card className="rounded-xl bg-load-medium/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
@@ -291,7 +291,7 @@ export function DashboardView() {
         )}
       </Card>
 
-      <Link href="/calendar">
+      <Link href="/calendar" className="block">
         <Card hoverable className="rounded-2xl p-4 text-center">
           <span className="text-sm font-semibold text-primary">View full calendar →</span>
         </Card>

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { TaskRow } from '@/components/ui/TaskRow';
@@ -12,6 +12,8 @@ import {
   WORKLOAD_LEVEL_LABELS,
   WORKLOAD_CHIP_CLASS,
   WORKLOAD_TEXT_CLASS,
+  toDateOnly,
+  formatDateISO,
 } from '@/lib/workload';
 import {
   computeSmartPlan,
@@ -23,6 +25,11 @@ import type { Course, ScheduleItem } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const dayLabelFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+const dayDetailFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+});
 
 export function SmartPlanner() {
   const { state, dispatch } = useAppState();
@@ -38,6 +45,28 @@ export function SmartPlanner() {
   const totalPlanned = plan.startToday.length + plan.startThisWeek.length + plan.startLater.length;
   const todayLoad = plan.weekLoad[0];
   const todayLevel = getWorkloadLevel(todayLoad.hours);
+
+  // Keyed the same way calculateDailyLoad keys plan.weekLoad (UTC-midnight
+  // ISO date), so a forecast day's key always finds the items actually due
+  // that day - reusing the workload engine's own date normalization instead
+  // of the calendar module's local-time one avoids an off-by-one across
+  // timezones.
+  const itemsByDueDate = useMemo(() => {
+    const map = new Map<string, ScheduleItem[]>();
+    for (const item of scheduleItems) {
+      const key = formatDateISO(toDateOnly(item.dueDate));
+      const existing = map.get(key);
+      if (existing) existing.push(item);
+      else map.set(key, [item]);
+    }
+    return map;
+  }, [scheduleItems]);
+
+  const [selectedForecastKey, setSelectedForecastKey] = useState<string | null>(null);
+  const selectedForecastDay = plan.weekLoad.find((d) => d.key === selectedForecastKey);
+  const selectedDayItems = selectedForecastKey
+    ? (itemsByDueDate.get(selectedForecastKey) ?? [])
+    : [];
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
@@ -112,12 +141,17 @@ export function SmartPlanner() {
             // stays visually neutral instead of borrowing the lowest tier's
             // color.
             const hasLoad = hours > 0;
+            const isSelected = selectedForecastKey === key;
             return (
-              <div
+              <button
                 key={key}
+                onClick={() => setSelectedForecastKey((prev) => (prev === key ? null : key))}
                 className={cn(
-                  'flex flex-col items-center gap-1 rounded-xl border p-2.5',
+                  'flex flex-col items-center gap-1 rounded-xl border p-2.5 text-left transition-all',
                   hasLoad ? WORKLOAD_CHIP_CLASS[level] : 'border-border bg-accent/40',
+                  isSelected
+                    ? 'ring-2 ring-primary ring-offset-2 ring-offset-card'
+                    : 'hover:-translate-y-0.5',
                 )}
               >
                 <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -132,10 +166,36 @@ export function SmartPlanner() {
                 >
                   {hasLoad ? `${hours.toFixed(1)}h` : 'Free'}
                 </span>
-              </div>
+              </button>
             );
           })}
         </div>
+
+        {selectedForecastDay && (
+          <div className="mt-5 border-t border-border pt-5">
+            <h3 className="mb-3 text-sm font-semibold text-foreground">
+              {dayDetailFormatter.format(selectedForecastDay.day)}
+            </h3>
+            {selectedDayItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Nothing due this day.</p>
+            ) : (
+              <div className="divide-y divide-border">
+                {selectedDayItems.map((item) => (
+                  <TaskRow
+                    key={item.id}
+                    title={item.title}
+                    type={item.type}
+                    courseCode={courses.find((c) => c.id === item.courseId)?.code ?? 'General'}
+                    courseColor={courses.find((c) => c.id === item.courseId)?.color}
+                    completed={item.completed}
+                    priority={item.priority}
+                    onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </Card>
 
       {totalPlanned === 0 ? null : (

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -2,35 +2,31 @@
 
 import { useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
-import { WORKLOAD_LEVEL_LABELS } from '@/lib/workload';
+import { useAuth } from '@/context/AuthContext';
+import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
+import {
+  getWorkloadLevel,
+  WORKLOAD_LEVEL_LABELS,
+  WORKLOAD_CHIP_CLASS,
+  WORKLOAD_TEXT_CLASS,
+} from '@/lib/workload';
 import {
   computeSmartPlan,
   getLocalReferenceDate,
   type PlannedItem,
 } from '@/lib/planner/computeSmartPlan';
 import { cn } from '@/lib/utils';
-import type { WorkloadLevel } from '@/types/schedule';
+import type { Course, ScheduleItem } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const dayLabelFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
 
-const LEVEL_DOT_CLASS: Record<WorkloadLevel, string> = {
-  low: 'bg-load-low',
-  medium: 'bg-load-medium',
-  high: 'bg-load-high',
-  critical: 'bg-load-critical',
-};
-
-const LEVEL_TEXT_CLASS: Record<WorkloadLevel, string> = {
-  low: 'text-load-low',
-  medium: 'text-load-medium',
-  high: 'text-load-high',
-  critical: 'text-load-critical',
-};
-
 export function SmartPlanner() {
-  const { state } = useAppState();
+  const { state, dispatch } = useAppState();
+  const { user } = useAuth();
   const { courses, scheduleItems } = state;
 
   const referenceDate = useMemo(() => getLocalReferenceDate(), []);
@@ -40,40 +36,161 @@ export function SmartPlanner() {
   );
 
   const totalPlanned = plan.startToday.length + plan.startThisWeek.length + plan.startLater.length;
+  const todayLoad = plan.weekLoad[0];
+  const todayLevel = getWorkloadLevel(todayLoad.hours);
+
+  const handleToggleComplete = async (item: ScheduleItem) => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+  };
 
   return (
     <div className="space-y-6">
+      {/* Hero: today's load is the single most useful glanceable fact on this
+          page, so it gets a large number instead of being buried in the
+          7-day strip alongside every other day. */}
+      <Card accent className="rounded-2xl p-6">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Today&apos;s Load
+          </span>
+          <span
+            className={cn(
+              'rounded-full border px-2.5 py-1 text-xs font-semibold',
+              WORKLOAD_CHIP_CLASS[todayLevel],
+              WORKLOAD_TEXT_CLASS[todayLevel],
+            )}
+          >
+            {WORKLOAD_LEVEL_LABELS[todayLevel]}
+          </span>
+        </div>
+        <div className="mb-5 flex items-end gap-2">
+          <span className="text-5xl font-bold tracking-tight text-foreground">
+            {todayLoad.hours.toFixed(1)}
+          </span>
+          <span className="pb-1.5 text-lg font-medium text-muted-foreground">effective hours</span>
+        </div>
+
+        {plan.startToday.length === 0 ? (
+          <EmptyState
+            icon={
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            }
+            title="Nothing to start today"
+            description="You're caught up - check back tomorrow."
+          />
+        ) : (
+          <div className="divide-y divide-border">
+            {plan.startToday.map(({ item, overloaded }) => (
+              <PlannedTaskRow
+                key={item.id}
+                item={item}
+                course={courses.find((c) => c.id === item.courseId)}
+                overloaded={overloaded}
+                onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+              />
+            ))}
+          </div>
+        )}
+      </Card>
+
       <Card className="rounded-2xl p-6">
-        <h2 className="text-sm font-semibold text-foreground mb-3">Next 7 Days</h2>
+        <h2 className="mb-4 text-base font-semibold text-foreground">7-Day Forecast</h2>
         <div className="grid grid-cols-7 gap-2">
-          {plan.weekLoad.map(({ key, day, level }) => (
-            <div key={key} className="flex flex-col items-center gap-1">
-              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                {dayLabelFormatter.format(day)}
-              </span>
-              <span className={cn('h-2 w-2 rounded-full', LEVEL_DOT_CLASS[level])} />
-              <span className={cn('text-[10px] font-medium', LEVEL_TEXT_CLASS[level])}>
-                {WORKLOAD_LEVEL_LABELS[level]}
-              </span>
-            </div>
-          ))}
+          {plan.weekLoad.map(({ key, day, hours, level }) => {
+            // A day with zero hours isn't a "Low" workload day - it's a day
+            // with no data. Coloring it green would misread as "you're fine
+            // today" when really nothing has been planned for it yet, so it
+            // stays visually neutral instead of borrowing the lowest tier's
+            // color.
+            const hasLoad = hours > 0;
+            return (
+              <div
+                key={key}
+                className={cn(
+                  'flex flex-col items-center gap-1 rounded-xl border p-2.5',
+                  hasLoad ? WORKLOAD_CHIP_CLASS[level] : 'border-border bg-accent/40',
+                )}
+              >
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {dayLabelFormatter.format(day)}
+                </span>
+                <span className="text-lg font-bold text-foreground">{day.getDate()}</span>
+                <span
+                  className={cn(
+                    'text-[10px] font-semibold',
+                    hasLoad ? WORKLOAD_TEXT_CLASS[level] : 'text-muted-foreground',
+                  )}
+                >
+                  {hasLoad ? `${hours.toFixed(1)}h` : 'Free'}
+                </span>
+              </div>
+            );
+          })}
         </div>
       </Card>
 
-      {totalPlanned === 0 ? (
-        <Card className="rounded-2xl p-6">
-          <p className="text-sm text-muted-foreground">
-            Nothing to plan. You&apos;re all caught up.
-          </p>
-        </Card>
-      ) : (
+      {totalPlanned === 0 ? null : (
         <>
-          <PlanSection title="Start Today" items={plan.startToday} courses={courses} urgent />
-          <PlanSection title="Start This Week" items={plan.startThisWeek} courses={courses} />
-          <PlanSection title="Later" items={plan.startLater} courses={courses} />
+          <PlanSection
+            title="Start This Week"
+            items={plan.startThisWeek}
+            courses={courses}
+            onToggleComplete={user ? handleToggleComplete : undefined}
+          />
+          <PlanSection
+            title="Later"
+            items={plan.startLater}
+            courses={courses}
+            onToggleComplete={user ? handleToggleComplete : undefined}
+          />
         </>
       )}
     </div>
+  );
+}
+
+function PlannedTaskRow({
+  item,
+  course,
+  overloaded,
+  onToggleComplete,
+}: {
+  item: PlannedItem['item'];
+  course: Course | undefined;
+  overloaded: boolean;
+  onToggleComplete?: () => void;
+}) {
+  return (
+    <TaskRow
+      title={item.title}
+      type={item.type}
+      courseCode={course ? course.code : 'General'}
+      courseColor={course?.color}
+      completed={item.completed}
+      priority={item.priority}
+      onToggleComplete={onToggleComplete}
+      trailing={
+        <>
+          {overloaded && (
+            <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
+              Overloaded
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            Due {dueDateFormatter.format(new Date(item.dueDate))}
+          </span>
+        </>
+      }
+    />
   );
 }
 
@@ -81,47 +198,28 @@ function PlanSection({
   title,
   items,
   courses,
-  urgent,
+  onToggleComplete,
 }: {
   title: string;
   items: PlannedItem[];
-  courses: { id: string; code: string; color?: string }[];
-  urgent?: boolean;
+  courses: Course[];
+  onToggleComplete?: (item: ScheduleItem) => void;
 }) {
   if (items.length === 0) return null;
 
   return (
     <Card className="rounded-2xl p-6">
-      <h2
-        className={cn('text-sm font-semibold mb-3', urgent ? 'text-load-high' : 'text-foreground')}
-      >
-        {title}
-      </h2>
+      <h2 className="mb-3 text-sm font-semibold text-foreground">{title}</h2>
       <div className="divide-y divide-border">
-        {items.map(({ item, overloaded }) => {
-          const course = courses.find((c) => c.id === item.courseId);
-          return (
-            <div key={item.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
-              <span
-                className={cn('h-2 w-2 rounded-full shrink-0', course?.color || 'bg-primary')}
-              />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-foreground truncate">{item.title}</div>
-                <div className="text-xs text-muted-foreground">
-                  {course ? course.code : 'General'}
-                </div>
-              </div>
-              {overloaded && (
-                <span className="text-[10px] font-semibold text-load-critical shrink-0">
-                  Overloaded
-                </span>
-              )}
-              <span className="text-xs text-muted-foreground shrink-0">
-                Due {dueDateFormatter.format(new Date(item.dueDate))}
-              </span>
-            </div>
-          );
-        })}
+        {items.map(({ item, overloaded }) => (
+          <PlannedTaskRow
+            key={item.id}
+            item={item}
+            course={courses.find((c) => c.id === item.courseId)}
+            overloaded={overloaded}
+            onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
+          />
+        ))}
       </div>
     </Card>
   );

--- a/src/lib/workload/index.ts
+++ b/src/lib/workload/index.ts
@@ -8,3 +8,4 @@ export * from './constants';
 export * from './dateUtils';
 export * from './dailyLoad';
 export * from './scheduling';
+export * from './uiClasses';

--- a/src/lib/workload/uiClasses.ts
+++ b/src/lib/workload/uiClasses.ts
@@ -1,0 +1,39 @@
+import type { WorkloadLevel } from '@/types/schedule';
+
+/**
+ * Shared Tailwind class tokens for rendering a WorkloadLevel, so every
+ * consumer (Calendar, Planner, ...) draws from the same palette instead of
+ * each page defining its own slightly-different mapping.
+ */
+
+/** Solid color, for small dot/swatch indicators. */
+export const WORKLOAD_SWATCH_CLASS: Record<WorkloadLevel, string> = {
+  low: 'bg-load-low',
+  medium: 'bg-load-medium',
+  high: 'bg-load-high',
+  critical: 'bg-load-critical',
+};
+
+/** Very low-opacity background, for tinting a whole cell/region. */
+export const WORKLOAD_TINT_CLASS: Record<WorkloadLevel, string> = {
+  low: '',
+  medium: 'bg-load-medium/10',
+  high: 'bg-load-high/10',
+  critical: 'bg-load-critical/15',
+};
+
+/** Tinted pill/chip background + border, for badges and legend entries. */
+export const WORKLOAD_CHIP_CLASS: Record<WorkloadLevel, string> = {
+  low: 'border-load-low/30 bg-load-low/10',
+  medium: 'border-load-medium/30 bg-load-medium/10',
+  high: 'border-load-high/30 bg-load-high/10',
+  critical: 'border-load-critical/30 bg-load-critical/10',
+};
+
+/** Text color, for labels that need to read as the level's color. */
+export const WORKLOAD_TEXT_CLASS: Record<WorkloadLevel, string> = {
+  low: 'text-load-low',
+  medium: 'text-load-medium',
+  high: 'text-load-high',
+  critical: 'text-load-critical',
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import defaultTheme from 'tailwindcss/defaultTheme';
 
 const config: Config = {
   content: [
@@ -11,6 +12,18 @@ const config: Config = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        // Wires the Geist variable font (loaded via next/font/local in
+        // layout.tsx) into Tailwind's default sans stack. Without this, the
+        // --font-geist-sans CSS variable is defined but nothing ever
+        // consumes it, so the app silently falls back to the browser's raw
+        // system-font stack - and different font-weight utilities on that
+        // stack can resolve to genuinely different typefaces (e.g. a bold
+        // number rendering in a different font family than adjacent medium-
+        // weight text), which is exactly the mismatch this fixes.
+        sans: ['var(--font-geist-sans)', ...defaultTheme.fontFamily.sans],
+        mono: ['var(--font-geist-mono)', ...defaultTheme.fontFamily.mono],
+      },
       colors: {
         background: 'hsl(var(--background) / <alpha-value>)',
         foreground: 'hsl(var(--foreground) / <alpha-value>)',


### PR DESCRIPTION
## Summary
- Root-cause fix: Geist font was loaded via next/font/local but never wired into Tailwind's font stack or applied to body, so the whole app silently ran on the raw browser fallback font (different font-weight utilities resolved to visibly different typefaces).
- Planner (Phase 4): hero "Today's Load" card with a large effective-hours number, forecast strip that distinguishes "no data" from "actually low workload," per-day click-through revealing an inline detail panel, TaskRow adoption with a working inline complete-toggle.
- Extracted shared workload color-chip classes into `lib/workload/uiClasses.ts` so Calendar and Planner draw from one palette.
- Dashboard: fixed inconsistent stat-card styling (Courses card was flat gray while its siblings were color-tinted) and a real layout bug where a Link-wrapped Card rendered as an inline element, killing the space-y-6 gap above it.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 173/173 passing
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation: font consistency across Planner/Dashboard in light+dark, forecast day click-through with detail panel, inline complete-toggle persists to Firestore, Dashboard card spacing/consistency fixes