### PR TITLE
Redesign Dashboard: gradient hero header, progress ring, icon-anchored sections

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -3,18 +3,24 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ProgressRing } from '@/components/ui/ProgressRing';
+import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
-import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { createScheduleItem, updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
+import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
+import type { ScheduleItem } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+const forecastDayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
 
 /**
  * Infers the "current" term as whichever term the most courses belong to.
@@ -37,6 +43,39 @@ function inferCurrentTerm(courses: { term?: string }[]): string | null {
     }
   }
   return best;
+}
+
+const SECTION_ICON_PATHS = {
+  courseLoad:
+    'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
+  tasks:
+    'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+  forecast:
+    'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm6 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m-6 0V5a2 2 0 012-2h2a2 2 0 012 2',
+  planner: 'M13 10V3L4 14h7v7l9-11h-7z',
+} as const;
+
+function SectionIcon({ path }: { path: keyof typeof SECTION_ICON_PATHS }) {
+  return (
+    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d={SECTION_ICON_PATHS[path]} />
+      </svg>
+    </span>
+  );
+}
+
+function getGreeting(hour: number): string {
+  if (hour < 5) return 'Working late';
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
 }
 
 export function DashboardView() {
@@ -65,7 +104,7 @@ export function DashboardView() {
   const upcomingTasks = pendingTasks
     .slice()
     .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
-    .slice(0, 3);
+    .slice(0, 4);
 
   const referenceDate = useMemo(() => getLocalReferenceDate(), []);
   const plan = useMemo(
@@ -73,6 +112,9 @@ export function DashboardView() {
     [scheduleItems, referenceDate],
   );
   const plannerPreview = [...plan.startToday, ...plan.startThisWeek].slice(0, 4);
+
+  const greeting = useMemo(() => getGreeting(new Date().getHours()), []);
+  const firstName = (user?.displayName || user?.email?.split('@')[0] || 'there').split(' ')[0];
 
   const handleAddCourse = async (values: CourseFormValues) => {
     if (!user) throw new Error('You must be signed in to add a course.');
@@ -113,39 +155,71 @@ export function DashboardView() {
     );
   };
 
+  const handleToggleComplete = async (item: ScheduleItem) => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+  };
+
   return (
     <div className="max-w-5xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground tracking-tight">Dashboard Overview</h1>
-        <p className="text-sm text-muted-foreground mt-1">{courses[0]?.term || 'No courses yet'}</p>
+      <div className="relative overflow-hidden rounded-2xl">
+        {/* Soft brand-gradient glow behind the greeting - the one hero moment
+            on the page's first screen, kept subtle (blurred, low opacity)
+            per the "don't go gradient crazy" rule rather than a solid fill. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -left-10 -top-16 h-56 w-56 rounded-full bg-gradient-brand opacity-[0.12] blur-3xl"
+        />
+        <div className="relative py-1">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground">
+            {greeting}, <span className="text-gradient-brand">{firstName}</span>
+          </h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            {currentTerm || courses[0]?.term || 'No courses yet'}
+          </p>
+        </div>
       </div>
 
-      <div className="flex flex-col md:flex-row gap-4">
-        <div className="flex flex-row md:flex-col gap-3 md:w-40 shrink-0">
-          <Card className="rounded-xl bg-gradient-brand border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-white">{termProgressPct}%</div>
-            <div className="text-xs text-white/80 mt-0.5">Term Progress</div>
-          </Card>
-          <Card className="rounded-xl bg-primary/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-primary">{courses.length}</div>
-            <div className="text-xs text-muted-foreground mt-0.5">Courses</div>
-          </Card>
-          <Card className="rounded-xl bg-load-medium/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-load-medium">{pendingTasks.length}</div>
-            <div className="text-xs text-muted-foreground mt-0.5">Pending</div>
-          </Card>
-          <Card className="rounded-xl bg-load-low/10 border-0 shadow-none p-4 flex-1 flex flex-col justify-center">
-            <div className="text-2xl font-bold text-load-low">{completedTasksCount}</div>
-            <div className="text-xs text-muted-foreground mt-0.5">Completed</div>
-          </Card>
-        </div>
+      <div className="grid gap-4 md:grid-cols-[15rem_1fr]">
+        <Card
+          accent
+          className="relative flex flex-col items-center justify-center gap-4 overflow-hidden rounded-2xl p-6"
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -bottom-10 -right-10 h-32 w-32 rounded-full bg-gradient-brand opacity-[0.08] blur-2xl"
+          />
+          <ProgressRing percent={termProgressPct} size={116} strokeWidth={10}>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-foreground">{termProgressPct}%</div>
+              <div className="text-[10px] text-muted-foreground">progress</div>
+            </div>
+          </ProgressRing>
+          <div className="grid w-full grid-cols-3 gap-2 text-center">
+            <div>
+              <div className="text-lg font-bold text-primary">{courses.length}</div>
+              <div className="text-[10px] text-muted-foreground">Courses</div>
+            </div>
+            <div>
+              <div className="text-lg font-bold text-load-medium">{pendingTasks.length}</div>
+              <div className="text-[10px] text-muted-foreground">Pending</div>
+            </div>
+            <div>
+              <div className="text-lg font-bold text-load-low">{completedTasksCount}</div>
+              <div className="text-[10px] text-muted-foreground">Done</div>
+            </div>
+          </div>
+        </Card>
 
-        <div className="flex-1 flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
           <Card className="rounded-2xl p-6">
             <div className="flex items-center justify-between mb-5">
-              <div>
-                <h2 className="text-base font-semibold text-foreground">Course Load</h2>
-                {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
+              <div className="flex items-center gap-3">
+                <SectionIcon path="courseLoad" />
+                <div>
+                  <h2 className="text-base font-semibold text-foreground">Course Load</h2>
+                  {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
+                </div>
               </div>
               <div className="flex items-center gap-3">
                 <Link
@@ -164,9 +238,26 @@ export function DashboardView() {
             </div>
 
             {courseLoad.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No courses yet. Add one to start tracking your workload.
-              </p>
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                    />
+                  </svg>
+                }
+                title="No courses yet"
+                description="Add one to start tracking your workload."
+                action={{ label: '+ Add Course', onClick: () => setAddCourseOpen(true) }}
+              />
             ) : (
               <div className="space-y-5">
                 {courseLoad.map(({ course, pct }) => (
@@ -193,8 +284,11 @@ export function DashboardView() {
           </Card>
 
           <Card className="rounded-2xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-3">
+                <SectionIcon path="tasks" />
+                <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
+              </div>
               <div className="flex items-center gap-3">
                 <Link href="/tasks" className="text-xs font-semibold text-primary hover:underline">
                   View all tasks →
@@ -208,33 +302,41 @@ export function DashboardView() {
               </div>
             </div>
             {upcomingTasks.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                Nothing due. You&apos;re all caught up.
-              </p>
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                }
+                title="Nothing due"
+                description="You're all caught up."
+              />
             ) : (
               <div className="divide-y divide-border">
                 {upcomingTasks.map((item) => {
                   const course = courses.find((c) => c.id === item.courseId);
                   return (
-                    <div
+                    <TaskRow
                       key={item.id}
-                      className="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
-                    >
-                      <span
-                        className={`h-2 w-2 rounded-full shrink-0 ${course?.color || 'bg-primary'}`}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="text-sm font-medium text-foreground truncate">
-                          {item.title}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {course ? course.code : 'General'}
-                        </div>
-                      </div>
-                      <div className="text-xs text-muted-foreground shrink-0">
-                        Due {dueDateFormatter.format(new Date(item.dueDate))}
-                      </div>
-                    </div>
+                      title={item.title}
+                      type={item.type}
+                      courseCode={course ? course.code : 'General'}
+                      courseColor={course?.color}
+                      completed={item.completed}
+                      priority={item.priority}
+                      onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                      trailing={
+                        <span className="text-xs text-muted-foreground">
+                          Due {dueDateFormatter.format(new Date(item.dueDate))}
+                        </span>
+                      }
+                    />
                   );
                 })}
               </div>
@@ -245,46 +347,103 @@ export function DashboardView() {
 
       <Card className="rounded-2xl p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-base font-semibold text-foreground">Planner Preview</h2>
+          <div className="flex items-center gap-3">
+            <SectionIcon path="forecast" />
+            <h2 className="text-base font-semibold text-foreground">7-Day Load</h2>
+          </div>
+          <Link href="/planner" className="text-xs font-semibold text-primary hover:underline">
+            Open planner →
+          </Link>
+        </div>
+        <div className="grid grid-cols-7 gap-2">
+          {plan.weekLoad.map(({ key, day, hours, level }) => {
+            const hasLoad = hours > 0;
+            return (
+              <div
+                key={key}
+                className={cn(
+                  'flex flex-col items-center gap-1 rounded-xl border p-2.5',
+                  hasLoad ? WORKLOAD_CHIP_CLASS[level] : 'border-border bg-accent/40',
+                )}
+              >
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {forecastDayFormatter.format(day)}
+                </span>
+                <span className="text-lg font-bold text-foreground">{day.getDate()}</span>
+                <span
+                  className={cn(
+                    'text-[10px] font-semibold',
+                    hasLoad ? WORKLOAD_TEXT_CLASS[level] : 'text-muted-foreground',
+                  )}
+                >
+                  {hasLoad ? `${hours.toFixed(1)}h` : 'Free'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+
+      <Card className="rounded-2xl p-6">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <SectionIcon path="planner" />
+            <h2 className="text-base font-semibold text-foreground">Planner Preview</h2>
+          </div>
           <Link href="/planner" className="text-xs font-semibold text-primary hover:underline">
             Open planner →
           </Link>
         </div>
         {plannerPreview.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Nothing needs attention yet. Check the calendar for what&apos;s ahead.
-          </p>
+          <EmptyState
+            icon={
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            }
+            title="Nothing needs attention yet"
+            description="Check the calendar for what's ahead."
+          />
         ) : (
           <div className="divide-y divide-border">
             {plannerPreview.map(({ item, startDate, overloaded }) => {
               const course = courses.find((c) => c.id === item.courseId);
               const startsToday = startDate <= plan.weekLoad[0].key;
               return (
-                <div key={item.id} className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
-                  <span
-                    className={cn('h-2 w-2 rounded-full shrink-0', course?.color || 'bg-primary')}
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-foreground truncate">{item.title}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {course ? course.code : 'General'}
-                    </div>
-                  </div>
-                  {overloaded ? (
-                    <span className="text-[10px] font-semibold text-load-critical shrink-0">
-                      Overloaded
-                    </span>
-                  ) : (
-                    <span
-                      className={cn(
-                        'text-[10px] font-semibold shrink-0',
-                        startsToday ? 'text-load-high' : 'text-muted-foreground',
-                      )}
-                    >
-                      {startsToday ? 'Start today' : 'This week'}
-                    </span>
-                  )}
-                </div>
+                <TaskRow
+                  key={item.id}
+                  title={item.title}
+                  type={item.type}
+                  courseCode={course ? course.code : 'General'}
+                  courseColor={course?.color}
+                  completed={item.completed}
+                  priority={item.priority}
+                  onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                  trailing={
+                    overloaded ? (
+                      <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
+                        Overloaded
+                      </span>
+                    ) : (
+                      <span
+                        className={cn(
+                          'rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                          startsToday
+                            ? 'bg-load-high/10 text-load-high'
+                            : 'bg-accent text-muted-foreground',
+                        )}
+                      >
+                        {startsToday ? 'Start today' : 'This week'}
+                      </span>
+                    )
+                  }
+                />
               );
             })}
           </div>

--- a/src/components/ui/ProgressRing.tsx
+++ b/src/components/ui/ProgressRing.tsx
@@ -1,0 +1,54 @@
+export interface ProgressRingProps {
+  /** 0-100 */
+  percent: number;
+  size?: number;
+  strokeWidth?: number;
+  children?: React.ReactNode;
+}
+
+/** Circular progress indicator using the same gradient as the brand mark
+ * (Logo.tsx / .bg-gradient-brand), so "progress" reads as a hero brand
+ * moment instead of a flat percentage number. */
+export function ProgressRing({ percent, size = 96, strokeWidth = 8, children }: ProgressRingProps) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - clamped / 100);
+  const gradientId = 'progress-ring-brand-grad';
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="-rotate-90">
+        <defs>
+          <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#8c6eff" />
+            <stop offset="55%" stopColor="#5b3df5" />
+            <stop offset="100%" stopColor="#00bfa0" />
+          </linearGradient>
+        </defs>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-muted"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={`url(#${gradientId})`}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className="transition-[stroke-dashoffset] duration-500 ease-out"
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Gradient hero greeting (time-of-day aware) with a subtle blurred glow backdrop.
- Term Progress now uses a new shared `ProgressRing` component (same gradient as the Logo mark) instead of a flat percentage.
- Every section header gets an icon badge, matching the visual language already established in Calendar/Planner.
- New "7-Day Load" strip on the dashboard, reusing the workload-forecast pattern from Planner.
- Upcoming Tasks and Planner Preview adopt `TaskRow` with a working inline complete-toggle.
- Empty states adopt the shared `EmptyState` component.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 173/173 passing
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation in both light and dark mode