### PR TITLE
Distinguish overdue from overloaded; branded loading screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 
 # local-only sample data, never committed
 /test-fixtures/
+
+# local browser automation profile, never committed
+/chrome-profile/

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,6 +86,26 @@
 }
 
 @layer utilities {
+  /* Standard indeterminate-progress sweep (position + width both animate,
+     not just a translate) - used by AppLoadingScreen since the actual
+     auth-resolution wait time isn't determinable up front. Percentages are
+     relative to the track, not the bar itself, so the sweep stays smooth
+     and symmetric instead of snapping between off-left and off-right. */
+  @keyframes loading-bar {
+    0% {
+      left: -40%;
+      width: 40%;
+    }
+    50% {
+      left: 30%;
+      width: 45%;
+    }
+    100% {
+      left: 100%;
+      width: 40%;
+    }
+  }
+
   /* Matches the Logo mark's own gradient (Logo.tsx) so brand color isn't
      confined to the icon - hero panels, progress rings, and CTAs can pick up
      the same identity. */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import AppLoadingScreen from '@/components/layout/AppLoadingScreen';
 
 export default function Home() {
   const { user, loading } = useAuth();
@@ -13,9 +14,5 @@ export default function Home() {
     router.replace(user ? '/dashboard' : '/login');
   }, [user, loading, router]);
 
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="text-sm text-muted-foreground">Loading...</div>
-    </div>
-  );
+  return <AppLoadingScreen />;
 }

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import AppLoadingScreen from '@/components/layout/AppLoadingScreen';
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
@@ -15,11 +16,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   }, [loading, user, router]);
 
   if (loading || !user) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-sm text-muted-foreground">Loading...</div>
