### PR TITLE
Dashboard/Courses: push course-color wash further (Direction B)

### DIFF
--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -11,7 +11,7 @@ import { createCourse } from '@/lib/firestore/courses';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import type { CourseFormValues } from '@/lib/validation/course';
-import { courseSwatch } from '@/lib/courseColors';
+import { courseSwatch, courseWash } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 
 type SortMode = 'code' | 'title' | 'term';
@@ -195,14 +195,14 @@ export function CoursesListView() {
                 <Link key={course.id} href={`/courses/${course.id}`} className="block">
                   <Card hoverable className="flex h-full flex-col overflow-hidden rounded-2xl p-0">
                     <div
-                      className={cn('h-1.5 w-full', courseSwatch(course.color).className)}
+                      className={cn('h-2 w-full', courseSwatch(course.color).className)}
                       style={courseSwatch(course.color).style}
                     />
-                    <div className="flex flex-1 flex-col p-5">
+                    <div className="flex flex-1 flex-col p-5" style={courseWash(course.color)}>
                       <div className="mb-2 flex items-center gap-3">
                         <span
                           className={cn(
-                            'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-bold text-white',
+                            'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-base font-bold text-white shadow-sm',
                             courseSwatch(course.color).className,
                           )}
                           style={courseSwatch(course.color).style}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -17,7 +17,7 @@ import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
-import { courseSwatch } from '@/lib/courseColors';
+import { courseChipTint, courseSwatch } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
@@ -231,29 +231,35 @@ export function DashboardView() {
                   action={{ label: '+ Add Course', onClick: () => setAddCourseOpen(true) }}
                 />
               ) : (
-                <div className="space-y-5">
-                  {courseLoad.map(({ course, pct }) => (
-                    <div key={course.id}>
-                      <div className="flex justify-between text-xs mb-1.5">
-                        <Link
-                          href={`/courses/${course.id}`}
-                          className="font-medium text-foreground hover:text-primary hover:underline"
-                        >
-                          {course.code} · {course.title}
-                        </Link>
-                        <span className="text-muted-foreground">{pct}%</span>
-                      </div>
-                      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className={cn(
-                            'h-full rounded-full',
-                            courseSwatch(course.color).className,
-                          )}
-                          style={{ width: `${pct}%`, ...courseSwatch(course.color).style }}
-                        />
-                      </div>
-                    </div>
-                  ))}
+                <div className="space-y-2">
+                  {courseLoad.map(({ course, pct }) => {
+                    const tint = courseChipTint(course.color);
+                    const swatch = courseSwatch(course.color);
+                    return (
+                      <Link
+                        key={course.id}
+                        href={`/courses/${course.id}`}
+                        className={cn(
+                          'block rounded-xl border p-3 transition-colors hover:brightness-95',
+                          tint.className,
+                        )}
+                        style={tint.style}
+                      >
+                        <div className="mb-1.5 flex items-center justify-between gap-2 text-xs">
+                          <span className="truncate font-semibold">
+                            {course.code} · {course.title}
+                          </span>
+                          <span className="shrink-0 font-semibold">{pct}%</span>
+                        </div>
+                        <div className="h-1.5 overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                          <div
+                            className={cn('h-full rounded-full', swatch.className)}
+                            style={{ width: `${pct}%`, ...swatch.style }}
+                          />
+                        </div>
+                      </Link>
+                    );
+                  })}
                 </div>
               )}
             </Card>

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -103,6 +103,18 @@ export function getCourseChipTintClass(color: string | undefined): string {
   return courseChipTint(color).className || DEFAULT_CHIP_TINT;
 }
 
+/** A faint full-surface background wash (course cards, list rows) - subtler
+ * than `courseChipTint` (no border, no text-color override, low alpha) so it
+ * layers under normal-contrast foreground text instead of competing with it.
+ * Always inline (rather than a static Tailwind class) since it needs to
+ * resolve a hex value for presets too, not just custom colors. */
+export function courseWash(color: string | undefined, alphaHex = '12'): CSSProperties {
+  const hex = isCustomColor(color)
+    ? color
+    : (COURSE_COLOR_PRESETS.find((p) => p.value === color)?.hex ?? '#7c3aed');
+  return { backgroundColor: `${hex}${alphaHex}` };
+}
+
 /**
  * Picks the color least represented among a user's existing courses (ties
  * broken by preset order), so a freshly autofilled or manually added course


### PR DESCRIPTION
## Summary
- Dashboard's Course Load rows become tinted chip-cards (`courseChipTint`) instead of plain text over a progress bar, so each course reads by its own color at a glance.
- Courses list cards get a bolder top color bar, a bigger `rounded-xl` avatar, and a new subtle full-card background wash — continues the "stronger color wash" propagation called out for Direction B, without touching text color so contrast is unaffected.
- New `courseWash()` helper in `courseColors.ts` resolves a hex value for both presets and custom colors (inline style, since Tailwind's JIT can't produce arbitrary background alpha for every preset without a static class list).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 183/183 passing
- [x] `npm run build` — clean production build
- [x] Live-verified against the dev-test account: Dashboard Course Load tinted cards (multiple course colors + the custom-hex "TEST 999" course), Courses list cards (bolder top bar, wash, avatar) in both dark and light mode.