### PR TITLE
Epic 6: Claude-powered syllabus autofiller + action-button/task-detail polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "syllabus-sense",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.117.1",
         "firebase": "^12.17.1",
         "firebase-admin": "^14.2.0",
         "next": "14.2.35",
@@ -53,6 +54,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.117.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
+      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -137,7 +159,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1954,6 +1975,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -4971,6 +4998,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
@@ -6804,6 +6837,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -9488,6 +9534,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -10169,6 +10225,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     ]
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.117.1",
     "firebase": "^12.17.1",
     "firebase-admin": "^14.2.0",
     "next": "14.2.35",

--- a/src/app/(app)/tasks/[taskId]/page.tsx
+++ b/src/app/(app)/tasks/[taskId]/page.tsx
@@ -1,0 +1,5 @@
+import { TaskDetailView } from '@/components/tasks/TaskDetailView';
+
+export default function TaskDetailPage({ params }: { params: { taskId: string } }) {
+  return <TaskDetailView taskId={params.taskId} />;
+}

--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type Anthropic from '@anthropic-ai/sdk';
+import { adminAuth } from '@/lib/firebase/admin';
+import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import {
+  SYLLABUS_EXTRACTION_SYSTEM_PROMPT,
+  SYLLABUS_EXTRACTION_TOOL,
+} from '@/lib/ai/syllabusExtractionTool';
+import { syllabusExtractionSchema } from '@/types/extraction';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+async function requireUser(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token || !adminAuth) return null;
+  try {
+    return await adminAuth.verifyIdToken(token);
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: { fileBase64?: string; fileName?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const { fileBase64, fileName } = body;
+  if (!fileBase64 || typeof fileBase64 !== 'string') {
+    return NextResponse.json({ error: 'Missing file.' }, { status: 400 });
+  }
+  // Rough size check on the base64 payload (base64 is ~4/3 the byte size).
+  if (fileBase64.length > MAX_FILE_BYTES * 1.4) {
+    return NextResponse.json({ error: 'File is too large (max 10MB).' }, { status: 400 });
+  }
+
+  let anthropic;
+  try {
+    anthropic = getAnthropicClient();
+  } catch {
+    return NextResponse.json(
+      { error: 'Syllabus extraction is not configured on the server.' },
+      { status: 503 },
+    );
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  let message;
+  try {
+    message = await anthropic.messages.create({
+      model: SYLLABUS_EXTRACTION_MODEL,
+      max_tokens: 8000,
+      system: `${SYLLABUS_EXTRACTION_SYSTEM_PROMPT}\n\nToday's date is ${today} - use it only to disambiguate a term/year if the syllabus itself doesn't state one clearly.`,
+      tools: [SYLLABUS_EXTRACTION_TOOL],
+      tool_choice: { type: 'tool', name: SYLLABUS_EXTRACTION_TOOL.name },
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
+              ...(fileName ? { title: fileName } : {}),
+            },
+            {
+              type: 'text',
+              text: 'Extract this syllabus into the record_syllabus_extraction tool.',
+            },
+          ],
+        },
+      ],
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Extraction request failed.' },
+      { status: 502 },
+    );
+  }
+
+  const toolUse = message.content.find(
+    (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+  );
+  if (!toolUse) {
+    return NextResponse.json(
+      { error: 'The model did not return structured data. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  const parsed = syllabusExtractionSchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    console.error('Syllabus extraction validation failed:', parsed.error.issues);
+    return NextResponse.json(
+      { error: 'The extracted data was malformed. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ result: parsed.data });
+}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -525,6 +525,7 @@ export function MonthCalendar() {
                         <TaskRow
                           key={item.id}
                           title={item.title}
+                          href={`/tasks/${item.id}`}
                           type={item.type}
                           courseCode={course ? course.code : 'General'}
                           courseColor={course?.color}
@@ -698,6 +699,7 @@ function DayDetailCard({
                     <TaskRow
                       key={item.id}
                       title={item.title}
+                      href={`/tasks/${item.id}`}
                       type={item.type}
                       courseCode={course ? course.code : 'General'}
                       courseColor={course?.color}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -2,8 +2,9 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import { BackLink } from '@/components/ui/BackLink';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { TaskRow } from '@/components/ui/TaskRow';
@@ -59,9 +60,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         <p className="text-sm text-muted-foreground">
           This course doesn&apos;t exist or has been removed.
         </p>
-        <Link href="/dashboard" className="text-sm font-semibold text-primary hover:underline">
-          ← Back to dashboard
-        </Link>
+        <BackLink href="/dashboard">Back to dashboard</BackLink>
       </div>
     );
   }
@@ -155,9 +154,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   return (
     <div className="max-w-3xl space-y-6">
-      <Link href="/dashboard" className="text-sm font-semibold text-primary hover:underline">
-        ← Back to dashboard
-      </Link>
+      <BackLink href="/dashboard">Back to dashboard</BackLink>
 
       <Card className="overflow-hidden rounded-2xl p-0">
         <div className={cn('h-2 w-full', course.color || 'bg-primary')} />
@@ -210,26 +207,27 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                   href={rmpUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="ml-auto text-xs font-semibold text-primary hover:underline"
+                  className="ml-auto inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/20"
                 >
-                  Rate My Professor →
+                  Rate My Professor
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2.5}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
                 </a>
               )}
             </div>
           )}
 
-          <div className="mt-4 flex flex-wrap items-center gap-4 border-t border-border pt-4">
-            <button
-              onClick={() => setEditCourseOpen(true)}
-              className="text-xs font-semibold text-primary hover:underline"
-            >
-              Edit
-            </button>
+          <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border pt-4">
+            <CardActionButton onClick={() => setEditCourseOpen(true)}>Edit</CardActionButton>
             {items.length > 0 && (
-              <button
-                onClick={handleExportICS}
-                className="flex items-center gap-1 text-xs font-semibold text-primary hover:underline"
-              >
+              <CardActionButton onClick={handleExportICS}>
                 <svg
                   className="h-3.5 w-3.5"
                   fill="none"
@@ -244,7 +242,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                   />
                 </svg>
                 Export .ics
-              </button>
+              </CardActionButton>
             )}
             <div className="ml-auto">
               {confirmingDeleteCourse ? (
@@ -252,13 +250,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                   <span className="text-muted-foreground">Delete course and its tasks?</span>
                   <button
                     onClick={handleDeleteCourse}
-                    className="font-semibold text-destructive hover:underline"
+                    className="rounded-full bg-destructive/10 px-3 py-1.5 font-semibold text-destructive transition-colors hover:bg-destructive/20"
                   >
                     Confirm
                   </button>
                   <button
                     onClick={() => setConfirmingDeleteCourse(false)}
-                    className="text-muted-foreground hover:underline"
+                    className="rounded-full px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -266,7 +264,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
               ) : (
                 <button
                   onClick={() => setConfirmingDeleteCourse(true)}
-                  className="text-xs font-semibold text-destructive hover:underline"
+                  className="inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
                 >
                   Delete
                 </button>
@@ -285,12 +283,9 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       <Card className="rounded-2xl p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-base font-semibold text-foreground">Tasks</h2>
-          <button
-            onClick={() => setAddTaskOpen(true)}
-            className="text-xs font-semibold text-primary hover:underline"
-          >
-            + Add Task
-          </button>
+          <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
+            Add Task
+          </CardActionButton>
         </div>
 
         {items.length === 0 ? (
@@ -322,6 +317,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                 <TaskRow
                   key={item.id}
                   title={item.title}
+                  href={'/tasks/' + item.id}
                   type={item.type}
                   courseColor={course.color}
                   completed={item.completed}
@@ -339,7 +335,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                       </span>
                       <button
                         onClick={() => setEditingItem(item)}
-                        className="text-xs font-semibold text-primary hover:underline"
+                        className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                       >
                         Edit
                       </button>

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -3,11 +3,13 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
+import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import type { CourseFormValues } from '@/lib/validation/course';
 import { cn } from '@/lib/utils';
 
@@ -36,6 +38,7 @@ export function CoursesListView() {
   );
   const [sortMode, setSortMode] = useState<SortMode>('code');
   const [addCourseOpen, setAddCourseOpen] = useState(false);
+  const [autofillOpen, setAutofillOpen] = useState(false);
 
   const terms = useMemo(
     () => Array.from(new Set(courses.map((c) => c.term).filter(Boolean))) as string[],
@@ -94,12 +97,27 @@ export function CoursesListView() {
           <h1 className="text-2xl font-bold text-foreground tracking-tight">Courses</h1>
           <p className="text-sm text-muted-foreground mt-1">Every course you&apos;re tracking.</p>
         </div>
-        <button
-          onClick={() => setAddCourseOpen(true)}
-          className="text-sm font-semibold text-primary hover:underline shrink-0"
-        >
-          + Add Course
-        </button>
+        <div className="flex items-center gap-2">
+          <CardActionButton onClick={() => setAutofillOpen(true)}>
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 13h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            Autofill from Syllabus
+          </CardActionButton>
+          <CardActionButton variant="solid" withPlus onClick={() => setAddCourseOpen(true)}>
+            Add Course
+          </CardActionButton>
+        </div>
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -237,6 +255,7 @@ export function CoursesListView() {
         onClose={() => setAddCourseOpen(false)}
         onSubmit={handleAddCourse}
       />
+      <SyllabusAutofillModal open={autofillOpen} onClose={() => setAutofillOpen(false)} />
     </div>
   );
 }

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
+import { CardActionLink, CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
@@ -160,19 +161,13 @@ export function DashboardView() {
                   {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
                 </div>
               </div>
-              <div className="flex items-center gap-3">
-                <Link
-                  href="/courses"
-                  className="text-xs font-semibold text-primary hover:underline"
-                >
-                  View all courses →
-                </Link>
-                <button
-                  onClick={() => setAddCourseOpen(true)}
-                  className="text-xs font-semibold text-primary hover:underline"
-                >
-                  + Add Course
-                </button>
+              <div className="flex items-center gap-2">
+                <CardActionLink href="/courses" withChevron>
+                  View all
+                </CardActionLink>
+                <CardActionButton variant="solid" withPlus onClick={() => setAddCourseOpen(true)}>
+                  Add Course
+                </CardActionButton>
               </div>
             </div>
 
@@ -228,16 +223,13 @@ export function DashboardView() {
                 <SectionIcon icon="tasks" />
                 <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
               </div>
-              <div className="flex items-center gap-3">
-                <Link href="/tasks" className="text-xs font-semibold text-primary hover:underline">
-                  View all tasks →
-                </Link>
-                <button
-                  onClick={() => setAddTaskOpen(true)}
-                  className="text-xs font-semibold text-primary hover:underline"
-                >
-                  + Add Task
-                </button>
+              <div className="flex items-center gap-2">
+                <CardActionLink href="/tasks" withChevron>
+                  View all
+                </CardActionLink>
+                <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
+                  Add Task
+                </CardActionButton>
               </div>
             </div>
             {upcomingTasks.length === 0 ? (
@@ -264,6 +256,7 @@ export function DashboardView() {
                     <TaskRow
                       key={item.id}
                       title={item.title}
+                      href={'/tasks/' + item.id}
                       type={item.type}
                       courseCode={course ? course.code : 'General'}
                       courseColor={course?.color}
@@ -290,9 +283,9 @@ export function DashboardView() {
             <SectionIcon icon="forecast" />
             <h2 className="text-base font-semibold text-foreground">7-Day Load</h2>
           </div>
-          <Link href="/planner" className="text-xs font-semibold text-primary hover:underline">
-            Open planner →
-          </Link>
+          <CardActionLink href="/planner" withChevron>
+            Open planner
+          </CardActionLink>
         </div>
         <div className="grid grid-cols-7 gap-2">
           {plan.weekLoad.map(({ key, day, hours, level }) => {
@@ -329,9 +322,9 @@ export function DashboardView() {
             <SectionIcon icon="planner" />
             <h2 className="text-base font-semibold text-foreground">Planner Preview</h2>
           </div>
-          <Link href="/planner" className="text-xs font-semibold text-primary hover:underline">
-            Open planner →
-          </Link>
+          <CardActionLink href="/planner" withChevron>
+            Open planner
+          </CardActionLink>
         </div>
         {plannerPreview.length === 0 ? (
           <EmptyState
@@ -358,6 +351,7 @@ export function DashboardView() {
                 <TaskRow
                   key={item.id}
                   title={item.title}
+                  href={'/tasks/' + item.id}
                   type={item.type}
                   courseCode={course ? course.code : 'General'}
                   courseColor={course?.color}
@@ -390,8 +384,19 @@ export function DashboardView() {
       </Card>
 
       <Link href="/calendar" className="block">
-        <Card hoverable className="rounded-2xl p-4 text-center">
-          <span className="text-sm font-semibold text-primary">View full calendar →</span>
+        <Card hoverable className="flex items-center justify-center rounded-2xl p-4">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-gradient-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition-transform hover:scale-[1.02]">
+            View full calendar
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.5}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </span>
         </Card>
       </Link>
 

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -184,6 +184,7 @@ export function SmartPlanner() {
                   <TaskRow
                     key={item.id}
                     title={item.title}
+                    href={`/tasks/${item.id}`}
                     type={item.type}
                     courseCode={courses.find((c) => c.id === item.courseId)?.code ?? 'General'}
                     courseColor={courses.find((c) => c.id === item.courseId)?.color}
@@ -232,6 +233,7 @@ function PlannedTaskRow({
   return (
     <TaskRow
       title={item.title}
+      href={`/tasks/${item.id}`}
       type={item.type}
       courseCode={course ? course.code : 'General'}
       courseColor={course?.color}

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -221,6 +221,7 @@ export function PlannerView() {
                 <TaskRow
                   key={item.id}
                   title={item.title}
+                  href={'/tasks/' + item.id}
                   type={item.type}
                   courseCode={
                     course ? `${course.code} · ${TYPE_LABELS[item.type]}` : TYPE_LABELS[item.type]
@@ -241,7 +242,7 @@ export function PlannerView() {
                       </span>
                       <button
                         onClick={() => setEditingItem(item)}
-                        className="text-xs font-semibold text-primary hover:underline"
+                        className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                       >
                         Edit
                       </button>

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -1,0 +1,637 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/Card';
+import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
+import { createCourse } from '@/lib/firestore/courses';
+import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { cn } from '@/lib/utils';
+import type {
+  ExtractedMeetingTime,
+  ExtractedScheduleItem,
+  SyllabusExtractionResult,
+} from '@/types/extraction';
+import type {
+  AssignmentType,
+  Course,
+  CourseModality,
+  MeetingTime,
+  ScheduleItem,
+} from '@/types/schedule';
+
+const COURSE_COLORS = [
+  'bg-blue-500',
+  'bg-green-500',
+  'bg-purple-500',
+  'bg-red-500',
+  'bg-orange-500',
+  'bg-teal-500',
+];
+
+const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const TYPE_LABELS: Record<AssignmentType, string> = {
+  assignment: 'Assignment',
+  exam: 'Exam',
+  quiz: 'Quiz',
+  project: 'Project',
+  reading: 'Reading',
+  other: 'Other',
+};
+
+type Step = 'upload' | 'extracting' | 'review' | 'saving';
+
+interface DraftItem extends ExtractedScheduleItem {
+  /** Local id for React keys/editing - not persisted as-is. */
+  key: string;
+  /** Whether this item will be created when the user confirms. Items with
+   * no resolvable date start unchecked and locked until a date is filled
+   * in, so nothing with a fabricated date silently lands on the calendar. */
+  include: boolean;
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export interface SyllabusAutofillModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalProps) {
+  const { dispatch } = useAppState();
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>('upload');
+  const [dragActive, setDragActive] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [course, setCourse] = useState<{
+    code: string;
+    title: string;
+    instructor: string;
+    term: string;
+    color: string;
+    modality: CourseModality | undefined;
+    meetingTimes: MeetingTime[];
+    materials: string[];
+    skipDates: string[];
+    notes: string;
+  } | null>(null);
+  const [items, setItems] = useState<DraftItem[]>([]);
+  const [unresolved, setUnresolved] = useState<string[]>([]);
+
+  if (!open) return null;
+
+  const reset = () => {
+    setStep('upload');
+    setFile(null);
+    setError(null);
+    setCourse(null);
+    setItems([]);
+    setUnresolved([]);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleFile = async (selected: File) => {
+    const result = validateSyllabusFile(selected);
+    if (!result.valid) {
+      setError(result.error ?? 'Invalid file.');
+      return;
+    }
+    setError(null);
+    setFile(selected);
+    setStep('extracting');
+
+    try {
+      if (!user) throw new Error('You must be signed in.');
+      const idToken = await user.getIdToken();
+      const fileBase64 = await fileToBase64(selected);
+      const res = await fetch('/api/syllabus/extract', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+        body: JSON.stringify({ fileBase64, fileName: selected.name }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Extraction failed.');
+
+      const result: SyllabusExtractionResult = data.result;
+      setCourse({
+        code: result.course.code,
+        title: result.course.title,
+        instructor: result.course.instructor ?? '',
+        term: result.course.term ?? '',
+        color: COURSE_COLORS[0],
+        modality: result.course.modality ?? undefined,
+        meetingTimes: result.course.meetingTimes.map((m: ExtractedMeetingTime) => ({
+          dayOfWeek: m.dayOfWeek,
+          startTime: m.startTime,
+          endTime: m.endTime,
+          location: m.location ?? '',
+        })),
+        materials: result.course.materials,
+        skipDates: result.course.skipDates,
+        notes: result.course.notes ?? '',
+      });
+      setItems(
+        result.scheduleItems.map((item, i) => ({
+          ...item,
+          key: `${i}-${item.title}`,
+          include: item.dueDate !== null,
+        })),
+      );
+      setUnresolved(result.unresolved);
+      setStep('review');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Extraction failed. Please try again.');
+      setStep('upload');
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    const dropped = e.dataTransfer.files[0];
+    if (dropped) handleFile(dropped);
+  };
+
+  const updateItem = (key: string, patch: Partial<DraftItem>) => {
+    setItems((prev) => prev.map((it) => (it.key === key ? { ...it, ...patch } : it)));
+  };
+
+  const updateMeeting = (index: number, patch: Partial<MeetingTime>) => {
+    setCourse((c) => {
+      if (!c) return c;
+      const meetingTimes = c.meetingTimes.map((m, i) => (i === index ? { ...m, ...patch } : m));
+      return { ...c, meetingTimes };
+    });
+  };
+
+  const removeMeeting = (index: number) => {
+    setCourse((c) =>
+      c ? { ...c, meetingTimes: c.meetingTimes.filter((_, i) => i !== index) } : c,
+    );
+  };
+
+  const updateMaterial = (index: number, value: string) => {
+    setCourse((c) => {
+      if (!c) return c;
+      const materials = c.materials.map((m, i) => (i === index ? value : m));
+      return { ...c, materials };
+    });
+  };
+
+  const removeMaterial = (index: number) => {
+    setCourse((c) => (c ? { ...c, materials: c.materials.filter((_, i) => i !== index) } : c));
+  };
+
+  const handleConfirm = async () => {
+    if (!course || !user) return;
+    setStep('saving');
+    setError(null);
+    try {
+      const newCourse: Course = {
+        id: crypto.randomUUID(),
+        code: course.code,
+        title: course.title,
+        color: course.color,
+        source: 'ai',
+        ...(course.instructor ? { instructor: course.instructor } : {}),
+        ...(course.term ? { term: course.term } : {}),
+        ...(course.modality ? { modality: course.modality } : {}),
+        ...(course.meetingTimes.length ? { meetingTimes: course.meetingTimes } : {}),
+        ...(course.materials.length ? { materials: course.materials.filter(Boolean) } : {}),
+        ...(course.skipDates.length ? { skipDates: course.skipDates } : {}),
+        ...(course.notes ? { notes: course.notes } : {}),
+      };
+      await createCourse(user.uid, newCourse, dispatch);
+
+      const included = items.filter((it) => it.include && it.dueDate);
+      for (const it of included) {
+        const scheduleItem: ScheduleItem = {
+          id: crypto.randomUUID(),
+          courseId: newCourse.id,
+          title: it.title,
+          type: it.type,
+          dueDate: new Date(`${it.dueDate}T23:59:00`).toISOString(),
+          completed: false,
+          priority: it.highStakes ? 'high' : 'medium',
+          source: 'ai',
+          ...(it.dateConfidence === 'approximate'
+            ? { dateConfidence: 'approximate' as const }
+            : {}),
+          ...(it.highStakes ? { highStakes: true } : {}),
+          ...(it.gradeWeight != null ? { gradeWeight: it.gradeWeight } : {}),
+          ...(it.gradeCategory ? { gradeCategory: it.gradeCategory } : {}),
+          ...(it.notes ? { notes: it.notes } : {}),
+        };
+        // Sequential, not parallel: keeps optimistic dispatch order stable
+        // and avoids hammering Firestore with a burst of concurrent writes
+        // for syllabi with 20+ items.
+        await createScheduleItem(user.uid, scheduleItem, dispatch);
+      }
+
+      if (file) {
+        try {
+          await saveSyllabusPdf(user.uid, newCourse.id, file);
+        } catch {
+          // Non-fatal: the course and tasks are already saved. The user can
+          // re-upload the PDF from the course page if this fails.
+        }
+      }
+
+      handleClose();
+      router.push(`/courses/${newCourse.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save. Please try again.');
+      setStep('review');
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="autofill-title"
+      onClick={step === 'upload' ? handleClose : undefined}
+    >
+      <div
+        className="max-h-full w-full max-w-2xl overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle id="autofill-title">Autofill from Syllabus</CardTitle>
+            <CardDescription>
+              Upload a syllabus PDF and review what Claude found before it&apos;s added.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            {error && (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {step === 'upload' && (
+              <div
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragActive(true);
+                }}
+                onDragLeave={() => setDragActive(false)}
+                onDrop={handleDrop}
+                onClick={() => inputRef.current?.click()}
+                role="button"
+                tabIndex={0}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1 rounded-xl border-2 border-dashed px-4 py-10 text-center cursor-pointer transition-colors',
+                  dragActive ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent',
+                )}
+              >
+                <span className="text-sm font-medium text-foreground">
+                  Drop a syllabus PDF here, or click to browse
+                </span>
+                <span className="text-xs text-muted-foreground">PDF only, up to 10MB</span>
+                <input
+                  ref={inputRef}
+                  type="file"
+                  accept="application/pdf"
+                  className="hidden"
+                  onChange={(e) => {
+                    const selected = e.target.files?.[0];
+                    if (selected) handleFile(selected);
+                    e.target.value = '';
+                  }}
+                />
+              </div>
+            )}
+
+            {step === 'extracting' && (
+              <div className="flex flex-col items-center justify-center gap-3 py-14">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <p className="text-sm text-muted-foreground">Reading your syllabus...</p>
+              </div>
+            )}
+
+            {(step === 'review' || step === 'saving') && course && (
+              <div className="space-y-6">
+                <section className="space-y-3">
+                  <h3 className="text-sm font-semibold text-foreground">Course</h3>
+                  <div className="grid grid-cols-2 gap-3">
+                    <TextField
+                      label="Code"
+                      value={course.code}
+                      onChange={(v) => setCourse((c) => c && { ...c, code: v })}
+                    />
+                    <TextField
+                      label="Term"
+                      value={course.term}
+                      onChange={(v) => setCourse((c) => c && { ...c, term: v })}
+                    />
+                  </div>
+                  <TextField
+                    label="Title"
+                    value={course.title}
+                    onChange={(v) => setCourse((c) => c && { ...c, title: v })}
+                  />
+                  <TextField
+                    label="Instructor"
+                    value={course.instructor}
+                    onChange={(v) => setCourse((c) => c && { ...c, instructor: v })}
+                  />
+                  <div className="flex gap-2">
+                    {COURSE_COLORS.map((color) => (
+                      <button
+                        key={color}
+                        type="button"
+                        aria-label={color}
+                        onClick={() => setCourse((c) => c && { ...c, color })}
+                        className={cn(
+                          'h-6 w-6 rounded-full transition-transform',
+                          color,
+                          course.color === color
+                            ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
+                            : 'hover:scale-110',
+                        )}
+                      />
+                    ))}
+                  </div>
+                </section>
+
+                {course.meetingTimes.length > 0 && (
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold text-foreground">Meeting times</h3>
+                    {course.meetingTimes.map((m, i) => (
+                      <div
+                        key={i}
+                        className="flex flex-wrap items-center gap-2 rounded-lg border border-border p-2 text-xs"
+                      >
+                        <select
+                          value={m.dayOfWeek}
+                          onChange={(e) => updateMeeting(i, { dayOfWeek: Number(e.target.value) })}
+                          className="rounded-md border border-border bg-background px-2 py-1 text-foreground"
+                        >
+                          {WEEKDAY_ABBR.map((label, d) => (
+                            <option key={d} value={d}>
+                              {label}
+                            </option>
+                          ))}
+                        </select>
+                        <input
+                          type="time"
+                          value={m.startTime}
+                          onChange={(e) => updateMeeting(i, { startTime: e.target.value })}
+                          className="rounded-md border border-border bg-background px-2 py-1 text-foreground"
+                        />
+                        <span className="text-muted-foreground">to</span>
+                        <input
+                          type="time"
+                          value={m.endTime}
+                          onChange={(e) => updateMeeting(i, { endTime: e.target.value })}
+                          className="rounded-md border border-border bg-background px-2 py-1 text-foreground"
+                        />
+                        <input
+                          value={m.location ?? ''}
+                          onChange={(e) => updateMeeting(i, { location: e.target.value })}
+                          placeholder="Location"
+                          className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-foreground"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeMeeting(i)}
+                          className="rounded-md px-1.5 py-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </section>
+                )}
+
+                {course.materials.length > 0 && (
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold text-foreground">
+                      Materials &amp; supplies
+                    </h3>
+                    <ul className="space-y-1.5">
+                      {course.materials.map((m, i) => (
+                        <li key={i} className="flex items-center gap-2">
+                          <input
+                            value={m}
+                            onChange={(e) => updateMaterial(i, e.target.value)}
+                            className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeMaterial(i)}
+                            className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                          >
+                            ✕
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">
+                    Schedule items ({items.filter((i) => i.include).length} of {items.length}{' '}
+                    selected)
+                  </h3>
+                  {items.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      No dated items found in this syllabus.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {items.map((it) => (
+                        <div
+                          key={it.key}
+                          className={cn(
+                            'rounded-lg border p-2.5 text-xs',
+                            it.include ? 'border-border' : 'border-dashed border-border opacity-70',
+                          )}
+                        >
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              checked={it.include}
+                              disabled={!it.dueDate}
+                              onChange={(e) => updateItem(it.key, { include: e.target.checked })}
+                              className="h-3.5 w-3.5 rounded border-border accent-primary"
+                            />
+                            <input
+                              value={it.title}
+                              onChange={(e) => updateItem(it.key, { title: e.target.value })}
+                              className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 font-medium text-foreground"
+                            />
+                            <select
+                              value={it.type}
+                              onChange={(e) =>
+                                updateItem(it.key, { type: e.target.value as AssignmentType })
+                              }
+                              className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground"
+                            >
+                              {Object.entries(TYPE_LABELS).map(([value, label]) => (
+                                <option key={value} value={value}>
+                                  {label}
+                                </option>
+                              ))}
+                            </select>
+                            <input
+                              type="date"
+                              value={it.dueDate ?? ''}
+                              onChange={(e) =>
+                                updateItem(it.key, {
+                                  dueDate: e.target.value || null,
+                                  include: e.target.value ? it.include : false,
+                                })
+                              }
+                              className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground"
+                            />
+                          </div>
+                          <div className="mt-1.5 flex flex-wrap items-center gap-1.5 pl-6">
+                            {it.dateConfidence === 'approximate' && (
+                              <span className="rounded-full bg-load-medium/10 px-2 py-0.5 font-semibold text-load-medium">
+                                ~ approximate date, please confirm
+                              </span>
+                            )}
+                            {it.dateConfidence === 'unknown' && (
+                              <span className="rounded-full bg-accent px-2 py-0.5 font-medium text-muted-foreground">
+                                No date found - add one to include this
+                              </span>
+                            )}
+                            {it.highStakes && (
+                              <span className="rounded-full bg-load-critical/10 px-2 py-0.5 font-semibold text-load-critical">
+                                High stakes
+                              </span>
+                            )}
+                            {it.gradeWeight != null && (
+                              <span className="rounded-full bg-primary/10 px-2 py-0.5 font-semibold text-primary">
+                                {it.gradeWeight}% of grade
+                              </span>
+                            )}
+                            {it.notes && <span className="text-muted-foreground">{it.notes}</span>}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </section>
+
+                {unresolved.length > 0 && (
+                  <section className="rounded-lg border border-load-medium/30 bg-load-medium/10 p-3">
+                    <h3 className="text-xs font-semibold text-load-medium">
+                      Couldn&apos;t determine
+                    </h3>
+                    <ul className="mt-1.5 space-y-1 text-xs text-foreground">
+                      {unresolved.map((note, i) => (
+                        <li key={i}>• {note}</li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+              </div>
+            )}
+          </CardContent>
+
+          {(step === 'review' || step === 'saving') && (
+            <CardFooter className="justify-end gap-2">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={step === 'saving' || !course?.code || !course?.title}
+                className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {step === 'saving' ? 'Saving...' : 'Add Course & Tasks'}
+              </button>
+            </CardFooter>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+/** Wraps the existing resumable-upload hook for a one-shot call outside of
+ * its own component lifecycle, so the originally-uploaded PDF ends up
+ * attached to the new course exactly like a manual syllabus upload would -
+ * reusing tested code instead of a second upload path. */
+async function saveSyllabusPdf(userId: string, courseId: string, file: File) {
+  const { ref, uploadBytes, getDownloadURL } = await import('firebase/storage');
+  const { doc, setDoc } = await import('firebase/firestore');
+  const { storage, db } = await import('@/lib/firebase/client');
+  if (!storage || !db) throw new Error('Storage is not configured.');
+
+  const id = crypto.randomUUID();
+  const storagePath = `users/${userId}/syllabi/${courseId}/${id}-${file.name}`;
+  const snapshot = await uploadBytes(ref(storage, storagePath), file);
+  const downloadURL = await getDownloadURL(snapshot.ref);
+  await setDoc(doc(db, 'users', userId, 'courses', courseId, 'syllabi', id), {
+    id,
+    courseId,
+    fileName: file.name,
+    storagePath,
+    downloadURL,
+    sizeBytes: file.size,
+    uploadedAt: new Date().toISOString(),
+  });
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-foreground">{label}</label>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+    </div>
+  );
+}

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { BackLink } from '@/components/ui/BackLink';
+import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
+import { TaskFormModal } from '@/components/tasks/TaskFormModal';
+import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
+import { ICON_PATHS } from '@/lib/icons';
+import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
+import type { AssignmentType } from '@/types/schedule';
+import { cn } from '@/lib/utils';
+
+const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const TYPE_LABELS: Record<AssignmentType, string> = {
+  assignment: 'Assignment',
+  exam: 'Exam',
+  quiz: 'Quiz',
+  project: 'Project',
+  reading: 'Reading',
+  other: 'Other',
+};
+
+const solidButtonClass =
+  'inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90';
+const outlineButtonClass =
+  'inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3.5 py-2 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-accent';
+const destructiveButtonClass =
+  'inline-flex items-center gap-1.5 rounded-lg border border-destructive/30 bg-destructive/10 px-3.5 py-2 text-sm font-semibold text-destructive transition-colors hover:bg-destructive/20';
+
+export function TaskDetailView({ taskId }: { taskId: string }) {
+  const { state, dispatch } = useAppState();
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const item = state.scheduleItems.find((i) => i.id === taskId);
+  const course = item ? state.courses.find((c) => c.id === item.courseId) : undefined;
+
+  if (!item) {
+    return (
+      <div className="max-w-2xl space-y-4">
+        <p className="text-sm text-muted-foreground">
+          This task doesn&apos;t exist or has been removed.
+        </p>
+        <BackLink href="/tasks">Back to tasks</BackLink>
+      </div>
+    );
+  }
+
+  const overdue = !item.completed && new Date(item.dueDate) < new Date();
+
+  const handleToggleComplete = async () => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+  };
+
+  const handleEditTask = async (values: ScheduleItemFormValues) => {
+    if (!user) throw new Error('You must be signed in to edit a task.');
+    await updateScheduleItem(
+      user.uid,
+      item,
+      {
+        ...item,
+        title: values.title,
+        type: values.type,
+        courseId: values.courseId,
+        dueDate: new Date(`${values.dueDate}T23:59:00`).toISOString(),
+        priority: values.priority,
+        ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
+        ...(values.notes ? { notes: values.notes } : {}),
+      },
+      dispatch,
+    );
+  };
+
+  const handleDelete = async () => {
+    if (!user) return;
+    await deleteScheduleItem(user.uid, item, dispatch);
+    router.push('/tasks');
+  };
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <BackLink href="/tasks">Back to tasks</BackLink>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <span
+            className={cn(
+              'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-white shadow-sm',
+              course?.color || 'bg-primary',
+            )}
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d={ICON_PATHS.tasks} />
+            </svg>
+          </span>
+          <div>
+            <h1
+              className={cn(
+                'text-2xl font-bold tracking-tight text-foreground',
+                item.completed && 'text-muted-foreground line-through',
+              )}
+            >
+              {item.title}
+            </h1>
+            {course && (
+              <Link
+                href={`/courses/${course.id}`}
+                className="text-sm text-muted-foreground hover:text-primary hover:underline"
+              >
+                {course.code} · {course.title}
+              </Link>
+            )}
+          </div>
+        </div>
+        <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={item.completed}
+            onChange={handleToggleComplete}
+            className="h-4 w-4 rounded border-border accent-primary"
+          />
+          Done
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
+          {TYPE_LABELS[item.type]}
+        </span>
+        {item.priority && (
+          <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium capitalize text-muted-foreground">
+            {item.priority} priority
+          </span>
+        )}
+        {overdue && (
+          <span className="rounded-full bg-load-critical/10 px-2.5 py-1 text-xs font-semibold text-load-critical">
+            Overdue
+          </span>
+        )}
+        {item.gradeWeight !== undefined && (
+          <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+            {item.gradeWeight}% of grade{item.gradeCategory ? ` · ${item.gradeCategory}` : ''}
+          </span>
+        )}
+        {item.source === 'ai' && (
+          <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            From syllabus
+          </span>
+        )}
+      </div>
+
+      <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5 text-sm">
+        <div>
+          <dt className="text-xs text-muted-foreground">Due</dt>
+          <dd className="mt-0.5 font-medium text-foreground">
+            {dueDateFormatter.format(new Date(item.dueDate))}
+          </dd>
+        </div>
+        {item.estimatedHours !== undefined && (
+          <div>
+            <dt className="text-xs text-muted-foreground">Estimated effort</dt>
+            <dd className="mt-0.5 font-medium text-foreground">{item.estimatedHours}h</dd>
+          </div>
+        )}
+      </dl>
+
+      {item.notes && (
+        <div className="border-t border-border pt-5">
+          <dt className="text-xs text-muted-foreground">Notes</dt>
+          <dd className="mt-1 whitespace-pre-wrap text-sm text-foreground">{item.notes}</dd>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-border pt-5">
+        <button onClick={() => setEditOpen(true)} className={solidButtonClass}>
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+            />
+          </svg>
+          Edit
+        </button>
+        <a
+          href={generateGoogleCalendarUrl(item, course)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={outlineButtonClass}
+        >
+          Google Calendar
+        </a>
+        <a
+          href={generateOutlookCalendarUrl(item, course)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={outlineButtonClass}
+        >
+          Outlook
+        </a>
+        <div className="ml-auto">
+          {confirmingDelete ? (
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground">Delete this task?</span>
+              <button
+                onClick={handleDelete}
+                className="rounded-lg bg-destructive px-3.5 py-2 font-semibold text-destructive-foreground transition-opacity hover:opacity-90"
+              >
+                Confirm
+              </button>
+              <button onClick={() => setConfirmingDelete(false)} className={outlineButtonClass}>
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button onClick={() => setConfirmingDelete(true)} className={destructiveButtonClass}>
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      <TaskFormModal
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSubmit={handleEditTask}
+        courses={state.courses}
+        initialItem={item}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/BackLink.tsx
+++ b/src/components/ui/BackLink.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+/** Consistent "← Back to X" navigation link for detail pages, styled as a
+ * quiet pill instead of a bare underlined blue link. */
+export function BackLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1 rounded-full px-2.5 py-1.5 -ml-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+    >
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2.5}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/ui/CardAction.tsx
+++ b/src/components/ui/CardAction.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+/**
+ * Pill-shaped action button for card headers (e.g. "+ Add Course", "View all
+ * tasks"). Replaces the old bare `text-primary hover:underline` links, which
+ * read as default browser hyperlinks rather than part of the design system.
+ * `variant="solid"` is for the primary action in a header (usually a "+ Add"
+ * button); `variant="ghost"` is for secondary navigation ("View all →").
+ */
+const baseClass =
+  'inline-flex shrink-0 items-center gap-1 rounded-full text-xs font-semibold transition-colors active:scale-[0.97]';
+
+const variantClass = {
+  solid: 'bg-primary/10 text-primary px-3 py-1.5 hover:bg-primary/20',
+  ghost:
+    'border border-border text-muted-foreground px-3 py-1.5 hover:border-primary/30 hover:bg-primary/5 hover:text-primary',
+} as const;
+
+export type CardActionVariant = keyof typeof variantClass;
+
+function PlusIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+interface SharedProps {
+  children: React.ReactNode;
+  variant?: CardActionVariant;
+  /** Shows a leading "+" glyph, for creation actions. */
+  withPlus?: boolean;
+  /** Shows a trailing chevron, for "view more"/navigation actions. */
+  withChevron?: boolean;
+  className?: string;
+}
+
+export function CardActionLink({
+  href,
+  children,
+  variant = 'ghost',
+  withPlus,
+  withChevron,
+  className,
+  ...rest
+}: SharedProps & { href: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <Link href={href} className={cn(baseClass, variantClass[variant], className)} {...rest}>
+      {withPlus && <PlusIcon />}
+      {children}
+      {withChevron && <ChevronRightIcon />}
+    </Link>
+  );
+}
+
+export function CardActionButton({
+  onClick,
+  children,
+  variant = 'ghost',
+  withPlus,
+  withChevron,
+  className,
+  disabled,
+  type = 'button',
+}: SharedProps & {
+  onClick?: () => void;
+  disabled?: boolean;
+  type?: 'button' | 'submit';
+}) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(baseClass, variantClass[variant], 'disabled:opacity-50', className)}
+    >
+      {withPlus && <PlusIcon />}
+      {children}
+      {withChevron && <ChevronRightIcon />}
+    </button>
+  );
+}

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import type { AssignmentType, Priority } from '@/types/schedule';
 
@@ -32,6 +33,9 @@ export interface TaskRowProps {
   onToggleComplete?: () => void;
   /** Right-aligned custom content: due labels, badges, edit/delete links. */
   trailing?: ReactNode;
+  /** When present, the row navigates to this URL on click (e.g. a task
+   * detail page), while the checkbox stays independently clickable. */
+  href?: string;
 }
 
 export function TaskRow({
@@ -43,19 +47,22 @@ export function TaskRow({
   priority = 'medium',
   onToggleComplete,
   trailing,
+  href,
 }: TaskRowProps) {
-  return (
-    <div
-      className={cn(
-        'flex items-center gap-3 py-2.5 pl-3 border-l-2 first:pt-0 last:pb-0',
-        PRIORITY_BORDER_CLASS[priority],
-      )}
-    >
+  const rowClass = cn(
+    'flex items-center gap-3 py-2.5 pl-3 border-l-2 first:pt-0 last:pb-0',
+    PRIORITY_BORDER_CLASS[priority],
+    href && 'rounded-r-lg transition-colors hover:bg-accent',
+  );
+
+  const content = (
+    <>
       {onToggleComplete && (
         <input
           type="checkbox"
           checked={completed}
           onChange={onToggleComplete}
+          onClick={(e) => e.stopPropagation()}
           className="h-4 w-4 rounded border-border accent-primary shrink-0"
           aria-label={`Mark ${title} complete`}
         />
@@ -87,7 +94,21 @@ export function TaskRow({
         </div>
         {courseCode && <div className="text-xs text-muted-foreground">{courseCode}</div>}
       </div>
-      {trailing && <div className="flex items-center gap-2 shrink-0">{trailing}</div>}
-    </div>
+      {trailing && (
+        <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
+          {trailing}
+        </div>
+      )}
+    </>
   );
+
+  if (href) {
+    return (
+      <Link href={href} className={rowClass}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={rowClass}>{content}</div>;
 }

--- a/src/lib/ai/anthropic.ts
+++ b/src/lib/ai/anthropic.ts
@@ -1,0 +1,27 @@
+/**
+ * Server-only Anthropic client. Never import this from client components -
+ * it reads ANTHROPIC_API_KEY directly and would leak the key into the
+ * client bundle.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+if (typeof window !== 'undefined') {
+  throw new Error('Internal Error: lib/ai/anthropic must not be imported in client-side code.');
+}
+
+let client: Anthropic | undefined;
+
+export function getAnthropicClient(): Anthropic {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is not configured.');
+  }
+  if (!client) {
+    client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  }
+  return client;
+}
+
+/** Latest, most capable Claude model - syllabus extraction benefits from
+ * strong document understanding and instruction-following on an unusual,
+ * multi-part JSON schema. */
+export const SYLLABUS_EXTRACTION_MODEL = 'claude-sonnet-5';

--- a/src/lib/ai/syllabusExtractionTool.ts
+++ b/src/lib/ai/syllabusExtractionTool.ts
@@ -1,0 +1,136 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+/**
+ * Forces Claude's response into our exact schema via tool-calling, rather
+ * than hoping it returns clean JSON in prose. Kept as a hand-written JSON
+ * Schema (mirroring `syllabusExtractionSchema` in src/types/extraction.ts)
+ * since the Anthropic tool `input_schema` is plain JSON Schema, not zod -
+ * the zod schema is the source of truth for validating the result server-
+ * side, this just shapes what the model is asked to produce.
+ */
+export const SYLLABUS_EXTRACTION_TOOL: Anthropic.Tool = {
+  name: 'record_syllabus_extraction',
+  description: 'Records the structured data extracted from a course syllabus.',
+  input_schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['course', 'scheduleItems', 'unresolved'],
+    properties: {
+      course: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['code', 'title', 'meetingTimes', 'materials', 'skipDates'],
+        properties: {
+          code: { type: 'string', description: 'e.g. "CSCI 213"' },
+          title: { type: 'string', description: 'e.g. "Computer Science I"' },
+          instructor: { type: ['string', 'null'] },
+          term: { type: ['string', 'null'], description: 'e.g. "Spring 2026"' },
+          modality: { type: ['string', 'null'], enum: ['in-person', 'online', 'hybrid', null] },
+          meetingTimes: {
+            type: 'array',
+            description:
+              'Only the actual recurring class/lecture/rehearsal schedule - never office hours or tutoring slots. Omit entirely for asynchronous/online courses with no fixed meeting time.',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['dayOfWeek', 'startTime', 'endTime'],
+              properties: {
+                dayOfWeek: {
+                  type: 'integer',
+                  minimum: 0,
+                  maximum: 6,
+                  description: '0=Sunday..6=Saturday',
+                },
+                startTime: { type: 'string', description: '24-hour "HH:mm"' },
+                endTime: { type: 'string', description: '24-hour "HH:mm"' },
+                location: { type: ['string', 'null'] },
+              },
+            },
+          },
+          materials: {
+            type: 'array',
+            description:
+              'General required/optional materials NOT tied to a specific date: textbook (mark required vs. optional), calculator, supplies, dress code, etc. Empty array if the syllabus states none are needed.',
+            items: { type: 'string' },
+          },
+          skipDates: {
+            type: 'array',
+            description:
+              'ISO dates (YYYY-MM-DD) within the term where class does NOT meet due to a holiday or break explicitly called out in the syllabus schedule (e.g. "1/19 - HOLIDAY - MLK Day", "Spring Break Week 3/9-3/13"). Only include dates you can resolve to a specific calendar date using the term/year.',
+            items: { type: 'string' },
+          },
+          notes: {
+            type: ['string', 'null'],
+            description:
+              'Free-text catch-all for things worth keeping but not worth modeling structurally: footnotes on meeting times (e.g. "sectional days start at noon"), "no comprehensive final exam", grading-dispute windows, etc.',
+          },
+        },
+      },
+      scheduleItems: {
+        type: 'array',
+        description:
+          'Every dated, gradeable, or otherwise calendar-worthy item: assignments, exams, quizzes, projects, readings with deadlines, and - just as importantly - "important dates" that are not traditional assignments: mandatory performances/rehearsals/trips, registrar deadlines mentioned in the syllabus (add/drop, withdrawal-with-refund cutoffs), and dated supply-acquisition needs (e.g. "acquire concert attire before the first performance"). Do NOT invent items (like a final exam) that are not actually mentioned. Do NOT include pure boilerplate (FERPA, ADA, academic honesty policy text).',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['title', 'type', 'dueDate', 'dateConfidence'],
+          properties: {
+            title: { type: 'string' },
+            type: {
+              type: 'string',
+              enum: ['assignment', 'exam', 'quiz', 'project', 'reading', 'other'],
+            },
+            dueDate: {
+              type: ['string', 'null'],
+              description:
+                'ISO date YYYY-MM-DD. Resolve week-ranges to an exact date when the syllabus states a default rule (e.g. "all due dates are Fridays", "due by 11:59pm of the due date") - apply that rule to the range. If no such rule exists, use the last day of the range as a best-guess date and mark dateConfidence "approximate". If there is truly no basis to compute any date (e.g. dates are only posted on the LMS, or attendance-only grading with no dated deliverables), use null and add a note to `unresolved` explaining why.',
+            },
+            dateConfidence: {
+              type: 'string',
+              enum: ['exact', 'approximate', 'unknown'],
+              description:
+                '"exact" = the syllabus stated this date directly, or it was deterministically resolved via a stated default-deadline rule. "approximate" = guessed from a range with no stated rule (e.g. last day of the week). "unknown" = dueDate is null.',
+            },
+            gradeWeight: {
+              type: ['number', 'null'],
+              description:
+                'Percentage of final grade (e.g. 15 for 15%), only when the syllabus states a percentage - omit/null for points-based or non-percentage grading.',
+            },
+            gradeCategory: {
+              type: ['string', 'null'],
+              description: 'e.g. "Homework", "Exam", "Final Project"',
+            },
+            notes: {
+              type: ['string', 'null'],
+              description:
+                'Short context worth surfacing, e.g. "counts as an unexcused absence; missing this = automatic F", "overnight travel required", "worth 3 midterm exams total".',
+            },
+            highStakes: {
+              type: 'boolean',
+              description:
+                'true if this item is unusually high-stakes: a large grade weight (roughly 15%+), or explicit "mandatory"/"required"/"automatic F if missed" language.',
+            },
+          },
+        },
+      },
+      unresolved: {
+        type: 'array',
+        description:
+          'Plain-language notes about things you noticed but could not confidently extract, for a human to see before confirming, e.g. "This syllabus does not list exam dates - your professor may post them on Blackboard/LMS separately."',
+        items: { type: 'string' },
+      },
+    },
+  },
+};
+
+export const SYLLABUS_EXTRACTION_SYSTEM_PROMPT = `You are an expert academic planner reading a college syllabus PDF to help a student build their calendar. Call the record_syllabus_extraction tool exactly once with everything you find. Follow these rules, learned from studying real university syllabi:
+
+1. Ignore boilerplate entirely: FERPA, ADA/accommodations, academic honesty, grade-dispute-window, and military-obligation statements are never calendar-worthy. Do not extract items from them.
+2. Distinguish the actual class/lecture/rehearsal meeting schedule from office hours or tutoring slots - only the former belongs in meetingTimes. Many syllabi (especially asynchronous online courses) have no meeting time at all - that's fine, leave meetingTimes empty rather than inventing one.
+3. Never invent items that aren't actually mentioned. If a syllabus explicitly says "no comprehensive final exam," do not add a final exam. If exam dates simply aren't given anywhere, don't guess a date - use dueDate: null and explain in unresolved.
+4. Prefer exact dates. When only a week-range is given, check the syllabus's own policy text for a stated default deadline rule (a specific weekday and/or time, e.g. "all assignments due Fridays by 11:59pm") and apply it to compute an exact date; only fall back to "approximate" (last day of the range) when no such rule exists.
+5. Grading isn't always percentage-based - some syllabi use point totals, some are attendance-only, some use completion-based "grading contracts" with no per-item weight at all. Leave gradeWeight/gradeCategory null rather than fabricating a percentage.
+6. Look beyond traditional assignments for other calendar-worthy dates: mandatory performances/rehearsals/trips (especially in arts/ensemble courses), registrar deadlines the syllabus itself lists (add/drop, withdrawal-with-refund cutoffs), and holidays/breaks called out in a weekly schedule table. Holidays/breaks go in skipDates (so recurring class meetings can skip them), not scheduleItems.
+7. Extract a general materials list only when the syllabus actually describes required/optional supplies (textbook, calculator, specific paper, dress code, instrument, etc.) - leave it empty if none are mentioned, and don't confuse free/open-source software tools with physical supplies.
+8. Flag highStakes: true on items with roughly 15%+ grade weight, or explicit "mandatory"/"required attendance"/"automatic F if missed" language - these deserve a visual warning during review, not the same treatment as a routine reading.
+9. If the term/year is stated anywhere in the document (header, "Spring 2026", a schedule table's date range), use it to resolve every date to a full ISO YYYY-MM-DD - never leave a date ambiguous about the year.`;

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+/**
+ * Schema for what Claude extracts from a syllabus PDF (Epic 6). Shared
+ * between the API route (validates the model's tool-call output before
+ * trusting it) and the review UI (typed draft the user edits before it's
+ * committed to Firestore via the normal createCourse/createScheduleItem
+ * calls - nothing here is written directly).
+ *
+ * Design notes, from reading 8 real syllabi before building this:
+ * - Not every syllabus has an explicit due date for every item (some post
+ *   dates on the LMS instead, some grade purely on attendance). `dueDate`
+ *   is nullable and `dateConfidence` is honest about how sure the
+ *   resolution is, rather than silently guessing.
+ * - Class meetings vs. office hours are easy to conflate; `meetingTimes`
+ *   should only be the actual class/lecture/rehearsal schedule.
+ * - Holidays/breaks called out in a weekly schedule table go in
+ *   `skipDates` so the calendar's recurring-meeting renderer can skip them,
+ *   distinct from `scheduleItems` (real deadlines never disappear).
+ * - Grading isn't always percentage-based (points totals, attendance-only,
+ *   completion contracts all show up) - `gradeWeight`/`gradeCategory` stay
+ *   optional.
+ */
+
+const assignmentTypeSchema = z.enum(['assignment', 'exam', 'quiz', 'project', 'reading', 'other']);
+
+const modalitySchema = z.enum(['in-person', 'online', 'hybrid']);
+
+export const extractedMeetingTimeSchema = z.object({
+  dayOfWeek: z.number().int().min(0).max(6),
+  startTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+  endTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+  location: z.string().max(100).nullable().optional(),
+});
+
+export const extractedScheduleItemSchema = z.object({
+  title: z.string().min(1).max(200),
+  type: assignmentTypeSchema,
+  /** ISO date YYYY-MM-DD, or null when the syllabus gives no basis to
+   * compute one at all (e.g. "dates posted on Blackboard"). */
+  dueDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable(),
+  dateConfidence: z.enum(['exact', 'approximate', 'unknown']),
+  gradeWeight: z.number().min(0).max(100).nullable().optional(),
+  gradeCategory: z.string().max(60).nullable().optional(),
+  /** Short free-text context, e.g. "counts as unexcused absence if missed". */
+  notes: z.string().max(300).nullable().optional(),
+  highStakes: z.boolean().optional(),
+});
+
+export const extractedCourseSchema = z.object({
+  code: z.string().min(1).max(20),
+  title: z.string().min(1).max(150),
+  instructor: z.string().max(100).nullable().optional(),
+  term: z.string().max(50).nullable().optional(),
+  modality: modalitySchema.nullable().optional(),
+  meetingTimes: z.array(extractedMeetingTimeSchema).default([]),
+  /** General materials/resources not tied to a specific date - textbook
+   * (required or optional), supplies, dress code, etc. */
+  materials: z.array(z.string().max(400)).default([]),
+  /** ISO dates within the term where meetings don't happen (holidays,
+   * breaks) called out in the syllabus's own schedule. */
+  skipDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).default([]),
+  /** Free-text catch-all for things worth keeping but not worth modeling
+   * structurally: footnotes on meeting times, "no comprehensive final",
+   * grading-dispute windows, etc. */
+  notes: z.string().max(1000).nullable().optional(),
+});
+
+export const syllabusExtractionSchema = z.object({
+  course: extractedCourseSchema,
+  scheduleItems: z.array(extractedScheduleItemSchema).default([]),
+  /** Things the parser noticed but couldn't confidently extract, in plain
+   * language for the review screen, e.g. "Exam dates aren't in this
+   * syllabus - your professor posts them on Blackboard." */
+  unresolved: z.array(z.string().max(300)).default([]),
+});
+
+export type ExtractedMeetingTime = z.infer<typeof extractedMeetingTimeSchema>;
+export type ExtractedScheduleItem = z.infer<typeof extractedScheduleItemSchema>;
+export type ExtractedCourse = z.infer<typeof extractedCourseSchema>;
+export type SyllabusExtractionResult = z.infer<typeof syllabusExtractionSchema>;

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -41,6 +41,14 @@ export interface Course {
   modality?: CourseModality;
   /** Recurring weekly meeting times, e.g. "MWF 9:00-10:15" */
   meetingTimes?: MeetingTime[];
+  /** General required/optional materials from the syllabus (textbook,
+   * calculator, supplies) that aren't tied to a specific due date. */
+  materials?: string[];
+  /** ISO dates (YYYY-MM-DD) on which recurring meetings should NOT render -
+   * holidays and breaks called out in the syllabus (e.g. "1/19 - HOLIDAY").
+   * Only suppresses `meetingTimes` occurrences; never affects `ScheduleItem`
+   * due dates, since a real deadline shouldn't disappear on a break. */
+  skipDates?: string[];
 }
 
 /**
@@ -86,6 +94,17 @@ export interface ScheduleItem {
   gradeCategory?: string;
   /** Whether this item was entered manually or created from AI syllabus extraction. Defaults to 'manual' when absent. */
   source?: DataSource;
+  /** How confident the AI extractor was in `dueDate`, when `source` is 'ai'.
+   * 'approximate' means the syllabus only gave a week/range and the date was
+   * resolved (e.g. via a stated "all due Fridays" rule or the range's last
+   * day) rather than stated explicitly - surfaced as a "please confirm"
+   * badge. Absent for manually-entered items, which are always exact. */
+  dateConfidence?: 'exact' | 'approximate';
+  /** Set when the AI extractor judged this item unusually high-stakes (large
+   * grade weight, or explicit "mandatory"/"automatic F if missed" language)
+   * so it can be visually flagged during review instead of blending in with
+   * routine items. */
+  highStakes?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Epic 6 (syllabus autofiller):** upload a syllabus PDF, get an editable draft course + schedule items back from Claude before anything touches Firestore. Design is based on reading 8 real university syllabi end-to-end (3 test fixtures + 5 of the user's own current courses) before writing extraction code - see commit message for the full list of rules this encodes (no invented items, week-range date resolution, high-stakes flagging, holiday/break `skipDates`, honest "couldn't determine" list).
- **Design fixes:** replaced bare underlined text links with real pill-button components across Dashboard/Courses/Course Detail/Planner; tasks are now clickable everywhere they appear and open a new `/tasks/[taskId]` detail page.

## Test plan
- [x] `npm run lint`, `vitest run` (180 tests), `tsc --noEmit`, `npm run build` all clean
- [x] Live-verified the autofiller against two real fixture syllabi with real Claude API calls (MUSC 303 - attendance-only grading, high-stakes performance dates; CSCI 313 - async course, percentage grading, approximate week-range dates, an item correctly left unchecked with no fabricated date)
- [x] Live-verified action-button/task-detail changes in both light and dark mode
- [x] Confirmed `ANTHROPIC_API_KEY` and `FIREBASE_ADMIN_*` are present in Vercel Production/Preview/Development