-      </div>
-    );
+    return <AppLoadingScreen />;
   }
 
   return <>{children}</>;

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -259,7 +259,7 @@ export function DashboardView() {
                   <SectionIcon icon="tasks" />
                   <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
                   {overdueCount > 0 && (
-                    <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
+                    <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
                       {overdueCount} overdue
                     </span>
                   )}
@@ -293,6 +293,7 @@ export function DashboardView() {
                 <div className="divide-y divide-border">
                   {upcomingTasks.map((item) => {
                     const course = courses.find((c) => c.id === item.courseId);
+                    const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
                     return (
                       <TaskRow
                         key={item.id}
@@ -305,9 +306,16 @@ export function DashboardView() {
                         priority={item.priority}
                         onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                         trailing={
-                          <span className="text-xs text-muted-foreground">
-                            Due {dueDateFormatter.format(new Date(item.dueDate))}
-                          </span>
+                          <>
+                            {overdue && (
+                              <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                                Overdue
+                              </span>
+                            )}
+                            <span className="text-xs text-muted-foreground">
+                              Due {dueDateFormatter.format(new Date(item.dueDate))}
+                            </span>
+                          </>
                         }
                       />
                     );

--- a/src/components/layout/AppLoadingScreen.tsx
+++ b/src/components/layout/AppLoadingScreen.tsx
@@ -1,0 +1,18 @@
+import Logo from './Logo';
+
+/**
+ * Shown while auth state resolves on a hard navigation (full page load or
+ * refresh) - before this existed it was a bare unstyled "Loading..." with
+ * no app chrome at all, which reads as broken on an otherwise-polished app
+ * and happens on every refresh/deep-link, not just first login.
+ */
+export default function AppLoadingScreen() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background">
+      <Logo className="h-12 w-12 animate-pulse" />
+      <div className="relative h-1 w-24 overflow-hidden rounded-full bg-muted">
+        <div className="absolute h-full animate-[loading-bar_1.4s_ease-in-out_infinite] rounded-full bg-gradient-brand" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -118,12 +118,13 @@ export function SmartPlanner() {
           />
         ) : (
           <div className="divide-y divide-border">
-            {plan.startToday.map(({ item, overloaded }) => (
+            {plan.startToday.map(({ item, overloaded, overdue }) => (
               <PlannedTaskRow
                 key={item.id}
                 item={item}
                 course={courses.find((c) => c.id === item.courseId)}
                 overloaded={overloaded}
+                overdue={overdue}
                 onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
               />
             ))}
@@ -223,11 +224,13 @@ function PlannedTaskRow({
   item,
   course,
   overloaded,
+  overdue,
   onToggleComplete,
 }: {
   item: PlannedItem['item'];
   course: Course | undefined;
   overloaded: boolean;
+  overdue: boolean;
   onToggleComplete?: () => void;
 }) {
   return (
@@ -242,10 +245,16 @@ function PlannedTaskRow({
       onToggleComplete={onToggleComplete}
       trailing={
         <>
-          {overloaded && (
-            <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
-              Overloaded
+          {overdue ? (
+            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+              Overdue
             </span>
+          ) : (
+            overloaded && (
+              <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
+                Overloaded
+              </span>
+            )
           )}
           <span className="text-xs text-muted-foreground">
             Due {dueDateFormatter.format(new Date(item.dueDate))}
@@ -273,12 +282,13 @@ function PlanSection({
     <Card className="rounded-2xl p-6">
       <h2 className="mb-3 text-sm font-semibold text-foreground">{title}</h2>
       <div className="divide-y divide-border">
-        {items.map(({ item, overloaded }) => (
+        {items.map(({ item, overloaded, overdue }) => (
           <PlannedTaskRow
             key={item.id}
             item={item}
             course={courses.find((c) => c.id === item.courseId)}
             overloaded={overloaded}
+            overdue={overdue}
             onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
           />
         ))}

--- a/src/lib/planner/computeSmartPlan.ts
+++ b/src/lib/planner/computeSmartPlan.ts
@@ -6,6 +6,11 @@ export interface PlannedItem {
   item: ScheduleItem;
   startDate: string;
   overloaded: boolean;
+  /** Already past its due date - distinct from `overloaded` (doesn't fit the
+   * week's capacity). A late item and a merely-full week require different
+   * reactions from the student, so they're tracked separately rather than
+   * both surfacing as the same badge. */
+  overdue: boolean;
 }
 
 export interface DayLoad {
@@ -56,7 +61,12 @@ export function computeSmartPlan(scheduleItems: ScheduleItem[], referenceDate: D
     const others = pendingItems.filter((i) => i.id !== item.id);
     const existingLoad = calculateDailyLoad(others, referenceDate);
     const rec = recommendStudyStartDate(item, referenceDate, existingLoad);
-    return { item, startDate: rec.startDate, overloaded: rec.overloaded };
+    // Matches the exact `!completed && dueDate < now` check used on Tasks/
+    // Course/Task-detail (real current moment, not the UTC-midnight
+    // `referenceDate` used for workload bucketing) so "overdue" means the
+    // same thing everywhere in the app.
+    const overdue = !item.completed && new Date(item.dueDate) < new Date();
+    return { item, startDate: rec.startDate, overloaded: rec.overloaded, overdue };
   });
   plannedItems.sort((a, b) => a.startDate.localeCompare(b.startDate));
 


### PR DESCRIPTION
## Summary
- Planner's "Overloaded" badge was shown identically for a genuinely late item and one that just doesn't fit this week's capacity (live-reproduced during a re-audit — every overdue item in the fixture account showed "Overloaded"). `PlannedItem` now carries its own `overdue` flag using the same check as Tasks/Course/Task-detail, and overdue takes priority over overloaded in the badge.
- Dashboard's "Upcoming Tasks" card now shows a per-row red "Overdue" pill matching `/tasks`, not just the aggregate count added in the last PR.
- Replaced the bare unstyled "Loading…" shown during auth resolution on every hard refresh/deep-link (also live-reproduced) with a branded `AppLoadingScreen` (logo + animated progress sweep), shared by the root page and `AuthGuard`.
- Ignore the local `chrome-profile/` directory created by browser automation tooling.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 180/180 passing
- [x] `npm run build` — succeeds
- [x] Live-verified in Chrome: Planner shows "Overdue" (not "Overloaded") on late items, Dashboard shows per-row overdue pills, hard-navigating to any page shows the branded loading screen instead of bare text, and the progress-bar sweep stays bounded and smooth in both themes