### PR TITLE
Fix auth panel vertical rhythm; redesign Profile with cover banner

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -25,9 +25,13 @@ export default function AuthGroupLayout({ children }: { children: React.ReactNod
     <div className="flex min-h-screen">
       {/* Brand panel: the primary logo/identity moment on this page, so the
           form-side card keeps its own logo small and mobile-only (see
-          login/signup pages) rather than duplicating it next to this. */}
-      <div className="hidden shrink-0 flex-col justify-between bg-gradient-brand p-10 text-white md:flex md:w-[42%] lg:w-1/2">
-        <div>
+          login/signup pages) rather than duplicating it next to this.
+          Everything - logo, headline, pillars - lives in one vertically-
+          centered block instead of being split top/bottom via
+          justify-between, which pinned the headline near the top and left a
+          dead gap before the pillars. */}
+      <div className="hidden shrink-0 flex-col justify-center bg-gradient-brand p-10 text-white md:flex md:w-[42%] lg:w-1/2">
+        <div className="max-w-sm">
           {/* Deliberately hardcoded dark text, not text-foreground: this
               chip's background is always white regardless of theme, so a
               theme-aware token would flip to white-on-white in dark mode. */}
@@ -35,32 +39,39 @@ export default function AuthGroupLayout({ children }: { children: React.ReactNod
             <Logo className="h-9 w-9 shrink-0" />
             <span className="text-lg font-bold tracking-tight text-slate-900">Syllabus Sense</span>
           </div>
-          <p className="mt-10 max-w-sm text-2xl font-bold leading-snug">
+          <p className="mt-8 text-3xl font-bold leading-tight">
             Your whole semester, actually organized.
           </p>
-        </div>
+          <p className="mt-3 text-sm text-white/75">
+            Upload once, plan smarter, and see it all on one beautiful calendar.
+          </p>
 
-        <ul className="space-y-5">
-          {PILLARS.map((pillar) => (
-            <li key={pillar.title} className="flex items-start gap-3">
-              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/15">
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d={ICON_PATHS[pillar.icon]} />
-                </svg>
-              </span>
-              <div>
-                <div className="text-sm font-semibold">{pillar.title}</div>
-                <div className="text-xs text-white/70">{pillar.description}</div>
-              </div>
-            </li>
-          ))}
-        </ul>
+          <ul className="mt-10 space-y-5">
+            {PILLARS.map((pillar) => (
+              <li key={pillar.title} className="flex items-start gap-3">
+                <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/15">
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d={ICON_PATHS[pillar.icon]}
+                    />
+                  </svg>
+                </span>
+                <div>
+                  <div className="text-sm font-semibold">{pillar.title}</div>
+                  <div className="text-xs text-white/70">{pillar.description}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
 
       <div className="flex flex-1 items-center justify-center bg-background px-4 py-12">

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -6,12 +6,31 @@ import { Card } from '@/components/ui/Card';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { cn } from '@/lib/utils';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
   day: 'numeric',
   year: 'numeric',
 });
+
+const PREFERENCE_ROWS: { label: string; description: string; defaultOn: boolean }[] = [
+  {
+    label: 'Daily digest email',
+    description: "A morning summary of what's due today.",
+    defaultOn: true,
+  },
+  {
+    label: 'Deadline reminders',
+    description: "Get notified 24 hours before something's due.",
+    defaultOn: true,
+  },
+  {
+    label: 'Weekly workload recap',
+    description: 'A Sunday night look at the week ahead.',
+    defaultOn: false,
+  },
+];
 
 export function ProfileView() {
   const { user, error, updateDisplayName, signOut, clearError } = useAuth();
@@ -51,13 +70,35 @@ export function ProfileView() {
         <p className="text-sm text-muted-foreground mt-1">Your account details.</p>
       </div>
 
-      <Card accent className="rounded-2xl p-6">
-        <div className="flex items-center gap-4 mb-6">
-          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-gradient-brand text-xl font-bold text-white">
-            {initial}
+      <Card className="overflow-hidden rounded-2xl p-0">
+        <div className="h-24 bg-gradient-brand" />
+        <div className="px-6 pb-6">
+          <div className="-mt-10 flex flex-wrap items-end justify-between gap-4">
+            <div className="flex items-end gap-4">
+              <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full bg-gradient-brand text-2xl font-bold text-white shadow-lg ring-4 ring-card">
+                {initial}
+              </div>
+              {!editing && (
+                <div className="pb-1">
+                  <div className="text-lg font-semibold text-foreground">
+                    {user.displayName || 'No display name set'}
+                  </div>
+                  <div className="text-sm text-muted-foreground">{user.email}</div>
+                </div>
+              )}
+            </div>
+            {!editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="pb-1 text-xs font-semibold text-primary hover:underline"
+              >
+                Edit
+              </button>
+            )}
           </div>
-          {editing ? (
-            <form onSubmit={handleSave} className="flex-1 flex items-center gap-2">
+
+          {editing && (
+            <form onSubmit={handleSave} className="mt-4 flex items-center gap-2">
               <input
                 autoFocus
                 value={name}
@@ -86,64 +127,68 @@ export function ProfileView() {
                 Cancel
               </button>
             </form>
-          ) : (
-            <div className="flex-1 flex items-center justify-between">
-              <div>
-                <div className="text-lg font-semibold text-foreground">
-                  {user.displayName || 'No display name set'}
-                </div>
-                <div className="text-sm text-muted-foreground">{user.email}</div>
-              </div>
-              <button
-                onClick={() => setEditing(true)}
-                className="text-xs font-semibold text-primary hover:underline"
-              >
-                Edit
-              </button>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
             </div>
           )}
-        </div>
 
-        {error && (
-          <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {error}
+          <div className="mt-6 grid grid-cols-3 gap-3">
+            <div className="rounded-xl border border-primary/20 bg-primary/10 p-3 text-center">
+              <div className="text-xl font-bold text-primary">{state.courses.length}</div>
+              <div className="text-[10px] font-medium text-muted-foreground">Courses</div>
+            </div>
+            <div className="rounded-xl border border-load-medium/30 bg-load-medium/10 p-3 text-center">
+              <div className="text-xl font-bold text-load-medium">{pendingCount}</div>
+              <div className="text-[10px] font-medium text-muted-foreground">Pending</div>
+            </div>
+            <div className="rounded-xl border border-load-low/30 bg-load-low/10 p-3 text-center">
+              <div className="text-xl font-bold text-load-low">{completedCount}</div>
+              <div className="text-[10px] font-medium text-muted-foreground">Done</div>
+            </div>
           </div>
-        )}
 
-        <div className="grid grid-cols-3 gap-3 border-t border-border pt-4 text-center">
-          <div>
-            <div className="text-lg font-bold text-primary">{state.courses.length}</div>
-            <div className="text-[10px] text-muted-foreground">Courses</div>
+          <div className="mt-5 flex items-center justify-between border-t border-border pt-4 text-sm">
+            <span className="text-muted-foreground">Member since</span>
+            <span className="font-medium text-foreground">{joined}</span>
           </div>
-          <div>
-            <div className="text-lg font-bold text-load-medium">{pendingCount}</div>
-            <div className="text-[10px] text-muted-foreground">Pending</div>
-          </div>
-          <div>
-            <div className="text-lg font-bold text-load-low">{completedCount}</div>
-            <div className="text-[10px] text-muted-foreground">Done</div>
-          </div>
-        </div>
-
-        <div className="flex justify-between text-sm border-t border-border mt-4 pt-4">
-          <span className="text-muted-foreground">Member since</span>
-          <span className="text-foreground">{joined}</span>
         </div>
       </Card>
 
       <Card className="rounded-2xl p-6">
-        <div className="flex items-center gap-3">
-          <SectionIcon icon="settings" />
-          <div>
-            <h2 className="text-base font-semibold text-foreground">
-              Preferences &amp; Notifications
-            </h2>
-            <p className="text-sm text-muted-foreground mt-0.5">
-              Study habits and notification settings.
-            </p>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <SectionIcon icon="settings" />
+            <div>
+              <h2 className="text-base font-semibold text-foreground">
+                Preferences &amp; Notifications
+              </h2>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Study habits and notification settings.
+              </p>
+            </div>
           </div>
+          <span className="shrink-0 rounded-full bg-accent px-2.5 py-1 text-[10px] font-semibold text-muted-foreground">
+            Coming soon
+          </span>
         </div>
-        <p className="text-sm text-muted-foreground mt-3">Coming soon.</p>
+
+        <div className="mt-5 divide-y divide-border border-t border-border">
+          {PREFERENCE_ROWS.map((row) => (
+            <div
+              key={row.label}
+              className="flex items-center justify-between gap-4 py-3.5 opacity-60"
+            >
+              <div>
+                <div className="text-sm font-medium text-foreground">{row.label}</div>
+                <div className="text-xs text-muted-foreground">{row.description}</div>
+              </div>
+              <ToggleMock checked={row.defaultOn} />
+            </div>
+          ))}
+        </div>
       </Card>
 
       <button
@@ -153,5 +198,26 @@ export function ProfileView() {
         Sign out
       </button>
     </div>
+  );
+}
+
+/** Visual-only toggle used to preview the not-yet-built preferences UI - no
+ * onClick, so it never implies a setting can actually be changed yet. */
+function ToggleMock({ checked }: { checked: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors',
+        checked ? 'bg-primary/50' : 'bg-muted',
+      )}
+    >
+      <span
+        className={cn(
+          'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+          checked ? 'translate-x-6' : 'translate-x-1',
+        )}
+      />
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- Auth split-screen: collapsed the brand panel's `justify-between` top/bottom split into one `justify-center` block so the headline no longer reads as stranded near the top with a dead gap before the pillar list.
- Profile: cover-banner header with an overlapping avatar, color-coded stat chips (replacing plain numbers), and real preview rows for the upcoming preferences (visual-only toggles, no onClick, so nothing implies a setting can actually be changed yet).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 180/180 passing
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation in both light and dark mode