### PR TITLE
Fix autofill label association, checkbox write races, dark border contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,7 +63,12 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 240 3.7% 18%;
+    /* 18% lightness measured as "enough" contrast against a 3.9% background
+       on paper, but read as functionally invisible in practice - low-lightness
+       colors don't separate perceptually the way the same numeric gap does
+       higher up the scale. Raised until card/row boundaries are actually
+       legible instead of relying entirely on shadow. */
+    --border: 240 6% 26%;
 
     --load-low: 142 71% 45%;
     --load-medium: 38 92% 50%;

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -377,22 +377,26 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   <h3 className="text-sm font-semibold text-foreground">Course</h3>
                   <div className="grid grid-cols-2 gap-3">
                     <TextField
+                      id="autofill-course-code"
                       label="Code"
                       value={course.code}
                       onChange={(v) => setCourse((c) => c && { ...c, code: v })}
                     />
                     <TextField
+                      id="autofill-course-term"
                       label="Term"
                       value={course.term}
                       onChange={(v) => setCourse((c) => c && { ...c, term: v })}
                     />
                   </div>
                   <TextField
+                    id="autofill-course-title"
                     label="Title"
                     value={course.title}
                     onChange={(v) => setCourse((c) => c && { ...c, title: v })}
                   />
                   <TextField
+                    id="autofill-course-instructor"
                     label="Instructor"
                     value={course.instructor}
                     onChange={(v) => setCourse((c) => c && { ...c, instructor: v })}
@@ -677,18 +681,23 @@ async function saveSyllabusPdf(userId: string, courseId: string, file: File) {
 }
 
 function TextField({
+  id,
   label,
   value,
   onChange,
 }: {
+  id: string;
   label: string;
   value: string;
   onChange: (value: string) => void;
 }) {
   return (
     <div className="space-y-1">
-      <label className="text-xs font-medium text-foreground">{label}</label>
+      <label htmlFor={id} className="text-xs font-medium text-foreground">
+        {label}
+      </label>
       <input
+        id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="w-full rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"

--- a/src/lib/__tests__/firestoreScheduleItems.test.ts
+++ b/src/lib/__tests__/firestoreScheduleItems.test.ts
@@ -64,6 +64,37 @@ describe('Firestore schedule items service', () => {
     expect(dispatch).toHaveBeenNthCalledWith(2, { type: 'UPDATE_SCHEDULE_ITEM', payload: item });
   });
 
+  it('serializes overlapping updates to the same item instead of racing', async () => {
+    // Simulates rapid double-clicking a checkbox: two updates fire before
+    // either Firestore write resolves. Without per-item serialization, both
+    // setDoc calls go out in parallel and whichever resolves last on the
+    // wire wins regardless of click order - this asserts the second write
+    // doesn't even start until the first one has settled.
+    let resolveFirstWrite: () => void = () => {};
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirstWrite = resolve;
+    });
+    setDocMock.mockImplementationOnce(() => firstWrite);
+    setDocMock.mockImplementationOnce(() => Promise.resolve());
+
+    const dispatch = vi.fn();
+    const toggledOn: ScheduleItem = { ...item, completed: true };
+    const toggledOff: ScheduleItem = { ...item, completed: false };
+
+    const firstUpdate = updateScheduleItem('u1', item, toggledOn, dispatch);
+    const secondUpdate = updateScheduleItem('u1', toggledOn, toggledOff, dispatch);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+
+    resolveFirstWrite();
+    await firstUpdate;
+    await secondUpdate;
+
+    expect(setDocMock).toHaveBeenCalledTimes(2);
+  });
+
   it('deleteScheduleItem rolls back by re-adding the item on failure', async () => {
     deleteDocMock.mockRejectedValueOnce(new Error('denied'));
     const dispatch = vi.fn();

--- a/src/lib/firestore/scheduleItems.ts
+++ b/src/lib/firestore/scheduleItems.ts
@@ -8,6 +8,35 @@ function requireDb() {
   return db;
 }
 
+/**
+ * Per-item write queue, keyed by schedule item id. Without this, rapid
+ * double-clicking a task's checkbox fires two overlapping `setDoc` calls -
+ * both carry the full item object (not a partial `completed` patch), so
+ * whichever one resolves last on the wire wins regardless of click order,
+ * silently diverging Firestore's stored state from what the UI shows.
+ * Chaining each update onto the previous one for the same item forces
+ * writes to land in the order they were requested instead of racing.
+ */
+const pendingWrites = new Map<string, Promise<unknown>>();
+
+function enqueueWrite(itemId: string, write: () => Promise<unknown>): Promise<unknown> {
+  const previous = pendingWrites.get(itemId) ?? Promise.resolve();
+  const run = previous.catch(() => {}).then(write);
+  pendingWrites.set(itemId, run);
+  // `run` itself is returned to the caller, who awaits and handles its
+  // rejection - but `.finally()` derives a *new* promise that re-rejects
+  // with the same reason, and nothing here consumes that one. Left
+  // dangling, a failed write logs as an unhandled rejection even though
+  // the caller already handled the original. Swallow it explicitly since
+  // this branch only exists for map cleanup, not error handling.
+  run
+    .finally(() => {
+      if (pendingWrites.get(itemId) === run) pendingWrites.delete(itemId);
+    })
+    .catch(() => {});
+  return run;
+}
+
 export async function createScheduleItem(
   userId: string,
   item: ScheduleItem,
@@ -30,7 +59,9 @@ export async function updateScheduleItem(
 ): Promise<void> {
   dispatch({ type: 'UPDATE_SCHEDULE_ITEM', payload: updatedItem });
   try {
-    await setDoc(doc(requireDb(), 'users', userId, 'scheduleItems', updatedItem.id), updatedItem);
+    await enqueueWrite(updatedItem.id, () =>
+      setDoc(doc(requireDb(), 'users', userId, 'scheduleItems', updatedItem.id), updatedItem),
+    );
   } catch (err) {
     dispatch({ type: 'UPDATE_SCHEDULE_ITEM', payload: previousItem });
     throw err;


### PR DESCRIPTION
## Summary
Three issues independently confirmed by agy's live re-audit of the app:

- **Autofill review-screen labels**: `TextField` (Code/Term/Title/Instructor) had no `htmlFor`/`id` pairing — clicking the label text didn't focus its input, unlike the manual Course/Task forms.
- **Checkbox write races**: `updateScheduleItem` had no guard against overlapping writes for the same item. Rapid double-clicking a task checkbox fired two overlapping `setDoc` calls; whichever resolved last on the wire won regardless of click order. Writes for the same item id now chain onto a per-item queue so they land in request order — covered by a new test.
- **Dark-mode border contrast**: `--border` (18% lightness against a 3.9% background) read as functionally invisible in practice on Planner/Calendar despite a numeric gap on paper. Raised to 26%.

Also investigated agy's "console 404s / service worker warnings" finding: live-checked console output and network requests against production across Dashboard/Calendar/Planner/Tasks — zero errors, zero 404s, everything 200. This was dev-server-only HMR chunk-hash noise (already documented from this session's own earlier testing), not a real production issue — no fix needed.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 181/181 passing (added a regression test that holds the first write open and asserts the second doesn't start until it settles)
- [x] `npm run build` — succeeds
- [x] Live-verified the border-contrast fix: confirmed via computed styles that the token change produced a real, meaningfully lighter border color against the dark background