### PR TITLE
Fix Dashboard term-filter stats and meetings leaking past their term

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -41,19 +41,32 @@ export function DashboardView() {
   const [autofillOpen, setAutofillOpen] = useState(false);
 
   const { courses, scheduleItems } = state;
-  const pendingTasks = scheduleItems.filter((item) => !item.completed);
-  const completedTasksCount = scheduleItems.length - pendingTasks.length;
-  const termProgressPct = scheduleItems.length
-    ? Math.round((completedTasksCount / scheduleItems.length) * 100)
-    : 0;
-  const now = useMemo(() => Date.now(), []);
-  const overdueCount = pendingTasks.filter((item) => new Date(item.dueDate).getTime() < now).length;
 
   const currentTerm = useMemo(
     () => resolveActiveTerm(state.selectedTerm, courses),
     [state.selectedTerm, courses],
   );
   const semesterCourses = currentTerm ? courses.filter((c) => c.term === currentTerm) : courses;
+  // All the stats below need to respect the selected term too, not just the
+  // Course Load card - previously they always used the full, unfiltered
+  // scheduleItems, so switching the term dropdown left the progress ring,
+  // pending/done counts, and Upcoming Tasks showing every term's data at once.
+  const semesterCourseIds = useMemo(
+    () => new Set(semesterCourses.map((c) => c.id)),
+    [semesterCourses],
+  );
+  const termScheduleItems = useMemo(
+    () => scheduleItems.filter((item) => semesterCourseIds.has(item.courseId)),
+    [scheduleItems, semesterCourseIds],
+  );
+
+  const pendingTasks = termScheduleItems.filter((item) => !item.completed);
+  const completedTasksCount = termScheduleItems.length - pendingTasks.length;
+  const termProgressPct = termScheduleItems.length
+    ? Math.round((completedTasksCount / termScheduleItems.length) * 100)
+    : 0;
+  const now = useMemo(() => Date.now(), []);
+  const overdueCount = pendingTasks.filter((item) => new Date(item.dueDate).getTime() < now).length;
 
   const courseLoad = semesterCourses.map((course) => {
     const items = scheduleItems.filter((item) => item.courseId === course.id);
@@ -69,8 +82,8 @@ export function DashboardView() {
 
   const referenceDate = useMemo(() => getLocalReferenceDate(), []);
   const plan = useMemo(
-    () => computeSmartPlan(scheduleItems, referenceDate),
-    [scheduleItems, referenceDate],
+    () => computeSmartPlan(termScheduleItems, referenceDate),
+    [termScheduleItems, referenceDate],
   );
   const plannerPreview = [...plan.startToday, ...plan.startThisWeek].slice(0, 4);
 

--- a/src/lib/__tests__/calendarMeetings.test.ts
+++ b/src/lib/__tests__/calendarMeetings.test.ts
@@ -47,6 +47,35 @@ describe('getMeetingsForDay', () => {
   });
 });
 
+describe('getMeetingsForDay term bounding', () => {
+  const springCourse: Course = {
+    id: 'c4',
+    code: 'ECE 211',
+    title: 'Circuit Analysis 1',
+    color: 'bg-blue-500',
+    term: 'Spring 2026',
+    meetingTimes: [{ dayOfWeek: 1, startTime: '09:00', endTime: '09:50' }],
+  };
+
+  it('renders a Spring course meeting within its own term months', () => {
+    const marchMonday = new Date(2026, 2, 2); // Mar 2, 2026 is a Monday
+    expect(getMeetingsForDay([springCourse], marchMonday).map((m) => m.course.id)).toEqual(['c4']);
+  });
+
+  it('does not render a Spring course meeting the following August', () => {
+    const augustMonday = new Date(2026, 7, 3); // Aug 3, 2026 is a Monday
+    expect(getMeetingsForDay([springCourse], augustMonday)).toEqual([]);
+  });
+
+  it('still renders every week for a course with no term set', () => {
+    const untouchedCourse: Course = { ...springCourse, id: 'c5', term: undefined };
+    const augustMonday = new Date(2026, 7, 3);
+    expect(getMeetingsForDay([untouchedCourse], augustMonday).map((m) => m.course.id)).toEqual([
+      'c5',
+    ]);
+  });
+});
+
 describe('formatTimeLabel', () => {
   it('formats morning times', () => {
     expect(formatTimeLabel('09:00')).toBe('9:00 AM');

--- a/src/lib/calendar/meetings.ts
+++ b/src/lib/calendar/meetings.ts
@@ -1,4 +1,5 @@
 import type { Course, MeetingTime } from '@/types/schedule';
+import { isWithinEstimatedTerm } from '@/lib/calendar/termDates';
 
 export interface MeetingOccurrence {
   course: Course;
@@ -11,15 +12,17 @@ export interface MeetingOccurrence {
  * Date.getDay()-compatible (0=Sunday), so no conversion is needed against
  * the calendar grid, which is also Sunday-first.
  *
- * There's no term-boundary data yet (courses only carry a free-text `term`
- * label, not start/end dates - that's #101), so a meeting matches every week
- * regardless of which month is being viewed. Acceptable for now; #101 will
- * narrow this once term boundaries exist.
+ * There's no real term-boundary data yet (courses only carry a free-text
+ * `term` label, not start/end dates - that's #101), so this bounds the
+ * recurrence to `estimateTermRange`'s parse of that label instead of
+ * matching every week forever - without it, a Spring course's MWF pattern
+ * kept rendering on every month of the calendar, including next August.
  */
 export function getMeetingsForDay(courses: Course[], day: Date): MeetingOccurrence[] {
   const dayOfWeek = day.getDay();
   const occurrences: MeetingOccurrence[] = [];
   for (const course of courses) {
+    if (!isWithinEstimatedTerm(course.term, day)) continue;
     for (const meeting of course.meetingTimes ?? []) {
       if (meeting.dayOfWeek === dayOfWeek) {
         occurrences.push({ course, meeting });

--- a/src/lib/calendar/termDates.ts
+++ b/src/lib/calendar/termDates.ts
@@ -1,0 +1,42 @@
+/**
+ * Courses only carry a free-text `term` label (e.g. "Fall 2026"), not real
+ * start/end dates (#101 will add those). Until then, recurring class
+ * meetings have no way to know they shouldn't render outside their own
+ * term's actual months - a Spring course's MWF pattern kept showing up on
+ * every single month of the calendar, including the following August.
+ *
+ * This parses the common season keywords out of the label and returns an
+ * approximate date range for that season, with a couple weeks of slop on
+ * each side so a real meeting near a term boundary doesn't get cut off.
+ * Unparseable/absent terms return null, and callers should treat that as
+ * "no bound available" (render as before) rather than "never show".
+ */
+export function estimateTermRange(term: string | undefined): { start: Date; end: Date } | null {
+  if (!term) return null;
+  const yearMatch = /\b(20\d{2})\b/.exec(term);
+  if (!yearMatch) return null;
+  const year = Number(yearMatch[1]);
+  const lower = term.toLowerCase();
+
+  if (lower.includes('spring')) {
+    return { start: new Date(year, 0, 1), end: new Date(year, 4, 31) };
+  }
+  if (lower.includes('summer')) {
+    return { start: new Date(year, 4, 15), end: new Date(year, 7, 31) };
+  }
+  if (lower.includes('winter')) {
+    return { start: new Date(year, 10, 15), end: new Date(year + 1, 1, 15) };
+  }
+  if (lower.includes('fall') || lower.includes('autumn')) {
+    return { start: new Date(year, 7, 1), end: new Date(year, 11, 31) };
+  }
+  return null;
+}
+
+/** Whether `day` falls within `term`'s estimated range - courses with an
+ * unparseable/absent term always pass, since there's no bound to check. */
+export function isWithinEstimatedTerm(term: string | undefined, day: Date): boolean {
+  const range = estimateTermRange(term);
+  if (!range) return true;
+  return day >= range.start && day <= range.end;
+}


### PR DESCRIPTION
## Summary
- **Dashboard term filter didn't actually filter stats.** Switching the term dropdown only re-scoped the Course Load card; the progress ring, Courses/Pending/Done counts, Upcoming Tasks, overdue badge, and 7-Day Load/Planner Preview all read from the full unfiltered `scheduleItems` regardless of the selected term. They now derive from a `termScheduleItems` set scoped the same way Course Load already was.
- **Recurring class meetings had no term boundary, so they rendered forever.** A Spring 2026 course's MWF pattern kept showing up on every month of the calendar, including the following August — this is what was reported as "why is ECE 211 showing up in August when it was last Spring." Root cause: `Course.term` is only a free-text label with no start/end dates (flagged as future work in the existing code comment for #101), and `getMeetingsForDay` had no bound at all.
- Added `estimateTermRange()` / `isWithinEstimatedTerm()` (`src/lib/calendar/termDates.ts`) that parses the season + year out of a course's term label into an approximate date range, and `getMeetingsForDay` now skips a course's meetings outside that range. Courses with no parseable term are untouched (render every week, as before). Real term start/end dates (#101) would replace this with an exact bound — this is the interim fix for the actual reported symptom.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 186/186 passing (3 new regression tests for the term-bounding behavior)
- [x] `npm run build` — clean production build
- [x] Live-verified against the dev-test account: confirmed ECE 211 (term "Spring 2026") no longer appears on the calendar in August 2026, but still correctly renders on Wednesday, Feb 4, 2026 (within its own term).