### PR TITLE
Harden syllabus autofiller: rate limiting, atomic writes, re-validation

### DIFF
--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type Anthropic from '@anthropic-ai/sdk';
 import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
 import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import { checkAndIncrementExtractionCount } from '@/lib/ai/extractionRateLimit';
 import {
   SYLLABUS_EXTRACTION_SYSTEM_PROMPT,
   SYLLABUS_EXTRACTION_TOOL,
@@ -45,6 +46,19 @@ export async function POST(req: NextRequest) {
   // Rough size check on the base64 payload (base64 is ~4/3 the byte size).
   if (fileBase64.length > MAX_FILE_BYTES * 1.4) {
     return NextResponse.json({ error: 'File is too large (max 10MB).' }, { status: 400 });
+  }
+  // The client declares application/pdf, but that's a spoofable browser MIME
+  // type - check the real magic bytes server-side before spending an API call.
+  if (!fileBase64.startsWith('JVBERi0')) {
+    return NextResponse.json({ error: 'That file is not a valid PDF.' }, { status: 400 });
+  }
+
+  const rateLimit = await checkAndIncrementExtractionCount(user.uid);
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "You've hit today's syllabus upload limit. Try again tomorrow." },
+      { status: 429 },
+    );
   }
 
   let anthropic;

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -11,8 +11,9 @@ import {
   CardFooter,
 } from '@/components/ui/Card';
 import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
