### PR TITLE
Support .docx syllabus uploads alongside PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.117.1",
         "firebase": "^12.17.1",
         "firebase-admin": "^14.2.0",
+        "mammoth": "^1.12.1",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18",
@@ -3008,6 +3009,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3477,6 +3487,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -3871,6 +3887,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4116,6 +4138,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -4143,6 +4171,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6118,6 +6155,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6171,7 +6214,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -6916,6 +6958,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -7005,6 +7095,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7688,6 +7787,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -7733,6 +7843,39 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.1.tgz",
+      "integrity": "sha512-nCH9KKjWi3jQ+i8bUKs7k1yrXtSEGpWgF8IYkzsFMcbn+5S6l4bZEBbyx2hOQErFiXPuAs9RPa6qjXVxhyx/8g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8283,6 +8426,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8352,6 +8501,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8408,7 +8563,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8752,6 +8906,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9346,6 +9506,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9519,6 +9685,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -10408,6 +10580,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -10476,7 +10654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -11038,6 +11215,15 @@
       "optional": true,
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@anthropic-ai/sdk": "^0.117.1",
     "firebase": "^12.17.1",
     "firebase-admin": "^14.2.0",
+    "mammoth": "^1.12.1",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ const PILLARS: { icon: IconKey; title: string; description: string }[] = [
   {
     icon: 'syllabus',
     title: 'Syllabus, uploaded once',
-    description: 'Keep every syllabus PDF attached to its course, always within reach.',
+    description: 'Keep every syllabus file attached to its course, always within reach.',
   },
   {
     icon: 'planner',

--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -14,6 +14,20 @@ export const maxDuration = 120;
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 
+/**
+ * Detected from magic bytes, not the client-declared MIME type (spoofable)
+ * or file extension. Both prefixes are stable regardless of what follows -
+ * base64 encodes in fixed 3-byte groups, so a known byte run at the start
+ * of a file always produces the same leading base64 characters.
+ * PDF: "%PDF-" (0x25 0x50 0x44 0x46 0x2D). DOCX: a .docx is a zip archive,
+ * so it starts with the zip local-file-header signature (0x50 0x4B 0x03 0x04).
+ */
+function detectFileKind(fileBase64: string): 'pdf' | 'docx' | null {
+  if (fileBase64.startsWith('JVBERi0')) return 'pdf';
+  if (fileBase64.startsWith('UEsDB')) return 'docx';
+  return null;
+}
+
 async function requireUser(req: NextRequest) {
   const authHeader = req.headers.get('authorization');
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
@@ -47,10 +61,14 @@ export async function POST(req: NextRequest) {
   if (fileBase64.length > MAX_FILE_BYTES * 1.4) {
     return NextResponse.json({ error: 'File is too large (max 10MB).' }, { status: 400 });
   }
-  // The client declares application/pdf, but that's a spoofable browser MIME
-  // type - check the real magic bytes server-side before spending an API call.
-  if (!fileBase64.startsWith('JVBERi0')) {
-    return NextResponse.json({ error: 'That file is not a valid PDF.' }, { status: 400 });
+  // The client declares a MIME type, but that's spoofable - check the real
+  // magic bytes server-side before spending an API call.
+  const fileKind = detectFileKind(fileBase64);
+  if (!fileKind) {
+    return NextResponse.json(
+      { error: 'That file is not a valid PDF or Word (.docx) document.' },
+      { status: 400 },
+    );
   }
 
   const rateLimit = await checkAndIncrementExtractionCount(user.uid);
@@ -59,6 +77,27 @@ export async function POST(req: NextRequest) {
       { error: "You've hit today's syllabus upload limit. Try again tomorrow." },
       { status: 429 },
     );
+  }
+
+  // Claude has native PDF understanding, but not .docx - a .docx is
+  // extracted to plain text server-side first and sent as a text block
+  // instead of a document block.
+  let docxText: string | null = null;
+  if (fileKind === 'docx') {
+    try {
+      const mammoth = await import('mammoth');
+      const buffer = Buffer.from(fileBase64, 'base64');
+      const result = await mammoth.extractRawText({ buffer });
+      docxText = result.value.trim();
+    } catch {
+      return NextResponse.json(
+        { error: "Couldn't read that Word document. Try re-saving it and uploading again." },
+        { status: 400 },
+      );
+    }
+    if (!docxText) {
+      return NextResponse.json({ error: 'That document appears to be empty.' }, { status: 400 });
+    }
   }
 
   let anthropic;
@@ -73,6 +112,30 @@ export async function POST(req: NextRequest) {
 
   const today = new Date().toISOString().slice(0, 10);
 
+  const documentContent: Anthropic.MessageParam['content'] =
+    fileKind === 'pdf'
+      ? [
+          {
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
+            ...(fileName ? { title: fileName } : {}),
+          },
+          {
+            type: 'text',
+            text: 'Extract this syllabus into the record_syllabus_extraction tool.',
+          },
+        ]
+      : [
+          {
+            type: 'text',
+            text: `Syllabus document${fileName ? ` (${fileName})` : ''}, extracted from a Word file:\n\n${docxText}`,
+          },
+          {
+            type: 'text',
+            text: 'Extract this syllabus into the record_syllabus_extraction tool.',
+          },
+        ];
+
   let message;
   try {
     message = await anthropic.messages.create({
@@ -81,22 +144,7 @@ export async function POST(req: NextRequest) {
       system: `${SYLLABUS_EXTRACTION_SYSTEM_PROMPT}\n\nToday's date is ${today} - use it only to disambiguate a term/year if the syllabus itself doesn't state one clearly.`,
       tools: [SYLLABUS_EXTRACTION_TOOL],
       tool_choice: { type: 'tool', name: SYLLABUS_EXTRACTION_TOOL.name },
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'document',
-              source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
-              ...(fileName ? { title: fileName } : {}),
-            },
-            {
-              type: 'text',
-              text: 'Extract this syllabus into the record_syllabus_extraction tool.',
-            },
-          ],
-        },
-      ],
+      messages: [{ role: 'user', content: documentContent }],
     });
   } catch (err) {
     return NextResponse.json(

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -137,7 +137,8 @@ export function DashboardView() {
             <div>
               <h2 className="text-lg font-bold">Got a syllabus? Let Claude set it up.</h2>
               <p className="mt-1 text-sm text-white/80">
-                Upload the PDF and get a course plus every assignment drafted for you to review.
+                Upload the PDF or Word doc and get a course plus every assignment drafted for you to
+                review.
               </p>
             </div>
             <button

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -323,7 +323,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
           <CardHeader>
             <CardTitle id="autofill-title">Autofill from Syllabus</CardTitle>
             <CardDescription>
-              Upload a syllabus PDF and review what Claude found before it&apos;s added.
+              Upload a syllabus PDF or Word doc and review what Claude found before it&apos;s added.
             </CardDescription>
           </CardHeader>
 
@@ -351,13 +351,13 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 )}
               >
                 <span className="text-sm font-medium text-foreground">
-                  Drop a syllabus PDF here, or click to browse
+                  Drop a syllabus PDF or Word doc here, or click to browse
                 </span>
-                <span className="text-xs text-muted-foreground">PDF only, up to 10MB</span>
+                <span className="text-xs text-muted-foreground">PDF or .docx, up to 10MB</span>
                 <input
                   ref={inputRef}
                   type="file"
-                  accept="application/pdf"
+                  accept="application/pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                   className="hidden"
                   onChange={(e) => {
                     const selected = e.target.files?.[0];

--- a/src/components/syllabus/SyllabusUploader.tsx
+++ b/src/components/syllabus/SyllabusUploader.tsx
@@ -62,13 +62,13 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
           )}
         >
           <span className="text-sm font-medium text-foreground">
-            Drop a syllabus PDF here, or click to browse
+            Drop a syllabus PDF or Word doc here, or click to browse
           </span>
-          <span className="text-xs text-muted-foreground">PDF only, up to 10MB</span>
+          <span className="text-xs text-muted-foreground">PDF or .docx, up to 10MB</span>
           <input
             ref={inputRef}
             type="file"
-            accept="application/pdf"
+            accept="application/pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             className="hidden"
             onChange={(e) => {
               const file = e.target.files?.[0];

--- a/src/lib/ai/syllabusExtractionTool.ts
+++ b/src/lib/ai/syllabusExtractionTool.ts
@@ -123,7 +123,7 @@ export const SYLLABUS_EXTRACTION_TOOL: Anthropic.Tool = {
   },
 };
 
-export const SYLLABUS_EXTRACTION_SYSTEM_PROMPT = `You are an expert academic planner reading a college syllabus PDF to help a student build their calendar. Call the record_syllabus_extraction tool exactly once with everything you find. Follow these rules, learned from studying real university syllabi:
+export const SYLLABUS_EXTRACTION_SYSTEM_PROMPT = `You are an expert academic planner reading a college syllabus (provided as a PDF or as plain text extracted from a Word document) to help a student build their calendar. Call the record_syllabus_extraction tool exactly once with everything you find. Follow these rules, learned from studying real university syllabi:
 
 1. Ignore boilerplate entirely: FERPA, ADA/accommodations, academic honesty, grade-dispute-window, and military-obligation statements are never calendar-worthy. Do not extract items from them.
 2. Distinguish the actual class/lecture/rehearsal meeting schedule from office hours or tutoring slots - only the former belongs in meetingTimes. Many syllabi (especially asynchronous online courses) have no meeting time at all - that's fine, leave meetingTimes empty rather than inventing one.

--- a/src/lib/validation/syllabusFile.ts
+++ b/src/lib/validation/syllabusFile.ts
@@ -1,13 +1,23 @@
 const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
+const ACCEPTED_TYPES = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
 export interface FileValidationResult {
   valid: boolean;
   error?: string;
 }
 
 export function validateSyllabusFile(file: File): FileValidationResult {
-  if (file.type !== 'application/pdf') {
-    return { valid: false, error: 'Only PDF files are supported.' };
+  // Browsers don't always fill in `file.type` correctly (some send '' for
+  // .docx depending on OS file-association state), so an unrecognized name
+  // extension is also accepted here - the server re-checks real magic bytes
+  // regardless, so this is just a fast client-side hint, not the real gate.
+  const hasAcceptedExtension = /\.(pdf|docx)$/i.test(file.name);
+  if (!ACCEPTED_TYPES.has(file.type) && !hasAcceptedExtension) {
+    return { valid: false, error: 'Only PDF or Word (.docx) files are supported.' };
   }
   if (file.size > MAX_SIZE_BYTES) {
     return { valid: false, error: 'File is too large (max 10MB).' };


### PR DESCRIPTION
## Summary
- The autofiller and the plain course-syllabus upload both only accepted PDF. Claude has native PDF understanding but not .docx, so a .docx is now extracted to plain text server-side with `mammoth` before being sent as a text block instead of a document block — same extraction schema, same tool-forced JSON output, same review screen either way.
- File type is detected from magic bytes (the zip local-file-header signature for .docx, same approach already used for the PDF check), not the client-declared MIME type or file extension, since both are spoofable/unreliable.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 180/180 passing
- [x] `npm run build` — succeeds
- [x] `npm audit` confirms no new vulnerabilities introduced by the `mammoth` dependency
- [x] End-to-end live test against a real `.docx` fixture through the actual running app and a real Anthropic API call: course code/title/instructor, meeting times, materials, and high-stakes/grade-weighted schedule items all extracted correctly and saved