### PR TITLE
Calendar key: semantic icons; customizable + AI-assigned course colors

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -30,10 +30,12 @@ import {
   WORKLOAD_LEVEL_LABELS,
   WORKLOAD_CHIP_CLASS,
   WORKLOAD_SWATCH_CLASS,
+  WORKLOAD_TEXT_CLASS,
   WORKLOAD_TINT_CLASS,
 } from '@/lib/workload';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
+import { courseChipTint, courseSwatch } from '@/lib/courseColors';
 import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
 
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -49,6 +51,80 @@ const agendaDayLabelFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 const weekLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+
+/** Semantic icons for the calendar key (course chips / workload / markers),
+ * replacing plain dots and squares so each row communicates what it means
+ * at a glance instead of relying purely on color. Small enough to stay
+ * inline rather than routing through the shared ICON_PATHS single-path
+ * convention - graduation cap and workload bars both need multiple shapes. */
+function GraduationCapIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M22 10L12 5 2 10l10 5 10-5z" />
+      <path d="M6 12v5c0 1.5 2.7 3 6 3s6-1.5 6-3v-5" />
+    </svg>
+  );
+}
+
+function FlagIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 3v18M4 4h11l-2 4 2 4H4" />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 6L9 17l-5-5" />
+    </svg>
+  );
+}
+
+/** Three ascending bars whose fill opacity encodes the workload level, so
+ * severity reads even without relying on the color alone - low fills only
+ * the first bar, critical fills all three at full strength. */
+function WorkloadGaugeIcon({ level, className }: { level: WorkloadLevel; className?: string }) {
+  const fill = {
+    low: [1, 0.2, 0.2],
+    medium: [1, 1, 0.2],
+    high: [1, 1, 0.55],
+    critical: [1, 1, 1],
+  }[level];
+
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <rect x="3" y="16" width="4" height="5" rx="1" opacity={fill[0]} />
+      <rect x="10" y="11" width="4" height="10" rx="1" opacity={fill[1]} />
+      <rect x="17" y="7" width="4" height="14" rx="1" opacity={fill[2]} />
+    </svg>
+  );
+}
 
 function formatWeekRangeLabel(weekDays: Date[]): string {
   const start = weekDays[0];
@@ -282,6 +358,8 @@ export function MonthCalendar() {
           <div className="flex flex-wrap items-center gap-1.5 mb-3">
             {state.courses.map((course) => {
               const hidden = hiddenCourseIds.has(course.id);
+              const tint = courseChipTint(course.color);
+              const swatch = courseSwatch(course.color);
               return (
                 <button
                   key={course.id}
@@ -290,10 +368,14 @@ export function MonthCalendar() {
                     'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                     hidden
                       ? 'border-border text-muted-foreground opacity-50'
-                      : 'border-border text-foreground hover:bg-accent',
+                      : cn(tint.className, 'hover:brightness-95'),
                   )}
+                  style={hidden ? undefined : tint.style}
                 >
-                  <span className={cn('h-2 w-2 rounded-full', course.color || 'bg-primary')} />
+                  <span
+                    className={cn('h-2 w-2 rounded-full', swatch.className)}
+                    style={swatch.style}
+                  />
                   {course.code}
                 </button>
               );
@@ -302,23 +384,25 @@ export function MonthCalendar() {
             <button
               onClick={() => setShowClasses((v) => !v)}
               className={cn(
-                'rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                 showClasses
                   ? 'border-border text-foreground hover:bg-accent'
                   : 'border-border text-muted-foreground opacity-50',
               )}
             >
+              <GraduationCapIcon className="h-3 w-3" />
               Classes
             </button>
             <button
               onClick={() => setShowCompleted((v) => !v)}
               className={cn(
-                'rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                 showCompleted
                   ? 'border-border text-foreground hover:bg-accent'
                   : 'border-border text-muted-foreground opacity-50',
               )}
             >
+              <CheckIcon className="h-3 w-3" />
               Completed
             </button>
           </div>
@@ -404,8 +488,9 @@ export function MonthCalendar() {
                             key={`${m.course.id}-${i}`}
                             className={cn(
                               'h-1.5 w-1.5 rounded-[2px]',
-                              m.course.color || 'bg-primary',
+                              courseSwatch(m.course.color).className,
                             )}
+                            style={courseSwatch(m.course.color).style}
                             title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}`}
                           />
                         ))}
@@ -446,13 +531,12 @@ export function MonthCalendar() {
                   <span
                     key={level}
                     className={cn(
-                      'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-foreground',
+                      'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium',
                       WORKLOAD_CHIP_CLASS[level],
+                      WORKLOAD_TEXT_CLASS[level],
                     )}
                   >
-                    <span
-                      className={cn('h-2.5 w-2.5 rounded-full', WORKLOAD_SWATCH_CLASS[level])}
-                    />
+                    <WorkloadGaugeIcon level={level} className="h-3 w-3" />
                     {WORKLOAD_LEVEL_LABELS[level]}
                   </span>
                 ))}
@@ -460,11 +544,11 @@ export function MonthCalendar() {
               <div className="flex flex-wrap items-center gap-2">
                 <span className="w-20 shrink-0 text-xs font-semibold text-foreground">Markers</span>
                 <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium text-foreground">
-                  <span className="h-2.5 w-2.5 shrink-0 rounded-[2px] bg-primary" />
+                  <GraduationCapIcon className="h-3 w-3 shrink-0" />
                   Class session
                 </span>
                 <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium text-foreground">
-                  <span className="h-2.5 w-4 shrink-0 rounded bg-primary" />
+                  <FlagIcon className="h-3 w-3 shrink-0" />
                   Due item
                 </span>
               </div>
@@ -510,8 +594,9 @@ export function MonthCalendar() {
                         <span
                           className={cn(
                             'h-2 w-2 shrink-0 rounded-[2px]',
-                            m.course.color || 'bg-primary',
+                            courseSwatch(m.course.color).className,
                           )}
+                          style={courseSwatch(m.course.color).style}
                         />
                         <span className="text-muted-foreground">
                           {formatTimeLabel(m.meeting.startTime)}
@@ -664,7 +749,11 @@ function DayDetailCard({
                 {meetings.map((m, i) => (
                   <div key={`${m.course.id}-${i}`} className="flex items-center gap-3 py-2">
                     <span
-                      className={cn('h-7 w-7 shrink-0 rounded-lg', m.course.color || 'bg-primary')}
+                      className={cn(
+                        'h-7 w-7 shrink-0 rounded-lg',
+                        courseSwatch(m.course.color).className,
+                      )}
+                      style={courseSwatch(m.course.color).style}
                     />
                     <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium text-foreground truncate">

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/calendar/meetings';
 import { cn } from '@/lib/utils';
 import { getWorkloadLevel } from '@/lib/workload';
+import { courseSwatch } from '@/lib/courseColors';
 import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
 
 // Full 24-hour day, like Google Calendar/Outlook - a hardcoded 7am-9pm window
@@ -154,14 +155,15 @@ export function WeekView({
                     if (end <= start) return null;
                     const top = (start - START_HOUR) * HOUR_HEIGHT;
                     const height = Math.max((end - start) * HOUR_HEIGHT, 20);
+                    const swatch = courseSwatch(m.course.color);
                     return (
                       <div
                         key={`${m.course.id}-${i}`}
                         className={cn(
                           'absolute left-0.5 right-0.5 overflow-hidden rounded-md px-1 py-0.5 text-[10px] font-medium text-white shadow-sm',
-                          m.course.color || 'bg-primary',
+                          swatch.className,
                         )}
-                        style={{ top, height }}
+                        style={{ top, height, ...swatch.style }}
                         title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}–${formatTimeLabel(m.meeting.endTime)}`}
                       >
                         <div className="truncate font-semibold">{m.course.code}</div>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -23,6 +23,7 @@ import { SyllabusList } from '@/components/syllabus/SyllabusList';
 import { formatTimeLabel } from '@/lib/calendar/meetings';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateRateMyProfessorUrl } from '@/lib/export/rateMyProfessor';
+import { courseSwatch } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
@@ -158,15 +159,19 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         <BackLink href="/dashboard">Back to dashboard</BackLink>
 
         <Card className="overflow-hidden rounded-2xl p-0">
-          <div className={cn('h-2 w-full', course.color || 'bg-primary')} />
+          <div
+            className={cn('h-2 w-full', courseSwatch(course.color).className)}
+            style={courseSwatch(course.color).style}
+          />
           <div className="p-6">
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-4">
                 <span
                   className={cn(
                     'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-lg font-bold text-white',
-                    course.color || 'bg-primary',
+                    courseSwatch(course.color).className,
                   )}
+                  style={courseSwatch(course.color).style}
                 >
                   {course.code.slice(0, 1)}
                 </span>

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, FormEvent } from 'react';
+import { useEffect, useRef, useState, FormEvent } from 'react';
 import {
   Card,
   CardHeader,
@@ -13,15 +13,10 @@ import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course
 import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useAppState } from '@/context/AppStateContext';
+import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
 
-const COURSE_COLORS = [
-  'bg-blue-500',
-  'bg-green-500',
-  'bg-purple-500',
-  'bg-red-500',
-  'bg-orange-500',
-  'bg-teal-500',
-];
+const isCustomColor = (color: string) => color.startsWith('#');
 
 const MODALITY_OPTIONS: { value: CourseModality; label: string }[] = [
   { value: 'in-person', label: 'In-person' },
@@ -59,16 +54,24 @@ const emptyValues: CourseFormValues = {
   title: '',
   instructor: '',
   term: '',
-  color: COURSE_COLORS[0],
+  color: COURSE_COLOR_PRESETS[0].value,
   modality: undefined,
   meetingTimes: [],
 };
 
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
+  const { state } = useAppState();
   const [values, setValues] = useState<CourseFormValues>(emptyValues);
   const [errors, setErrors] = useState<Partial<Record<keyof CourseFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Latest courses without being a dependency below - the effect should only
+  // recompute a fresh course's default color when the modal actually opens,
+  // not every time Firestore syncs a change while it's sitting open with a
+  // half-filled form.
+  const coursesRef = useRef(state.courses);
+  coursesRef.current = state.courses;
 
   useEffect(() => {
     if (!open) return;
@@ -79,11 +82,14 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             title: initialCourse.title,
             instructor: initialCourse.instructor ?? '',
             term: initialCourse.term ?? '',
-            color: initialCourse.color ?? COURSE_COLORS[0],
+            color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
             modality: initialCourse.modality,
             meetingTimes: initialCourse.meetingTimes ?? [],
           }
-        : emptyValues,
+        : // A fresh course defaults to whichever preset is least represented
+          // among the user's existing courses, so a student with 8+ courses
+          // doesn't land on the same blue every time.
+          { ...emptyValues, color: pickNextCourseColor(coursesRef.current) },
     );
     setErrors({});
     setSubmitError(null);
@@ -219,22 +225,54 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
 
               <div className="space-y-1.5">
                 <span className="text-sm font-medium text-foreground">Color</span>
-                <div className="flex gap-2">
-                  {COURSE_COLORS.map((color) => (
+                <div className="flex flex-wrap gap-2">
+                  {COURSE_COLOR_PRESETS.map((preset) => (
                     <button
-                      key={color}
+                      key={preset.value}
                       type="button"
-                      aria-label={color}
-                      onClick={() => setValues((s) => ({ ...s, color }))}
+                      aria-label={preset.value}
+                      onClick={() => setValues((s) => ({ ...s, color: preset.value }))}
                       className={cn(
                         'h-7 w-7 rounded-full transition-transform',
-                        color,
-                        values.color === color
+                        preset.value,
+                        values.color === preset.value
                           ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
                           : 'hover:scale-110',
                       )}
                     />
                   ))}
+                  <label
+                    aria-label="Custom color"
+                    title="Custom color"
+                    className={cn(
+                      'relative flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
+                      isCustomColor(values.color) &&
+                        'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
+                    )}
+                    style={
+                      isCustomColor(values.color)
+                        ? { backgroundColor: values.color, borderStyle: 'solid' }
+                        : undefined
+                    }
+                  >
+                    {!isCustomColor(values.color) && (
+                      <svg
+                        className="h-3.5 w-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                      </svg>
+                    )}
+                    <input
+                      type="color"
+                      className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                      value={isCustomColor(values.color) ? values.color : '#7c3aed'}
+                      onChange={(e) => setValues((s) => ({ ...s, color: e.target.value }))}
+                    />
+                  </label>
                 </div>
               </div>
 

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -11,6 +11,7 @@ import { createCourse } from '@/lib/firestore/courses';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import type { CourseFormValues } from '@/lib/validation/course';
+import { courseSwatch } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 
 type SortMode = 'code' | 'title' | 'term';
@@ -193,14 +194,18 @@ export function CoursesListView() {
               return (
                 <Link key={course.id} href={`/courses/${course.id}`} className="block">
                   <Card hoverable className="flex h-full flex-col overflow-hidden rounded-2xl p-0">
-                    <div className={cn('h-1.5 w-full', course.color || 'bg-primary')} />
+                    <div
+                      className={cn('h-1.5 w-full', courseSwatch(course.color).className)}
+                      style={courseSwatch(course.color).style}
+                    />
                     <div className="flex flex-1 flex-col p-5">
                       <div className="mb-2 flex items-center gap-3">
                         <span
                           className={cn(
                             'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-bold text-white',
-                            course.color || 'bg-primary',
+                            courseSwatch(course.color).className,
                           )}
+                          style={courseSwatch(course.color).style}
                         >
                           {course.code.slice(0, 1)}
                         </span>
@@ -241,8 +246,11 @@ export function CoursesListView() {
                         {items.length > 0 && (
                           <div className="h-1.5 overflow-hidden rounded-full bg-muted">
                             <div
-                              className={cn('h-full rounded-full', course.color || 'bg-primary')}
-                              style={{ width: `${pct}%` }}
+                              className={cn(
+                                'h-full rounded-full',
+                                courseSwatch(course.color).className,
+                              )}
+                              style={{ width: `${pct}%`, ...courseSwatch(course.color).style }}
                             />
                           </div>
                         )}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -17,6 +17,7 @@ import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
+import { courseSwatch } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
@@ -244,8 +245,11 @@ export function DashboardView() {
                       </div>
                       <div className="h-1.5 rounded-full bg-muted overflow-hidden">
                         <div
-                          className={`h-full rounded-full ${course.color || 'bg-primary'}`}
-                          style={{ width: `${pct}%` }}
+                          className={cn(
+                            'h-full rounded-full',
+                            courseSwatch(course.color).className,
+                          )}
+                          style={{ width: `${pct}%`, ...courseSwatch(course.color).style }}
                         />
                       </div>
                     </div>

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -17,6 +17,7 @@ import { scheduleItemFormSchema } from '@/lib/validation/scheduleItem';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import type {
   ExtractedMeetingTime,
@@ -30,15 +31,6 @@ import type {
   MeetingTime,
   ScheduleItem,
 } from '@/types/schedule';
-
-const COURSE_COLORS = [
-  'bg-blue-500',
-  'bg-green-500',
-  'bg-purple-500',
-  'bg-red-500',
-  'bg-orange-500',
-  'bg-teal-500',
-];
 
 const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -80,7 +72,7 @@ export interface SyllabusAutofillModalProps {
 }
 
 export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalProps) {
-  const { dispatch } = useAppState();
+  const { state, dispatch } = useAppState();
   const { user } = useAuth();
   const router = useRouter();
 
@@ -155,7 +147,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         title: result.course.title,
         instructor: result.course.instructor ?? '',
         term: result.course.term ?? '',
-        color: COURSE_COLORS[0],
+        // Auto-assigned to whichever preset is least represented among the
+        // user's existing courses, so extracted courses don't all default
+        // to the same blue - the user can still change it on the review
+        // screen before confirming.
+        color: pickNextCourseColor(state.courses),
         modality: result.course.modality ?? undefined,
         meetingTimes: result.course.meetingTimes.map((m: ExtractedMeetingTime) => ({
           dayOfWeek: m.dayOfWeek,
@@ -401,22 +397,54 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     value={course.instructor}
                     onChange={(v) => setCourse((c) => c && { ...c, instructor: v })}
                   />
-                  <div className="flex gap-2">
-                    {COURSE_COLORS.map((color) => (
+                  <div className="flex flex-wrap gap-2">
+                    {COURSE_COLOR_PRESETS.map((preset) => (
                       <button
-                        key={color}
+                        key={preset.value}
                         type="button"
-                        aria-label={color}
-                        onClick={() => setCourse((c) => c && { ...c, color })}
+                        aria-label={preset.value}
+                        onClick={() => setCourse((c) => c && { ...c, color: preset.value })}
                         className={cn(
                           'h-6 w-6 rounded-full transition-transform',
-                          color,
-                          course.color === color
+                          preset.value,
+                          course.color === preset.value
                             ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
                             : 'hover:scale-110',
                         )}
                       />
                     ))}
+                    <label
+                      aria-label="Custom color"
+                      title="Custom color"
+                      className={cn(
+                        'relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
+                        course.color.startsWith('#') &&
+                          'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
+                      )}
+                      style={
+                        course.color.startsWith('#')
+                          ? { backgroundColor: course.color, borderStyle: 'solid' }
+                          : undefined
+                      }
+                    >
+                      {!course.color.startsWith('#') && (
+                        <svg
+                          className="h-3 w-3"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                        </svg>
+                      )}
+                      <input
+                        type="color"
+                        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                        value={course.color.startsWith('#') ? course.color : '#7c3aed'}
+                        onChange={(e) => setCourse((c) => c && { ...c, color: e.target.value })}
+                      />
+                    </label>
                   </div>
                 </section>
 

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { courseSwatch } from '@/lib/courseColors';
 import type { AssignmentType, Priority } from '@/types/schedule';
 
 const TYPE_ICON_PATH: Record<AssignmentType, string> = {
@@ -70,8 +71,9 @@ export function TaskRow({
       <span
         className={cn(
           'h-7 w-7 rounded-lg flex items-center justify-center shrink-0 text-white',
-          courseColor || 'bg-primary',
+          courseSwatch(courseColor).className,
         )}
+        style={courseSwatch(courseColor).style}
       >
         <svg
           className="h-3.5 w-3.5"

--- a/src/lib/__tests__/CourseFormModal.test.tsx
+++ b/src/lib/__tests__/CourseFormModal.test.tsx
@@ -2,11 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
+import { AppStateProvider } from '@/context/AppStateContext';
 import type { Course } from '@/types/schedule';
+
+function renderModal(ui: React.ReactElement) {
+  return render(<AppStateProvider initialState={{ courses: [] }}>{ui}</AppStateProvider>);
+}
 
 describe('CourseFormModal', () => {
   it('renders nothing when closed', () => {
-    const { container } = render(
+    const { container } = renderModal(
       <CourseFormModal open={false} onClose={vi.fn()} onSubmit={vi.fn()} />,
     );
     expect(container.firstChild).toBeNull();
@@ -14,7 +19,7 @@ describe('CourseFormModal', () => {
 
   it('blocks submit and shows errors when required fields are empty', async () => {
     const onSubmit = vi.fn();
-    render(<CourseFormModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+    renderModal(<CourseFormModal open onClose={vi.fn()} onSubmit={onSubmit} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Course' }));
 
@@ -25,7 +30,7 @@ describe('CourseFormModal', () => {
 
   it('clears a field error as soon as the user retypes it (regression: errors used to stick)', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
-    render(<CourseFormModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+    renderModal(<CourseFormModal open onClose={vi.fn()} onSubmit={onSubmit} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Course' }));
     expect(await screen.findByText('Course code is required')).toBeDefined();
@@ -37,7 +42,7 @@ describe('CourseFormModal', () => {
   it('submits parsed values and closes on success', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const onClose = vi.fn();
-    render(<CourseFormModal open onClose={onClose} onSubmit={onSubmit} />);
+    renderModal(<CourseFormModal open onClose={onClose} onSubmit={onSubmit} />);
 
     fireEvent.change(screen.getByLabelText('Course Code'), { target: { value: 'CSCI 213' } });
     fireEvent.change(screen.getByLabelText('Course Title'), {
@@ -56,7 +61,7 @@ describe('CourseFormModal', () => {
   it('shows a submit error and stays open when onSubmit rejects', async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error('Firestore is not configured.'));
     const onClose = vi.fn();
-    render(<CourseFormModal open onClose={onClose} onSubmit={onSubmit} />);
+    renderModal(<CourseFormModal open onClose={onClose} onSubmit={onSubmit} />);
 
     fireEvent.change(screen.getByLabelText('Course Code'), { target: { value: 'CSCI 213' } });
     fireEvent.change(screen.getByLabelText('Course Title'), { target: { value: 'Intro' } });
@@ -73,7 +78,9 @@ describe('CourseFormModal', () => {
       title: 'Linear Algebra',
       color: 'bg-green-500',
     };
-    render(<CourseFormModal open onClose={vi.fn()} onSubmit={vi.fn()} initialCourse={course} />);
+    renderModal(
+      <CourseFormModal open onClose={vi.fn()} onSubmit={vi.fn()} initialCourse={course} />,
+    );
 
     expect((screen.getByLabelText('Course Code') as HTMLInputElement).value).toBe('MATH 301');
     expect((screen.getByLabelText('Course Title') as HTMLInputElement).value).toBe(

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -1,0 +1,129 @@
+import type { CSSProperties } from 'react';
+import type { Course } from '@/types/schedule';
+
+/**
+ * A course's color is either one of these curated Tailwind presets (stored
+ * as the literal class name, e.g. "bg-blue-500") or a user-picked custom
+ * hex string (e.g. "#7c3aed"). Presets stay Tailwind classes rather than
+ * hex so existing usages that just do `className={course.color}` keep
+ * working unchanged; custom colors are the escape hatch for when 14 presets
+ * still isn't enough to keep every course visually distinct.
+ */
+export interface CoursePreset {
+  /** Tailwind class name, also the value stored on Course.color. */
+  value: string;
+  /** Approximate hex of the same swatch, used only for the tint math below -
+   * Tailwind's own JIT output is what actually renders the solid color. */
+  hex: string;
+}
+
+export const COURSE_COLOR_PRESETS: CoursePreset[] = [
+  { value: 'bg-blue-500', hex: '#3b82f6' },
+  { value: 'bg-green-500', hex: '#22c55e' },
+  { value: 'bg-purple-500', hex: '#a855f7' },
+  { value: 'bg-red-500', hex: '#ef4444' },
+  { value: 'bg-orange-500', hex: '#f97316' },
+  { value: 'bg-teal-500', hex: '#14b8a6' },
+  { value: 'bg-pink-500', hex: '#ec4899' },
+  { value: 'bg-indigo-500', hex: '#6366f1' },
+  { value: 'bg-amber-500', hex: '#f59e0b' },
+  { value: 'bg-cyan-500', hex: '#06b6d4' },
+  { value: 'bg-rose-500', hex: '#f43f5e' },
+  { value: 'bg-lime-500', hex: '#84cc16' },
+  { value: 'bg-violet-500', hex: '#8b5cf6' },
+  { value: 'bg-emerald-500', hex: '#10b981' },
+];
+
+/** Back-compat alias - the old 6-entry list some components imported by
+ * this name. Kept as the first 6 presets so previously-saved courses using
+ * these exact classes keep resolving the same swatch. */
+export const COURSE_COLORS = COURSE_COLOR_PRESETS.slice(0, 6).map((p) => p.value);
+
+/** Static literal Tailwind classes (not built from a template string) so
+ * Tailwind's content scanner can see them verbatim in source - a
+ * runtime-concatenated `${color}/15` would never make it into the
+ * generated CSS. */
+export const COURSE_CHIP_TINT_CLASS: Record<string, string> = {
+  'bg-blue-500': 'bg-blue-500/15 border-blue-500/30 text-blue-700 dark:text-blue-400',
+  'bg-green-500': 'bg-green-500/15 border-green-500/30 text-green-700 dark:text-green-400',
+  'bg-purple-500': 'bg-purple-500/15 border-purple-500/30 text-purple-700 dark:text-purple-400',
+  'bg-red-500': 'bg-red-500/15 border-red-500/30 text-red-700 dark:text-red-400',
+  'bg-orange-500': 'bg-orange-500/15 border-orange-500/30 text-orange-700 dark:text-orange-400',
+  'bg-teal-500': 'bg-teal-500/15 border-teal-500/30 text-teal-700 dark:text-teal-400',
+  'bg-pink-500': 'bg-pink-500/15 border-pink-500/30 text-pink-700 dark:text-pink-400',
+  'bg-indigo-500': 'bg-indigo-500/15 border-indigo-500/30 text-indigo-700 dark:text-indigo-400',
+  'bg-amber-500': 'bg-amber-500/15 border-amber-500/30 text-amber-700 dark:text-amber-400',
+  'bg-cyan-500': 'bg-cyan-500/15 border-cyan-500/30 text-cyan-700 dark:text-cyan-400',
+  'bg-rose-500': 'bg-rose-500/15 border-rose-500/30 text-rose-700 dark:text-rose-400',
+  'bg-lime-500': 'bg-lime-500/15 border-lime-500/30 text-lime-700 dark:text-lime-400',
+  'bg-violet-500': 'bg-violet-500/15 border-violet-500/30 text-violet-700 dark:text-violet-400',
+  'bg-emerald-500':
+    'bg-emerald-500/15 border-emerald-500/30 text-emerald-700 dark:text-emerald-400',
+};
+
+const DEFAULT_CHIP_TINT = 'bg-primary/10 border-primary/25 text-primary';
+
+function isCustomColor(color: string | undefined): color is string {
+  return !!color && color.startsWith('#');
+}
+
+/** For a solid swatch (dot, avatar badge, bar fill, day-chip background):
+ * a Tailwind class for presets, or an inline style for a custom hex. */
+export function courseSwatch(color: string | undefined): {
+  className: string;
+  style?: CSSProperties;
+} {
+  if (isCustomColor(color)) return { className: '', style: { backgroundColor: color } };
+  return { className: color || 'bg-primary' };
+}
+
+/** For a tinted chip/pill background matching a course's color, at legend
+ * or filter-chip weight. */
+export function courseChipTint(color: string | undefined): {
+  className: string;
+  style?: CSSProperties;
+} {
+  if (isCustomColor(color)) {
+    return {
+      className: '',
+      style: {
+        backgroundColor: `${color}26`, // ~15% alpha
+        borderColor: `${color}4d`, // ~30% alpha
+        color,
+      },
+    };
+  }
+  return {
+    className: color ? (COURSE_CHIP_TINT_CLASS[color] ?? DEFAULT_CHIP_TINT) : DEFAULT_CHIP_TINT,
+  };
+}
+
+/** @deprecated use courseChipTint - kept temporarily for call sites not yet migrated. */
+export function getCourseChipTintClass(color: string | undefined): string {
+  return courseChipTint(color).className || DEFAULT_CHIP_TINT;
+}
+
+/**
+ * Picks the color least represented among a user's existing courses (ties
+ * broken by preset order), so a freshly autofilled or manually added course
+ * doesn't default to the same blue every other course starts as. Custom
+ * hex colors count toward "used" but never get reassigned automatically.
+ */
+export function pickNextCourseColor(existingCourses: Pick<Course, 'color'>[]): string {
+  const counts = new Map(COURSE_COLOR_PRESETS.map((p) => [p.value, 0]));
+  for (const course of existingCourses) {
+    if (course.color && counts.has(course.color)) {
+      counts.set(course.color, (counts.get(course.color) ?? 0) + 1);
+    }
+  }
+  let best = COURSE_COLOR_PRESETS[0].value;
+  let bestCount = Infinity;
+  for (const preset of COURSE_COLOR_PRESETS) {
+    const count = counts.get(preset.value) ?? 0;
+    if (count < bestCount) {
+      best = preset.value;
+      bestCount = count;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- Implements the "Semantic Icons" direction from the calendar-key redesign pitch: course chips get a tinted background matching the course color, the workload legend gets a 3-bar gauge icon whose fill encodes severity, and the "Class session / Due item" markers plus Classes/Completed toggles get real glyphs (graduation cap, flag, checkmark) instead of plain dots and squares.
- Course colors are now genuinely customizable: 14 curated presets (up from 6) plus a native color-picker swatch for any arbitrary hex. `Course.color` stores either a Tailwind class (presets) or a hex string (custom) - a new `src/lib/courseColors.ts` is the single source of truth, with `courseSwatch()`/`courseChipTint()` helpers so every consumer renders the right thing without duplicating the branching logic.
- New courses - manual or autofilled - now default to whichever preset color is least represented among the user's existing courses (`pickNextCourseColor`), instead of every course starting the same blue.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 180/180 passing (updated `CourseFormModal.test.tsx` to wrap `AppStateProvider`, now required since the modal reads existing courses for its color default)
- [x] `npm run build` — succeeds
- [x] Live-verified in Chrome: calendar legend icons render correctly in dark mode; a 10th course auto-defaulted to green after 9 existing courses were all blue; a custom hex color (set via the native color picker) round-tripped correctly through the course card's cover bar, avatar, and progress bar