-import { createCourse } from '@/lib/firestore/courses';
-import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { createCourseWithScheduleItems } from '@/lib/firestore/courses';
+import { courseFormSchema } from '@/lib/validation/course';
+import { scheduleItemFormSchema } from '@/lib/validation/scheduleItem';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { cn } from '@/lib/utils';
@@ -213,6 +214,34 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
   const handleConfirm = async () => {
     if (!course || !user) return;
+
+    // The review screen lets the user freely edit whatever Claude extracted,
+    // so re-validate here with the same schemas the manual course/task forms
+    // use - a hand-typed 500-character title shouldn't reach Firestore just
+    // because it arrived via the autofiller instead of the regular form.
+    const courseCheck = courseFormSchema.safeParse(course);
+    if (!courseCheck.success) {
+      setError(courseCheck.error.issues[0]?.message ?? 'Check the course details above.');
+      return;
+    }
+    for (const it of items) {
+      if (!it.include || !it.dueDate) continue;
+      const itemCheck = scheduleItemFormSchema.safeParse({
+        title: it.title,
+        type: it.type,
+        courseId: 'pending',
+        dueDate: it.dueDate,
+        priority: it.highStakes ? 'high' : 'medium',
+        notes: it.notes ?? undefined,
+      });
+      if (!itemCheck.success) {
+        setError(
+          `"${it.title || 'Untitled item'}": ${itemCheck.error.issues[0]?.message ?? 'Check this item.'}`,
+        );
+        return;
+      }
+    }
+
     setStep('saving');
     setError(null);
     try {
@@ -230,32 +259,27 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         ...(course.skipDates.length ? { skipDates: course.skipDates } : {}),
         ...(course.notes ? { notes: course.notes } : {}),
       };
-      await createCourse(user.uid, newCourse, dispatch);
-
       const included = items.filter((it) => it.include && it.dueDate);
-      for (const it of included) {
-        const scheduleItem: ScheduleItem = {
-          id: crypto.randomUUID(),
-          courseId: newCourse.id,
-          title: it.title,
-          type: it.type,
-          dueDate: new Date(`${it.dueDate}T23:59:00`).toISOString(),
-          completed: false,
-          priority: it.highStakes ? 'high' : 'medium',
-          source: 'ai',
-          ...(it.dateConfidence === 'approximate'
-            ? { dateConfidence: 'approximate' as const }
-            : {}),
-          ...(it.highStakes ? { highStakes: true } : {}),
-          ...(it.gradeWeight != null ? { gradeWeight: it.gradeWeight } : {}),
-          ...(it.gradeCategory ? { gradeCategory: it.gradeCategory } : {}),
-          ...(it.notes ? { notes: it.notes } : {}),
-        };
-        // Sequential, not parallel: keeps optimistic dispatch order stable
-        // and avoids hammering Firestore with a burst of concurrent writes
-        // for syllabi with 20+ items.
-        await createScheduleItem(user.uid, scheduleItem, dispatch);
-      }
+      const scheduleItems: ScheduleItem[] = included.map((it) => ({
+        id: crypto.randomUUID(),
+        courseId: newCourse.id,
+        title: it.title,
+        type: it.type,
+        dueDate: new Date(`${it.dueDate}T23:59:00`).toISOString(),
+        completed: false,
+        priority: it.highStakes ? 'high' : 'medium',
+        source: 'ai',
+        ...(it.dateConfidence === 'approximate' ? { dateConfidence: 'approximate' as const } : {}),
+        ...(it.highStakes ? { highStakes: true } : {}),
+        ...(it.gradeWeight != null ? { gradeWeight: it.gradeWeight } : {}),
+        ...(it.gradeCategory ? { gradeCategory: it.gradeCategory } : {}),
+        ...(it.notes ? { notes: it.notes } : {}),
+      }));
+
+      // Single atomic batch: the course and all its schedule items land
+      // together or not at all, instead of the course succeeding while a
+      // mid-loop failure leaves some assignments missing.
+      await createCourseWithScheduleItems(user.uid, newCourse, scheduleItems, dispatch);
 
       if (file) {
         try {

--- a/src/lib/ai/extractionRateLimit.ts
+++ b/src/lib/ai/extractionRateLimit.ts
@@ -1,0 +1,42 @@
+import { adminDb } from '@/lib/firebase/adminFirestore';
+
+/** Generous but real ceiling - a student re-uploading a syllabus a few times
+ * while fixing a bad scan is normal; a scripted loop burning Anthropic spend
+ * is not. Tracked server-side so it can't be bypassed by the client. */
+const DAILY_LIMIT = 15;
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+}
+
+/**
+ * Atomically checks and increments a per-user daily extraction counter,
+ * stored outside any collection the client has rules access to (the
+ * Firestore rules' catch-all `allow read, write: if false` denies clients
+ * by default, so this is admin-only by construction, not just convention).
+ */
+export async function checkAndIncrementExtractionCount(userId: string): Promise<RateLimitResult> {
+  if (!adminDb) {
+    // Fails open only if the admin SDK isn't configured at all (e.g. local
+    // dev without admin env vars) - the route itself still requires a valid
+    // user token, so this isn't an open door, just an unmetered one.
+    return { allowed: true, remaining: DAILY_LIMIT };
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const ref = adminDb.collection('rateLimits').doc(userId);
+
+  return adminDb.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const data = snap.data() as { date?: string; count?: number } | undefined;
+
+    const count = data?.date === today ? (data.count ?? 0) : 0;
+    if (count >= DAILY_LIMIT) {
+      return { allowed: false, remaining: 0 };
+    }
+
+    tx.set(ref, { date: today, count: count + 1 }, { merge: true });
+    return { allowed: true, remaining: DAILY_LIMIT - (count + 1) };
+  });
+}

--- a/src/lib/firebase/adminFirestore.ts
+++ b/src/lib/firebase/adminFirestore.ts
@@ -1,0 +1,38 @@
+/**
+ * Server-only Firestore Admin client, deliberately separate from
+ * src/lib/firebase/admin.ts. That module also imports `firebase-admin/auth`
+ * at the top level, and firebase-admin's Auth module pulls in jwks-rsa,
+ * which crashes with ERR_REQUIRE_ESM inside Vercel's Lambda runtime (see
+ * src/lib/auth/verifyFirebaseIdToken.ts for the full story - that file
+ * replaces firebase-admin's Auth entirely for the same reason). Anything
+ * that only needs Firestore admin access must import from here instead of
+ * admin.ts, or it drags the broken Auth import back in.
+ */
+import { initializeApp, getApps, getApp, cert, App } from 'firebase-admin/app';
+import { getFirestore as getAdminDb, Firestore } from 'firebase-admin/firestore';
+
+if (typeof window !== 'undefined') {
+  throw new Error('Internal Error: firebase-admin must not be imported in client-side code.');
+}
+
+const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY;
+
+let adminDb: Firestore | undefined;
+
+if (projectId && clientEmail && privateKey) {
+  const formattedPrivateKey = privateKey.replace(/\\n/g, '\n');
+  const databaseId = process.env.NEXT_PUBLIC_FIRESTORE_DATABASE_ID;
+
+  const app: App = !getApps().length
+    ? initializeApp({
+        credential: cert({ projectId, clientEmail, privateKey: formattedPrivateKey }),
+      })
+    : getApp();
+
+  adminDb =
+    databaseId && databaseId !== '(default)' ? getAdminDb(app, databaseId) : getAdminDb(app);
+}
+
+export { adminDb };

--- a/src/lib/firestore/courses.ts
+++ b/src/lib/firestore/courses.ts
@@ -27,6 +27,36 @@ export async function createCourse(
   }
 }
 
