### PR TITLE
Add semester switcher (#101)

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { WeekView } from '@/components/calendar/WeekView';
-import { useAppState } from '@/context/AppStateContext';
+import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import {
@@ -99,6 +99,20 @@ export function MonthCalendar() {
   const courseOf = (item: ScheduleItem) => state.courses.find((c) => c.id === item.courseId);
   const courseColor = (item: ScheduleItem) => courseOf(item)?.color || 'bg-primary';
 
+  // #101: recurring class meetings are inherently term-bound (a Fall 2026
+  // MWF pattern shouldn't keep rendering forever into Spring 2027), so they
+  // get scoped to the active term. Due-date items deliberately do NOT get
+  // this treatment - a concrete deadline is real regardless of which term is
+  // "selected" right now, so hiding it here could cause a missed assignment.
+  const activeTerm = useMemo(
+    () => resolveActiveTerm(state.selectedTerm, state.courses),
+    [state.selectedTerm, state.courses],
+  );
+  const termScopedCourses = useMemo(
+    () => (activeTerm ? state.courses.filter((c) => c.term === activeTerm) : state.courses),
+    [state.courses, activeTerm],
+  );
+
   const toggleCourseVisibility = (courseId: string) => {
     setHiddenCourseIds((prev) => {
       const next = new Set(prev);
@@ -117,7 +131,9 @@ export function MonthCalendar() {
 
   const visibleMeetings = (day: Date): MeetingOccurrence[] => {
     if (!showClasses) return [];
-    return getMeetingsForDay(state.courses, day).filter((m) => !hiddenCourseIds.has(m.course.id));
+    return getMeetingsForDay(termScopedCourses, day).filter(
+      (m) => !hiddenCourseIds.has(m.course.id),
+    );
   };
 
   // Monthly stats: pending load and the single busiest day, computed only

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
-import { useAppState } from '@/context/AppStateContext';
+import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
@@ -27,7 +27,13 @@ export function CoursesListView() {
   const { courses, scheduleItems } = state;
 
   const [search, setSearch] = useState('');
-  const [termFilter, setTermFilter] = useState('all');
+  // Seeded from the global term switcher (#101) so this page opens already
+  // scoped to whatever term the rest of the app is showing, while staying a
+  // fully independent local filter the user can change without affecting
+  // the global selection.
+  const [termFilter, setTermFilter] = useState(
+    () => resolveActiveTerm(state.selectedTerm, state.courses) ?? 'all',
+  );
   const [sortMode, setSortMode] = useState<SortMode>('code');
   const [addCourseOpen, setAddCourseOpen] = useState(false);
 

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { TaskRow } from '@/components/ui/TaskRow';
-import { useAppState } from '@/context/AppStateContext';
+import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
 import { createScheduleItem, updateScheduleItem } from '@/lib/firestore/scheduleItems';
@@ -22,29 +22,6 @@ import type { ScheduleItem } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const forecastDayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
-
-/**
- * Infers the "current" term as whichever term the most courses belong to.
- * There's no explicit term-switcher yet (that's #101) - this is a reasonable
- * interim default that degrades gracefully to "show everything" once a user
- * has courses spanning multiple terms without a clear majority.
- */
-function inferCurrentTerm(courses: { term?: string }[]): string | null {
-  const counts = new Map<string, number>();
-  for (const course of courses) {
-    if (!course.term) continue;
-    counts.set(course.term, (counts.get(course.term) ?? 0) + 1);
-  }
-  let best: string | null = null;
-  let bestCount = 0;
-  for (const [term, count] of Array.from(counts)) {
-    if (count > bestCount) {
-      best = term;
-      bestCount = count;
-    }
-  }
-  return best;
-}
 
 function getGreeting(hour: number): string {
   if (hour < 5) return 'Working late';
@@ -66,7 +43,10 @@ export function DashboardView() {
     ? Math.round((completedTasksCount / scheduleItems.length) * 100)
     : 0;
 
-  const currentTerm = useMemo(() => inferCurrentTerm(courses), [courses]);
+  const currentTerm = useMemo(
+    () => resolveActiveTerm(state.selectedTerm, courses),
+    [state.selectedTerm, courses],
+  );
   const semesterCourses = currentTerm ? courses.filter((c) => c.term === currentTerm) : courses;
 
   const courseLoad = semesterCourses.map((course) => {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import { useSidebar } from './SidebarContext';
 import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
 import Logo from './Logo';
+import { TermSwitcher } from './TermSwitcher';
 
 export default function Navbar() {
   const { toggle } = useSidebar();
@@ -55,6 +56,7 @@ export default function Navbar() {
       </div>
 
       <div className="flex items-center gap-4">
+        {mounted && user && <TermSwitcher />}
         {mounted && user && (
           <Link
             href="/profile"

--- a/src/components/layout/TermSwitcher.tsx
+++ b/src/components/layout/TermSwitcher.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useMemo } from 'react';
+import { inferCurrentTerm, useAppState } from '@/context/AppStateContext';
+
+/** #101 semester switcher. Hidden entirely when there's nothing to switch
+ * between (zero or one distinct term across the user's courses) so it
+ * doesn't clutter the navbar for the common case of a single-semester user. */
+export function TermSwitcher() {
+  const { state, dispatch } = useAppState();
+
+  const terms = useMemo(
+    () => Array.from(new Set(state.courses.map((c) => c.term).filter(Boolean))) as string[],
+    [state.courses],
+  );
+
+  if (terms.length < 2) return null;
+
+  // Mirrors resolveActiveTerm's fallback so the dropdown's displayed value
+  // always matches what the rest of the app is actually scoped to, even
+  // before the user has made an explicit choice.
+  const displayValue = state.selectedTerm ?? inferCurrentTerm(state.courses) ?? 'all';
+
+  return (
+    <select
+      value={displayValue}
+      onChange={(e) =>
+        dispatch({
+          type: 'SELECT_TERM',
+          payload: e.target.value === 'all' ? 'all' : e.target.value,
+        })
+      }
+      aria-label="Select term"
+      className="rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+    >
+      <option value="all">All Terms</option>
+      {terms.map((term) => (
+        <option key={term} value={term}>
+          {term}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import React, { createContext, useContext, useMemo, useReducer } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 import { Course, ScheduleItem } from '@/types/schedule';
 
 export interface AppState {
   courses: Course[];
   scheduleItems: ScheduleItem[];
   selectedCourseId: string | null;
+  /** #101 semester switcher. `null` means "no explicit choice made yet" -
+   * consumers should fall back to `inferCurrentTerm`. The literal string
+   * 'all' is an explicit user choice to see every term, distinct from "no
+   * opinion yet". A specific term string filters to that term. */
+  selectedTerm: string | null;
   initialized: boolean;
 }
 
@@ -20,12 +25,14 @@ export type AppAction =
   | { type: 'UPDATE_SCHEDULE_ITEM'; payload: ScheduleItem }
   | { type: 'REMOVE_SCHEDULE_ITEM'; payload: string }
   | { type: 'TOGGLE_SCHEDULE_ITEM_COMPLETED'; payload: string }
-  | { type: 'SELECT_COURSE'; payload: string | null };
+  | { type: 'SELECT_COURSE'; payload: string | null }
+  | { type: 'SELECT_TERM'; payload: string | null };
 
 export const initialAppState: AppState = {
   courses: [],
   scheduleItems: [],
   selectedCourseId: null,
+  selectedTerm: null,
   initialized: false,
 };
 
@@ -76,6 +83,8 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       };
     case 'SELECT_COURSE':
       return { ...state, selectedCourseId: action.payload };
+    case 'SELECT_TERM':
+      return { ...state, selectedTerm: action.payload };
     default:
       return state;
   }
@@ -93,13 +102,48 @@ interface AppStateProviderProps {
   initialState?: Partial<AppState>;
 }
 
+const TERM_STORAGE_KEY = 'syllabus-sense-selected-term';
+
+function readStoredTerm(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(TERM_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
 export function AppStateProvider({ children, initialState }: AppStateProviderProps) {
   const mergedInitialState: AppState = {
     ...initialAppState,
     ...initialState,
   };
 
-  const [state, dispatch] = useReducer(appStateReducer, mergedInitialState);
+  // Reads localStorage synchronously in the reducer's lazy initializer
+  // (runs during the very first render, before any child mounts) rather
+  // than in a useEffect - restoring it in an effect would leave a window
+  // where children's own mount-time reads (e.g. a filter's lazy useState
+  // seeded from selectedTerm) see the still-null default and miss the
+  // restored value entirely. Guarded on the caller's own initialState so a
+  // test/consumer that explicitly passes initialState.selectedTerm is never
+  // silently overridden by a stale value from a previous session.
+  const [state, dispatch] = useReducer(appStateReducer, mergedInitialState, (init) => {
+    if (init.selectedTerm !== null) return init;
+    const stored = readStoredTerm();
+    return stored ? { ...init, selectedTerm: stored } : init;
+  });
+
+  useEffect(() => {
+    try {
+      if (state.selectedTerm) {
+        window.localStorage.setItem(TERM_STORAGE_KEY, state.selectedTerm);
+      } else {
+        window.localStorage.removeItem(TERM_STORAGE_KEY);
+      }
+    } catch {
+      // ignore localStorage errors (e.g. private browsing)
+    }
+  }, [state.selectedTerm]);
 
   // Memoized so consumers only re-render when app state actually changes.
   // This provider sits below SidebarProvider and ThemeProvider, so without
@@ -126,4 +170,46 @@ export function getSelectedCourse(state: AppState): Course | null {
 export function getScheduleItemsByCourse(state: AppState, courseId: string | null): ScheduleItem[] {
   if (!courseId) return [];
   return state.scheduleItems.filter((item) => item.courseId === courseId);
+}
+
+/**
+ * #101 semester switcher support.
+ *
+ * Infers the "current" term as whichever term the most courses belong to.
+ * There's no explicit term-boundary data (courses only carry a free-text
+ * `term` label, not start/end dates) - this is a reasonable default that
+ * degrades gracefully to "show everything" once a user has courses spanning
+ * multiple terms without a clear majority.
+ */
+export function inferCurrentTerm(courses: Pick<Course, 'term'>[]): string | null {
+  const counts = new Map<string, number>();
+  for (const course of courses) {
+    if (!course.term) continue;
+    counts.set(course.term, (counts.get(course.term) ?? 0) + 1);
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [term, count] of Array.from(counts)) {
+    if (count > bestCount) {
+      best = term;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolves what term the app should actually scope views to, given the
+ * user's stored preference (`AppState.selectedTerm`) and their courses.
+ * Returns `null` to mean "no filter - show every term" (either because the
+ * user explicitly chose 'All Terms', or because there's nothing to infer
+ * yet), or a specific term string to filter by.
+ */
+export function resolveActiveTerm(
+  selectedTerm: string | null,
+  courses: Pick<Course, 'term'>[],
+): string | null {
+  if (selectedTerm === 'all') return null;
+  if (selectedTerm) return selectedTerm;
+  return inferCurrentTerm(courses);
 }

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -148,6 +148,14 @@ describe('AppStateContext Reducer & Selectors', () => {
     expect(state.scheduleItems).toHaveLength(0);
   });
 
+  it('handles SELECT_TERM', () => {
+    let state = appStateReducer(initialAppState, { type: 'SELECT_TERM', payload: 'Fall 2026' });
+    expect(state.selectedTerm).toBe('Fall 2026');
+
+    state = appStateReducer(state, { type: 'SELECT_TERM', payload: 'all' });
+    expect(state.selectedTerm).toBe('all');
+  });
+
   it('handles SET_COURSES and SET_SCHEDULE_ITEMS', () => {
     let state = appStateReducer(initialAppState, { type: 'SET_COURSES', payload: [mockCourse] });
     expect(state.courses).toHaveLength(1);
@@ -162,6 +170,7 @@ describe('AppStateContext Reducer & Selectors', () => {
       courses: [mockCourse],
       scheduleItems: [mockItem],
       selectedCourseId: 'c1',
+      selectedTerm: null,
       initialized: true,
     };
 

--- a/src/lib/__tests__/termResolution.test.ts
+++ b/src/lib/__tests__/termResolution.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { inferCurrentTerm, resolveActiveTerm } from '@/context/AppStateContext';
+
+describe('inferCurrentTerm', () => {
+  it('returns the term shared by the most courses', () => {
+    const courses = [{ term: 'Fall 2026' }, { term: 'Fall 2026' }, { term: 'Spring 2027' }];
+    expect(inferCurrentTerm(courses)).toBe('Fall 2026');
+  });
+
+  it('returns null when no course has a term', () => {
+    expect(inferCurrentTerm([{ term: undefined }, {}])).toBeNull();
+  });
+
+  it('returns null for an empty course list', () => {
+    expect(inferCurrentTerm([])).toBeNull();
+  });
+});
+
+describe('resolveActiveTerm', () => {
+  const courses = [{ term: 'Fall 2026' }, { term: 'Fall 2026' }, { term: 'Spring 2027' }];
+
+  it('returns null (no filter) when the user explicitly chose "all"', () => {
+    expect(resolveActiveTerm('all', courses)).toBeNull();
+  });
+
+  it('returns the explicit term when one is selected', () => {
+    expect(resolveActiveTerm('Spring 2027', courses)).toBe('Spring 2027');
+  });
+
+  it('falls back to inferCurrentTerm when nothing has been explicitly chosen', () => {
+    expect(resolveActiveTerm(null, courses)).toBe('Fall 2026');
+  });
+});


### PR DESCRIPTION
## Summary
- Global `AppState.selectedTerm`, persisted to localStorage, with a `resolveActiveTerm` helper falling back to the majority-term inference when no explicit choice has been made.
- New `TermSwitcher` navbar dropdown, hidden when there's nothing to switch between (0-1 distinct terms).
- Wired into Dashboard (Course Load/stats), Courses list (local filter seeds from the global selection), and Calendar (recurring class meetings are now term-scoped, so a Fall 2026 MWF pattern doesn't render forever into Spring 2027). Due-date tasks are deliberately NOT term-scoped anywhere — a concrete deadline is real regardless of the selected term.
- Fixed a real race found during implementation: restoring the persisted term via `useEffect` left a window where a child's mount-time lazy state could read the still-null default first. Fixed by reading localStorage synchronously in the reducer's lazy initializer instead.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 180/180 passing (new `termResolution.test.ts` + a `SELECT_TERM` reducer test)
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation: added a temporary second course in a different term, confirmed the switcher appears, Courses list scopes correctly, and Calendar recurring meetings show/hide based on the active term; cleaned up the temporary course afterward