### PR TITLE
Make Profile preferences real, not a static mockup

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -6,6 +6,11 @@ import { Card } from '@/components/ui/Card';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import {
+  updateUserPreferences,
+  useUserPreferences,
+  type UserPreferences,
+} from '@/lib/firestore/preferences';
 import { cn } from '@/lib/utils';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -14,21 +19,21 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-const PREFERENCE_ROWS: { label: string; description: string; defaultOn: boolean }[] = [
+const PREFERENCE_ROWS: { key: keyof UserPreferences; label: string; description: string }[] = [
   {
+    key: 'dailyDigest',
     label: 'Daily digest email',
     description: "A morning summary of what's due today.",
-    defaultOn: true,
   },
   {
+    key: 'deadlineReminders',
     label: 'Deadline reminders',
     description: "Get notified 24 hours before something's due.",
-    defaultOn: true,
   },
   {
+    key: 'weeklyRecap',
     label: 'Weekly workload recap',
     description: 'A Sunday night look at the week ahead.',
-    defaultOn: false,
   },
 ];
 
@@ -39,8 +44,25 @@ export function ProfileView() {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(user?.displayName ?? '');
   const [saving, setSaving] = useState(false);
+  const [preferences, setPreferences] = useUserPreferences(user?.uid);
+  const [savingPrefKey, setSavingPrefKey] = useState<keyof UserPreferences | null>(null);
 
   if (!user) return null;
+
+  const handleTogglePreference = async (key: keyof UserPreferences) => {
+    if (!preferences) return;
+    const previous = preferences;
+    const next = { ...preferences, [key]: !preferences[key] };
+    setPreferences(next);
+    setSavingPrefKey(key);
+    try {
+      await updateUserPreferences(user.uid, next);
+    } catch {
+      setPreferences(previous);
+    } finally {
+      setSavingPrefKey(null);
+    }
+  };
 
   const initial = (user.displayName || user.email || '?').charAt(0).toUpperCase();
   const joined = user.metadata.creationTime
@@ -162,37 +184,38 @@ export function ProfileView() {
       </Card>
 
       <Card className="rounded-2xl p-6">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <SectionIcon icon="settings" />
-            <div>
-              <h2 className="text-base font-semibold text-foreground">
-                Preferences &amp; Notifications
-              </h2>
-              <p className="text-sm text-muted-foreground mt-0.5">
-                Study habits and notification settings.
-              </p>
-            </div>
+        <div className="flex items-center gap-3">
+          <SectionIcon icon="settings" />
+          <div>
+            <h2 className="text-base font-semibold text-foreground">
+              Preferences &amp; Notifications
+            </h2>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Study habits and notification settings.
+            </p>
           </div>
-          <span className="shrink-0 rounded-full bg-accent px-2.5 py-1 text-[10px] font-semibold text-muted-foreground">
-            Coming soon
-          </span>
         </div>
 
         <div className="mt-5 divide-y divide-border border-t border-border">
           {PREFERENCE_ROWS.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center justify-between gap-4 py-3.5 opacity-60"
-            >
+            <div key={row.key} className="flex items-center justify-between gap-4 py-3.5">
               <div>
                 <div className="text-sm font-medium text-foreground">{row.label}</div>
                 <div className="text-xs text-muted-foreground">{row.description}</div>
               </div>
-              <ToggleMock checked={row.defaultOn} />
+              <Toggle
+                checked={preferences ? preferences[row.key] : false}
+                disabled={!preferences || savingPrefKey === row.key}
+                onClick={() => handleTogglePreference(row.key)}
+              />
             </div>
           ))}
         </div>
+
+        <p className="mt-4 border-t border-border pt-4 text-xs text-muted-foreground">
+          Saved to your account. We don&apos;t send these notifications yet - flipping a switch here
+          saves your preference for when we do.
+        </p>
       </Card>
 
       <button
@@ -205,15 +228,25 @@ export function ProfileView() {
   );
 }
 
-/** Visual-only toggle used to preview the not-yet-built preferences UI - no
- * onClick, so it never implies a setting can actually be changed yet. */
-function ToggleMock({ checked }: { checked: boolean }) {
+function Toggle({
+  checked,
+  onClick,
+  disabled,
+}: {
+  checked: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
-    <span
-      aria-hidden
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onClick}
+      disabled={disabled}
       className={cn(
-        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors',
-        checked ? 'bg-primary/50' : 'bg-muted',
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50',
+        checked ? 'bg-primary' : 'bg-muted',
       )}
     >
       <span
@@ -222,6 +255,6 @@ function ToggleMock({ checked }: { checked: boolean }) {
           checked ? 'translate-x-6' : 'translate-x-1',
         )}
       />
-    </span>
+    </button>
   );
 }

--- a/src/lib/firestore/preferences.ts
+++ b/src/lib/firestore/preferences.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+
+export interface UserPreferences {
+  dailyDigest: boolean;
+  deadlineReminders: boolean;
+  weeklyRecap: boolean;
+}
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  dailyDigest: true,
+  deadlineReminders: true,
+  weeklyRecap: false,
+};
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+/**
+ * Stored as a `preferences` field on the user's own root document
+ * (`users/{userId}`), not a subcollection - the existing security rule on
+ * that document (`request.auth.uid == userId`) already covers it, so no
+ * rules changes were needed.
+ *
+ * Returns a setter alongside the live value so callers can apply the same
+ * optimistic-update pattern used by the other Firestore hooks in this app
+ * (set local state immediately, write, roll back on failure) - the
+ * onSnapshot listener still reconciles with the server value shortly after.
+ */
+export function useUserPreferences(
+  userId: string | undefined,
+): [UserPreferences | null, (preferences: UserPreferences) => void] {
+  const [preferences, setPreferences] = useState<UserPreferences | null>(null);
+
+  useEffect(() => {
+    if (!userId || !db) return;
+    const unsubscribe = onSnapshot(doc(db, 'users', userId), (snapshot) => {
+      const stored = snapshot.data()?.preferences as Partial<UserPreferences> | undefined;
+      setPreferences({ ...DEFAULT_PREFERENCES, ...stored });
+    });
+    return unsubscribe;
+  }, [userId]);
+
+  return [preferences, setPreferences];
+}
+
+export async function updateUserPreferences(
+  userId: string,
+  preferences: UserPreferences,
+): Promise<void> {
+  await setDoc(doc(requireDb(), 'users', userId), { preferences }, { merge: true });
+}


### PR DESCRIPTION
## Summary
- New `src/lib/firestore/preferences.ts`: preferences stored on the user's own root document (`users/{userId}`), no new security rules needed.
- Replaced the visual-only toggle mockup with a real interactive `Toggle` wired to Firestore, using the same optimistic-update-then-write pattern as the rest of the app's Firestore hooks.
- Removed the "Coming soon" badge (the setting itself is real now); added an honest disclaimer that this saves the preference but doesn't yet trigger actual email delivery, which needs a separate backend this PR doesn't build.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 180/180 passing
- [x] `npm run build` clean
- [x] Live-verified via Chrome automation: toggled a preference on, reloaded the page, confirmed it read back as on from Firestore (not just local state), then toggled it back off