### PR TITLE
Mobile-responsive pass: Calendar, Planner, Dashboard 7-day strip, Navbar

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -173,7 +173,6 @@ export function MonthCalendar() {
   );
 
   const courseOf = (item: ScheduleItem) => state.courses.find((c) => c.id === item.courseId);
-  const courseColor = (item: ScheduleItem) => courseOf(item)?.color || 'bg-primary';
 
   // #101: recurring class meetings are inherently term-bound (a Fall 2026
   // MWF pattern shouldn't keep rendering forever into Spring 2027), so they
@@ -289,17 +288,17 @@ export function MonthCalendar() {
 
   return (
     <div className="space-y-4">
-      <Card className="rounded-2xl p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-bold tracking-tight text-foreground">
+      <Card className="rounded-2xl p-4 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+          <h2 className="text-lg font-bold tracking-tight text-foreground sm:text-xl">
             {viewMode === 'month' && monthLabelFormatter.format(viewMonth)}
             {viewMode === 'week' && formatWeekRangeLabel(weekDays)}
             {viewMode === 'agenda' && 'Next 30 days'}
           </h2>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <button
               onClick={handleExportICS}
-              className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex items-center gap-1.5 rounded-lg border border-border px-2 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:px-2.5"
               title="Download visible items as a .ics file"
             >
               <svg
@@ -315,7 +314,7 @@ export function MonthCalendar() {
                   d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"
                 />
               </svg>
-              Export
+              <span className="hidden sm:inline">Export</span>
             </button>
             <div className="flex items-center rounded-lg border border-border p-0.5 text-xs font-medium">
               {(['month', 'week', 'agenda'] as const).map((mode) => (
@@ -355,7 +354,7 @@ export function MonthCalendar() {
         </div>
 
         {state.courses.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1.5 mb-3">
+          <div className="-mx-1 mb-3 flex items-center gap-1.5 overflow-x-auto px-1 pb-1 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0 sm:pb-0">
             {state.courses.map((course) => {
               const hidden = hiddenCourseIds.has(course.id);
               const tint = courseChipTint(course.color);
@@ -365,7 +364,7 @@ export function MonthCalendar() {
                   key={course.id}
                   onClick={() => toggleCourseVisibility(course.id)}
                   className={cn(
-                    'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                    'flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                     hidden
                       ? 'border-border text-muted-foreground opacity-50'
                       : cn(tint.className, 'hover:brightness-95'),
@@ -380,11 +379,11 @@ export function MonthCalendar() {
                 </button>
               );
             })}
-            <span className="mx-1 h-4 w-px bg-border" />
+            <span className="mx-1 h-4 w-px shrink-0 bg-border" />
             <button
               onClick={() => setShowClasses((v) => !v)}
               className={cn(
-                'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                'flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                 showClasses
                   ? 'border-border text-foreground hover:bg-accent'
                   : 'border-border text-muted-foreground opacity-50',
@@ -396,7 +395,7 @@ export function MonthCalendar() {
             <button
               onClick={() => setShowCompleted((v) => !v)}
               className={cn(
-                'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                'flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                 showCompleted
                   ? 'border-border text-foreground hover:bg-accent'
                   : 'border-border text-muted-foreground opacity-50',
@@ -436,18 +435,19 @@ export function MonthCalendar() {
 
         {viewMode === 'month' && (
           <>
-            <div className="grid grid-cols-7 gap-1 mb-1">
+            <div className="grid grid-cols-7 gap-0.5 mb-1 sm:gap-1">
               {WEEKDAY_LABELS.map((label) => (
                 <div
                   key={label}
                   className="text-center text-[10px] font-semibold uppercase tracking-wide text-muted-foreground py-1"
                 >
-                  {label}
+                  <span className="sm:hidden">{label.slice(0, 1)}</span>
+                  <span className="hidden sm:inline">{label}</span>
                 </div>
               ))}
             </div>
 
-            <div className="grid grid-cols-7 gap-1" onKeyDown={handleGridKeyDown}>
+            <div className="grid grid-cols-7 gap-0.5 sm:gap-1" onKeyDown={handleGridKeyDown}>
               {grid.map((day) => {
                 const dayItems = visibleDayItems(day);
                 const dayMeetings = visibleMeetings(day);
@@ -464,7 +464,7 @@ export function MonthCalendar() {
                     key={day.toISOString()}
                     onClick={() => selectDay(day)}
                     className={cn(
-                      'min-h-[6.5rem] rounded-xl p-1.5 flex flex-col items-start gap-1 text-left transition-colors',
+                      'min-h-[4rem] rounded-lg p-1 flex flex-col items-start gap-0.5 text-left transition-colors sm:min-h-[6.5rem] sm:rounded-xl sm:p-1.5 sm:gap-1',
                       inCurrentMonth ? 'hover:bg-accent' : 'opacity-40 hover:bg-accent/50',
                       isSelected && 'ring-2 ring-primary',
                       !isSelected && inCurrentMonth && WORKLOAD_TINT_CLASS[heatLevel],
@@ -472,7 +472,7 @@ export function MonthCalendar() {
                   >
                     <span
                       className={cn(
-                        'flex h-6 w-6 items-center justify-center rounded-full text-xs',
+                        'flex h-5 w-5 items-center justify-center rounded-full text-[10px] sm:h-6 sm:w-6 sm:text-xs',
                         isToday
                           ? 'bg-gradient-brand font-bold text-white shadow-card'
                           : 'text-foreground',
@@ -503,9 +503,10 @@ export function MonthCalendar() {
                           key={item.id}
                           className={cn(
                             'block w-full truncate rounded px-1 py-0.5 text-[9px] font-medium leading-tight text-white',
-                            courseColor(item),
+                            courseSwatch(courseOf(item)?.color).className,
                             item.completed && 'opacity-40 line-through',
                           )}
+                          style={courseSwatch(courseOf(item)?.color).style}
                           title={item.title}
                         >
                           {item.title}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -331,7 +331,7 @@ export function DashboardView() {
           </div>
         </div>
 
-        <Card className="rounded-2xl p-6">
+        <Card className="rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <SectionIcon icon="forecast" />
@@ -341,24 +341,26 @@ export function DashboardView() {
               Open planner
             </CardActionLink>
           </div>
-          <div className="grid grid-cols-7 gap-2">
+          <div className="grid grid-cols-7 gap-1 sm:gap-2">
             {plan.weekLoad.map(({ key, day, hours, level }) => {
               const hasLoad = hours > 0;
               return (
                 <div
                   key={key}
                   className={cn(
-                    'flex flex-col items-center gap-1 rounded-xl border p-2.5',
+                    'flex flex-col items-center gap-0.5 rounded-lg border p-1 sm:gap-1 sm:rounded-xl sm:p-2.5',
                     hasLoad ? WORKLOAD_CHIP_CLASS[level] : 'border-border bg-accent/40',
                   )}
                 >
-                  <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  <span className="text-[8px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-[10px]">
                     {forecastDayFormatter.format(day)}
                   </span>
-                  <span className="text-lg font-bold text-foreground">{day.getDate()}</span>
+                  <span className="text-sm font-bold text-foreground sm:text-lg">
+                    {day.getDate()}
+                  </span>
                   <span
                     className={cn(
-                      'text-[10px] font-semibold',
+                      'text-[8px] font-semibold sm:text-[10px]',
                       hasLoad ? WORKLOAD_TEXT_CLASS[level] : 'text-muted-foreground',
                     )}
                   >

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -26,8 +26,8 @@ export default function Navbar() {
   }, []);
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-20 glass border-b border-border/40 bg-card/80 flex items-center justify-between px-6">
-      <div className="flex items-center gap-4">
+    <header className="fixed top-0 left-0 right-0 z-50 h-20 glass border-b border-border/40 bg-card/80 flex items-center justify-between px-3 sm:px-6">
+      <div className="flex items-center gap-2 sm:gap-4">
         {/* Mobile Hamburger Button */}
         <button
           onClick={toggle}
@@ -50,12 +50,12 @@ export default function Navbar() {
           href="/"
           className="flex items-center gap-2.5 text-lg font-bold tracking-tight text-foreground hover:opacity-90 transition-opacity"
         >
-          <Logo className="h-14 w-14 shrink-0" />
-          Syllabus Sense
+          <Logo className="h-9 w-9 shrink-0 sm:h-14 sm:w-14" />
+          <span className="hidden sm:inline">Syllabus Sense</span>
         </Link>
       </div>
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-2 sm:gap-4">
         {mounted && user && <TermSwitcher />}
         {mounted && user && (
           <Link

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -153,6 +153,7 @@ export default function Sidebar() {
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => setIsOpen(false)}
                 className={cn(
                   'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200',
                   isActive

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -78,7 +78,7 @@ export function SmartPlanner() {
       {/* Hero: today's load is the single most useful glanceable fact on this
           page, so it gets a large number instead of being buried in the
           7-day strip alongside every other day. */}
-      <Card accent className="rounded-2xl p-6">
+      <Card accent className="rounded-2xl p-4 sm:p-6">
         <div className="mb-4 flex items-start justify-between gap-4">
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Today&apos;s Load
@@ -94,10 +94,12 @@ export function SmartPlanner() {
           </span>
         </div>
         <div className="mb-5 flex items-end gap-2">
-          <span className="text-5xl font-bold tracking-tight text-foreground">
+          <span className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
             {todayLoad.hours.toFixed(1)}
           </span>
-          <span className="pb-1.5 text-lg font-medium text-muted-foreground">effective hours</span>
+          <span className="pb-1.5 text-base font-medium text-muted-foreground sm:text-lg">
+            effective hours
+          </span>
         </div>
 
         {plan.startToday.length === 0 ? (
@@ -132,9 +134,9 @@ export function SmartPlanner() {
         )}
       </Card>
 
-      <Card className="rounded-2xl p-6">
+      <Card className="rounded-2xl p-4 sm:p-6">
         <h2 className="mb-4 text-base font-semibold text-foreground">7-Day Forecast</h2>
-        <div className="grid grid-cols-7 gap-2">
+        <div className="grid grid-cols-7 gap-1 sm:gap-2">
           {plan.weekLoad.map(({ key, day, hours, level }) => {
             // A day with zero hours isn't a "Low" workload day - it's a day
             // with no data. Coloring it green would misread as "you're fine
@@ -148,20 +150,22 @@ export function SmartPlanner() {
                 key={key}
                 onClick={() => setSelectedForecastKey((prev) => (prev === key ? null : key))}
                 className={cn(
-                  'flex flex-col items-center gap-1 rounded-xl border p-2.5 text-left transition-all',
+                  'flex flex-col items-center gap-0.5 rounded-lg border p-1 text-left transition-all sm:gap-1 sm:rounded-xl sm:p-2.5',
                   hasLoad ? WORKLOAD_CHIP_CLASS[level] : 'border-border bg-accent/40',
                   isSelected
                     ? 'ring-2 ring-primary ring-offset-2 ring-offset-card'
                     : 'hover:-translate-y-0.5',
                 )}
               >
-                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <span className="text-[8px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-[10px]">
                   {dayLabelFormatter.format(day)}
                 </span>
-                <span className="text-lg font-bold text-foreground">{day.getDate()}</span>
+                <span className="text-sm font-bold text-foreground sm:text-lg">
+                  {day.getDate()}
+                </span>
                 <span
                   className={cn(
-                    'text-[10px] font-semibold',
+                    'text-[8px] font-semibold sm:text-[10px]',
                     hasLoad ? WORKLOAD_TEXT_CLASS[level] : 'text-muted-foreground',
                   )}
                 >


### PR DESCRIPTION
## Summary
Both the original code-level UX/UI audit and agy's live re-audit confirmed the same real breakage at a 375px viewport: the calendar filter row wraps to 2-3 lines before showing a single date, the Planner/Dashboard 7-day grids compress to unusably narrow columns, and the navbar's logo/wordmark/term-switcher/greeting crowd into overlap. None of these pages had any `sm:`/`md:` responsive classes.

- **Calendar**: the course/Classes/Completed filter row now scrolls horizontally on mobile instead of wrapping (the specific thing flagged as looking bad on both desktop and mobile) — all chips get `shrink-0` so they don't compress inside the scroll container. Day cells, weekday labels (single-letter on mobile), header controls, and Card padding all get a smaller mobile treatment via `sm:` prefixes without changing desktop appearance.
- **Planner and Dashboard's 7-day grids**: same `grid-cols-7` pattern, same fix — smaller gap/padding/font under `sm:` so numbers and hour labels fit instead of clipping.
- **Navbar**: smaller logo and hidden wordmark below `sm:`, tighter gaps and padding, so the hamburger/logo/term-switcher/theme-toggle/sign-out cluster doesn't overflow a narrow screen.
- **Sidebar**: the mobile drawer now closes when a nav link is clicked — previously it stayed open over the destination page after navigating, a real bug independent of the responsive-class work.
- Also fixed a latent bug found while touching this file: the month grid's day-item chips still used the pre-`courseColors`-refactor helper, which doesn't handle custom hex course colors.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 181/181 passing
- [x] `npm run build` — succeeds
- [x] No desktop regression — spot-checked Dashboard/Planner/Calendar at full width, pixel-identical to before
- [ ] **Not independently visually confirmed at 375px this session** — the browser tool's `resize_window` doesn't affect the real viewport here (confirmed via `window.innerWidth` still reporting 1536 after a resize call, a known limitation from earlier in this session). Every responsive class was chosen from real pixel math against a 375px viewport, not guessed, but a real-device or DevTools-device-mode check is worth doing before considering this fully closed out.