### PR TITLE
Fix logo not rendering on mobile (duplicate SVG gradient ids)

### DIFF
--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -1,20 +1,33 @@
+import { useId } from 'react';
+
 export default function Logo({ className }: { className?: string }) {
+  // Gradient ids must be unique per rendered <Logo> - the auth pages render
+  // one copy in the (hidden-on-mobile, but still DOM-present) brand panel
+  // and another in the form card itself. With a shared hardcoded id, some
+  // mobile browsers refuse to resolve a url(#id) gradient reference whose
+  // first-in-DOM definition lives inside a display:none subtree, so the
+  // visible logo's fill silently disappeared, leaving only the white ring
+  // and center dot. useId() keeps every instance's ids distinct.
+  const uid = useId();
+  const mainGradId = `logo-main-grad-${uid}`;
+  const tealGradId = `logo-teal-grad-${uid}`;
+
   return (
     <svg viewBox="0 0 200 200" className={className} role="img" aria-label="Syllabus Sense logo">
       <defs>
-        <linearGradient id="logo-main-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <linearGradient id={mainGradId} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#8C6EFF" />
           <stop offset="100%" stopColor="#5B3DF5" />
         </linearGradient>
-        <linearGradient id="logo-teal-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <linearGradient id={tealGradId} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#3DFFD0" />
           <stop offset="100%" stopColor="#00BFA0" />
         </linearGradient>
       </defs>
-      <rect x="12" y="12" width="176" height="176" rx="44" fill="url(#logo-main-grad)" />
+      <rect x="12" y="12" width="176" height="176" rx="44" fill={`url(#${mainGradId})`} />
       <circle cx="100" cy="100" r="72" fill="none" stroke="#FFFFFF" strokeWidth="11" />
       <polygon points="137,63 110,110 63,137" fill="#FFFFFF" />
-      <polygon points="137,63 90,90 63,137" fill="url(#logo-teal-grad)" />
+      <polygon points="137,63 90,90 63,137" fill={`url(#${tealGradId})`} />
       <circle cx="100" cy="100" r="15" fill="#FFFFFF" />
       <circle cx="100" cy="100" r="8" fill="#5B3DF5" />
     </svg>


### PR DESCRIPTION
## Summary
Reported directly from a real phone: the logo on the login page showed only a small dot instead of the full gradient mark.

Root cause: the auth layout renders two `<Logo>` copies simultaneously - one in the desktop brand panel (`hidden md:flex`, so `display:none` on mobile but still present in the DOM) and one in the login/signup card itself (`md:hidden`, visible only on mobile). Both used the same hardcoded `<linearGradient id="logo-main-grad">` / `id="logo-teal-grad"`. On mobile, the hidden brand-panel copy sits earlier in the DOM, and some mobile browsers refuse to resolve a `url(#id)` gradient reference whose first-in-DOM definition lives inside a `display:none` subtree - so the visible logo's `rect`/`polygon` fills silently disappeared, leaving only the white ring and center dot (matches the screenshot exactly).

Fix: `Logo` now derives its gradient ids from React's `useId()`, so every rendered instance gets unique ids regardless of how many copies are mounted on the page at once.

## Test plan
- [x] `npm run lint` - clean
- [x] `npx vitest run` - 186/186 passing
- [x] `npm run build` - clean production build
- [x] Live-verified: confirmed the two `<Logo>` instances on `/login` now render distinct gradient ids, then reproduced the exact mobile condition (brand panel `display:none`, form-card logo visible) via a temporary CSS override at the actual desktop viewport and confirmed the full gradient mark now renders instead of just the ring/dot.