### PR TITLE
Fix workload engine bucketing due items one day late

### DIFF
--- a/src/lib/__tests__/workload.test.ts
+++ b/src/lib/__tests__/workload.test.ts
@@ -9,6 +9,8 @@ import {
   calculateDailyLoad,
   getWorkloadLevel,
   recommendStudyStartDate,
+  toDateOnly,
+  formatDateISO,
   WORKLOAD_LEVEL_THRESHOLDS,
 } from '@/lib/workload';
 
@@ -291,5 +293,39 @@ describe('cross-cutting integration', () => {
     const level = getWorkloadLevel(dailyLoad.get(REFERENCE_DATE) ?? 0);
     expect(typeof level).toBe('string');
     expect(['low', 'medium', 'high', 'critical']).toContain(level);
+  });
+});
+
+describe('toDateOnly - real ScheduleItem.dueDate values (regression)', () => {
+  // The app never stores a bare 'YYYY-MM-DD' - a due date picked as "Aug 21"
+  // is saved via `new Date('2026-08-21T23:59:00').toISOString()`, i.e. 23:59
+  // in whatever timezone the browser that created it was running in,
+  // converted to a UTC instant. Reading that instant's calendar day back out
+  // with *UTC* getters (the old bug) rolls it into the next day for any
+  // negative-UTC-offset user - a Friday due date's load/heat would land on
+  // Saturday. This asserts the real construction path round-trips to the
+  // same day as the literal date, regardless of what timezone the test
+  // itself runs in.
+  const realDueDateFor = (dateOnly: string) => new Date(`${dateOnly}T23:59:00`).toISOString();
+
+  it('recovers the same calendar day from a full ISO instant as from the bare date string', () => {
+    const literal = toDateOnly('2026-08-21');
+    const asStoredByTheApp = toDateOnly(realDueDateFor('2026-08-21'));
+    expect(formatDateISO(asStoredByTheApp)).toBe(formatDateISO(literal));
+    expect(formatDateISO(asStoredByTheApp)).toBe('2026-08-21');
+  });
+
+  it('buckets a Friday-due item under Friday, not Saturday, in calculateDailyLoad', () => {
+    const item = makeItem({ dueDate: realDueDateFor('2026-08-21'), estimatedHours: 3 });
+    // referenceDate ("today") also goes through the app's real construction
+    // path here, not a bare string, to match how MonthCalendar/SmartPlanner
+    // actually call this.
+    const today = toDateOnly(realDueDateFor('2026-08-16'));
+    const dailyLoad = calculateDailyLoad([item], today);
+    expect(dailyLoad.has('2026-08-22')).toBe(false);
+    // The item is due today+5, inside the default 7-day distribution window,
+    // so its hours are spread across several days ending on the due date -
+    // the due date itself must be one of them, under the correct key.
+    expect(dailyLoad.get('2026-08-21')).toBeGreaterThan(0);
   });
 });

--- a/src/lib/workload/dateUtils.ts
+++ b/src/lib/workload/dateUtils.ts
@@ -2,15 +2,44 @@
  * Small set of date-only helpers used throughout the workload engine.
  *
  * All workload calculations operate on calendar days, not instants, so every
- * date is normalized to UTC midnight ("date-only") before any arithmetic.
- * Using UTC (rather than local time) keeps the engine deterministic
- * regardless of the machine/timezone running it, which matters for tests.
+ * date is normalized to a UTC-midnight Date ("date-only") before any
+ * arithmetic - `addDays`/`diffInDays`/`enumerateDays` all assume their inputs
+ * are already in that stable form. That normalization step is the one place
+ * that has to be careful about *which* calendar day a given input means.
  */
 
-/** Parses an ISO date/datetime string (or Date) into a UTC-midnight Date. */
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parses an ISO date/datetime string (or Date) into a UTC-midnight Date
+ * representing the correct calendar day - three input shapes, three rules:
+ *
+ * - A `Date` object is assumed to already be a UTC-midnight calendar day
+ *   (the convention every caller in this codebase follows, e.g.
+ *   `getLocalReferenceDate()`), so it's read back with UTC getters unchanged.
+ * - A bare `YYYY-MM-DD` string (no time component - used throughout this
+ *   module's own test suite) is parsed digit-by-digit, never through `Date`,
+ *   so it can't be shifted by any timezone at all.
+ * - A full ISO instant string - what `ScheduleItem.dueDate` actually is in
+ *   production (`new Date(`${date}T23:59:00`).toISOString()`, i.e. 23:59 in
+ *   whichever timezone created it, converted to UTC) - is read with *local*
+ *   getters. This was the actual bug: reading it with UTC getters rolls any
+ *   negative-UTC-offset user's evening due date into the next UTC day, so a
+ *   Friday-due item's load/heat landed on Saturday. `lib/calendar/dates.ts`
+ *   already reads the same values with local getters for exactly this
+ *   reason; this brings the workload engine's day-bucketing in line with it.
+ */
 export function toDateOnly(input: string | Date): Date {
-  const d = typeof input === 'string' ? new Date(input) : input;
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  if (typeof input !== 'string') {
+    return new Date(Date.UTC(input.getUTCFullYear(), input.getUTCMonth(), input.getUTCDate()));
+  }
+  const dateOnly = DATE_ONLY_PATTERN.exec(input);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+  }
+  const d = new Date(input);
+  return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
 }
 
 /** Formats a UTC-midnight Date as an ISO `YYYY-MM-DD` string. */


### PR DESCRIPTION
## Summary
Real `ScheduleItem.dueDate` values are stored via `new Date(\`\${date}T23:59:00\`).toISOString()` — 23:59 in whatever timezone the browser that created it was in, converted to a UTC instant. The workload engine's `toDateOnly()` read that instant back out with UTC getters, which rolls any negative-UTC-offset user's evening due date into the next UTC calendar day. `lib/calendar/dates.ts` already reads the same values with local getters for exactly this reason (its own comment describes the exact failure mode) — the two modules disagreed on what day a due date landed on, and the workload engine's version was wrong.

Concretely: an item due Friday would have its load/heat/"busiest day" indicator land on Saturday's cell instead of Friday's, while the task list's own "Due" label (a separate, already-correct code path) still showed Friday — exactly the bug reported.

`toDateOnly()` now branches on what it's actually given:
- A `Date` object is assumed to already be a UTC-midnight calendar day (the convention every caller already follows, e.g. `getLocalReferenceDate()`) — read with UTC getters, unchanged.
- A bare `'YYYY-MM-DD'` string (used throughout this module's own tests) is parsed digit-by-digit, never through `Date`, so no timezone can touch it — unchanged.
- A full ISO instant string (what a real `dueDate` actually is) is now read with **local** getters, matching `lib/calendar/dates.ts`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 183/183 passing (added a regression test that reproduces the real construction path end-to-end and confirms it round-trips to the same calendar day as the literal date string, regardless of what timezone the test itself runs in)
- [x] `npm run build` — succeeds
- [x] Manually confirmed the old code would have failed the new test (`node -e` reproduction against this machine's real `America/Los_Angeles` timezone showed the old UTC-getter logic returning the day *after* the picked due date)
- [x] Live-verified against the dev-test account's real data (weekly Friday-due HNES 111 items across a full month) — every item now lands on its correct Friday cell with no Saturday spillover, and the calendar's "Busiest day" callout matches the visibly-tinted cell