+/**
+ * Creates a course together with a batch of schedule items in a single
+ * atomic Firestore write - used by the syllabus autofiller, where a course
+ * with 20+ extracted assignments should never partially land (e.g. the
+ * course saved but half the assignments missing because of a mid-loop
+ * network failure).
+ */
+export async function createCourseWithScheduleItems(
+  userId: string,
+  course: Course,
+  scheduleItems: ScheduleItem[],
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'ADD_COURSE', payload: course });
+  scheduleItems.forEach((item) => dispatch({ type: 'ADD_SCHEDULE_ITEM', payload: item }));
+  try {
+    const database = requireDb();
+    const batch = writeBatch(database);
+    batch.set(doc(database, 'users', userId, 'courses', course.id), course);
+    scheduleItems.forEach((item) => {
+      batch.set(doc(database, 'users', userId, 'scheduleItems', item.id), item);
+    });
+    await batch.commit();
+  } catch (err) {
+    dispatch({ type: 'REMOVE_COURSE', payload: course.id });
+    scheduleItems.forEach((item) => dispatch({ type: 'REMOVE_SCHEDULE_ITEM', payload: item.id }));
+    throw err;
+  }
+}
+
 export async function updateCourse(
   userId: string,
   previousCourse: Course,

--- a/src/lib/validation/course.ts
+++ b/src/lib/validation/course.ts
@@ -20,7 +20,7 @@ export const courseFormSchema = z.object({
     .string()
     .trim()
     .min(1, 'Course title is required')
-    .max(100, 'Keep it under 100 characters'),
+    .max(150, 'Keep it under 150 characters'),
   instructor: z.string().trim().max(100, 'Keep it under 100 characters').optional(),
   term: z.string().trim().max(50, 'Keep it under 50 characters').optional(),
   color: z.string().min(1),

--- a/src/lib/validation/scheduleItem.ts
+++ b/src/lib/validation/scheduleItem.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const scheduleItemFormSchema = z.object({
-  title: z.string().trim().min(1, 'Title is required').max(150, 'Keep it under 150 characters'),
+  title: z.string().trim().min(1, 'Title is required').max(200, 'Keep it under 200 characters'),
   type: z.enum(['assignment', 'exam', 'quiz', 'project', 'reading', 'other']),
   courseId: z.string().min(1, 'Select a course'),
   dueDate: z.string().min(1, 'Due date is required'),


### PR DESCRIPTION
## Summary
- Adds a per-user daily rate limit (15/day) on `/api/syllabus/extract`, tracked server-side via a Firestore Admin SDK transaction (a new Firestore-only admin module that avoids the `firebase-admin/auth` import chain responsible for the earlier ERR_REQUIRE_ESM crash), plus PDF magic-byte validation on the uploaded file.
- Course + schedule item creation from the autofiller now happens in one atomic Firestore batch (`createCourseWithScheduleItems`) instead of a sequential create-then-loop, so a mid-save failure can't leave a course with only some of its assignments.
- The review screen's editable draft is now re-validated with the same `courseFormSchema`/`scheduleItemFormSchema` used by the manual course/task forms before it's written to Firestore.
- Unified the title max-length limits between the extraction schema (`src/types/extraction.ts`) and the manual-entry schemas (`src/lib/validation/{course,scheduleItem}.ts`) so nothing extracted from a real syllabus gets silently truncated on save.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 180/180 passing
- [x] `npm run build` — succeeds
- [x] Local production-mode server (`npm run start`): homepage/login load 200, `/api/syllabus/extract` returns 401 for an unauthenticated request as expected