### PR TITLE
Add AI course summary and important-notes feature

### DIFF
--- a/src/app/api/syllabus/summarize/route.ts
+++ b/src/app/api/syllabus/summarize/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type Anthropic from '@anthropic-ai/sdk';
+import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
+import { adminStorage } from '@/lib/firebase/adminStorage';
+import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import { checkAndIncrementExtractionCount } from '@/lib/ai/extractionRateLimit';
+import { COURSE_SUMMARY_SYSTEM_PROMPT, COURSE_SUMMARY_TOOL } from '@/lib/ai/courseSummaryTool';
+import { courseSummarySchema } from '@/types/courseSummary';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+async function requireUser(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+  if (!token || !projectId) return null;
+  try {
+    return await verifyFirebaseIdToken(token, projectId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Summarizes an already-uploaded syllabus into a plain-English course
+ * summary plus "important notes" the student could get burned by missing -
+ * reuses the same daily AI-usage budget as extraction (checkAndIncrement-
+ * ExtractionCount) rather than a separate limiter, since both are Anthropic
+ * calls against a student's own uploaded documents.
+ *
+ * Takes the file's storage path directly (not a syllabus id looked up
+ * server-side) - same trust model as the file proxy: the path is checked
+ * against the caller's own `users/{uid}/...` prefix, so a client-supplied
+ * path can't read anyone else's file.
+ */
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: { storagePath?: string; fileName?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const { storagePath, fileName } = body;
+  if (!storagePath || !fileName) {
+    return NextResponse.json({ error: 'Missing storagePath or fileName.' }, { status: 400 });
+  }
+  if (!storagePath.startsWith(`users/${user.uid}/`)) {
+    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+  }
+
+  const fileKind = fileName.toLowerCase().endsWith('.pdf')
+    ? 'pdf'
+    : fileName.toLowerCase().endsWith('.docx')
+      ? 'docx'
+      : null;
+  if (!fileKind) {
+    return NextResponse.json(
+      { error: 'Only PDF and .docx syllabi can be summarized.' },
+      { status: 400 },
+    );
+  }
+
+  if (!adminStorage) {
+    return NextResponse.json(
+      { error: 'Storage is not configured on the server.' },
+      { status: 500 },
+    );
+  }
+
+  let fileBase64: string;
+  try {
+    const file = adminStorage.bucket().file(storagePath);
+    const [bytes] = await file.download();
+    fileBase64 = bytes.toString('base64');
+  } catch {
+    return NextResponse.json({ error: "Couldn't read that file." }, { status: 404 });
+  }
+
+  let docxText: string | null = null;
+  if (fileKind === 'docx') {
+    try {
+      const mammoth = await import('mammoth');
+      const buffer = Buffer.from(fileBase64, 'base64');
+      const result = await mammoth.extractRawText({ buffer });
+      docxText = result.value.trim();
+    } catch {
+      return NextResponse.json(
+        { error: "Couldn't read that Word document. Try re-saving it and uploading again." },
+        { status: 400 },
+      );
+    }
+    if (!docxText) {
+      return NextResponse.json({ error: 'That document appears to be empty.' }, { status: 400 });
+    }
+  }
+
+  const rateLimit = await checkAndIncrementExtractionCount(user.uid);
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "You've hit today's AI usage limit. Try again tomorrow." },
+      { status: 429 },
+    );
+  }
+
+  let anthropic;
+  try {
+    anthropic = getAnthropicClient();
+  } catch {
+    return NextResponse.json(
+      { error: 'Course summarization is not configured on the server.' },
+      { status: 503 },
+    );
+  }
+
+  const documentContent: Anthropic.MessageParam['content'] =
+    fileKind === 'pdf'
+      ? [
+          {
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
+            title: fileName,
+          },
+          { type: 'text', text: 'Summarize this syllabus into the record_course_summary tool.' },
+        ]
+      : [
+          {
+            type: 'text',
+            text: `Syllabus document (${fileName}), extracted from a Word file:\n\n${docxText}`,
+          },
+          { type: 'text', text: 'Summarize this syllabus into the record_course_summary tool.' },
+        ];
+
+  let message;
+  try {
+    message = await anthropic.messages.create({
+      model: SYLLABUS_EXTRACTION_MODEL,
+      max_tokens: 2000,
+      system: COURSE_SUMMARY_SYSTEM_PROMPT,
+      tools: [COURSE_SUMMARY_TOOL],
+      tool_choice: { type: 'tool', name: COURSE_SUMMARY_TOOL.name },
+      messages: [{ role: 'user', content: documentContent }],
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Summarization request failed.' },
+      { status: 502 },
+    );
+  }
+
+  const toolUse = message.content.find(
+    (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+  );
+  if (!toolUse) {
+    return NextResponse.json(
+      { error: 'The model did not return structured data. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  const parsed = courseSummarySchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    console.error('Course summary validation failed:', parsed.error.issues);
+    return NextResponse.json({ error: 'The summary was malformed. Try again.' }, { status: 502 });
+  }
+
+  return NextResponse.json({ result: parsed.data });
+}

--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { useSyllabi } from '@/lib/firestore/useSyllabi';
+import { updateCourse } from '@/lib/firestore/courses';
+import { courseSummarySchema, type CourseSummaryNote } from '@/types/courseSummary';
+import type { Course } from '@/types/schedule';
+
+const CATEGORY_LABEL: Record<CourseSummaryNote['category'], string> = {
+  attendance: 'Attendance',
+  grading: 'Grading',
+  lateWork: 'Late work',
+  academicIntegrity: 'Academic integrity',
+  prerequisite: 'Prerequisite',
+  highStakes: 'High-stakes',
+  communication: 'Communication',
+  other: 'Note',
+};
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en-US', { numeric: 'auto' });
+
+function formatRelativeTime(iso: string): string {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  if (Math.abs(diffDays) < 1) return 'today';
+  return relativeTimeFormatter.format(diffDays, 'day');
+}
+
+export function CourseAiSummaryCard({ course }: { course: Course }) {
+  const { user } = useAuth();
+  const { dispatch } = useAppState();
+  const syllabi = useSyllabi(user?.uid, course.id);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Most recently uploaded syllabus - the one worth summarizing if there's
+  // more than one on file.
+  const latestSyllabus = syllabi
+    .slice()
+    .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
+
+  if (!latestSyllabus) return null;
+
+  const handleGenerate = async () => {
+    if (!user) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch('/api/syllabus/summarize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          storagePath: latestSyllabus.storagePath,
+          fileName: latestSyllabus.fileName,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'Summarization failed.');
+
+      const parsed = courseSummarySchema.parse(body.result);
+      await updateCourse(
+        user.uid,
+        course,
+        {
+          ...course,
+          aiSummary: {
+            ...parsed,
+            generatedAt: new Date().toISOString(),
+            sourceFileName: latestSyllabus.fileName,
+          },
+        },
+        dispatch,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const summary = course.aiSummary;
+  // A summary generated from a since-deleted/replaced file is still shown -
+  // it's better to have slightly stale info clearly labeled with its source
+  // than to silently discard a real Anthropic result.
+  const isStale = summary && summary.sourceFileName !== latestSyllabus.fileName;
+
+  return (
+    <Card className="rounded-2xl p-6 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-brand text-white">
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z"
+              />
+            </svg>
+          </span>
+          <h2 className="text-base font-semibold text-foreground">AI Summary</h2>
+        </div>
+        <button
+          onClick={handleGenerate}
+          disabled={generating}
+          className="text-xs font-semibold text-primary hover:underline disabled:pointer-events-none disabled:opacity-50"
+        >
+          {generating ? 'Generating…' : summary ? 'Regenerate' : 'Generate'}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {!summary && !generating && !error && (
+        <p className="text-sm text-muted-foreground">
+          Get a plain-English summary and a list of things to watch out for, generated from{' '}
+          {latestSyllabus.fileName}.
+        </p>
+      )}
+
+      {generating && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Reading {latestSyllabus.fileName}…
+        </div>
+      )}
+
+      {summary && !generating && (
+        <div className="space-y-4">
+          <p className="text-sm leading-relaxed text-foreground">{summary.summary}</p>
+
+          {summary.importantNotes.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Watch out for
+              </p>
+              <ul className="space-y-2">
+                {summary.importantNotes.map((note, i) => (
+                  <li key={i} className="flex items-start gap-2.5 text-sm text-foreground">
+                    <span className="mt-0.5 shrink-0 rounded-full bg-accent px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {CATEGORY_LABEL[note.category]}
+                    </span>
+                    <span className="leading-relaxed">{note.note}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            Generated {formatRelativeTime(summary.generatedAt)} from {summary.sourceFileName}
+            {isStale && ' (a newer syllabus has been uploaded since)'}
+          </p>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -20,6 +20,7 @@ import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
 import { SyllabusList } from '@/components/syllabus/SyllabusList';
+import { CourseAiSummaryCard } from '@/components/courses/CourseAiSummaryCard';
 import { formatTimeLabel } from '@/lib/calendar/meetings';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateRateMyProfessorUrl } from '@/lib/export/rateMyProfessor';
@@ -286,6 +287,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
           <SyllabusList userId={user?.uid} courseId={course.id} />
           <SyllabusUploader userId={user?.uid ?? ''} courseId={course.id} />
         </Card>
+
+        <CourseAiSummaryCard course={course} />
 
         <Card className="rounded-2xl p-6">
           <div className="flex items-center justify-between mb-4">

--- a/src/lib/ai/courseSummaryTool.ts
+++ b/src/lib/ai/courseSummaryTool.ts
@@ -1,0 +1,53 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+export const COURSE_SUMMARY_SYSTEM_PROMPT = `You are helping a student quickly understand a course syllabus they just uploaded. Read the whole document and produce two things:
+
+1. A short, plain-English summary (2-4 sentences) of what the course actually covers, its format (lecture/online/hybrid, how it's graded overall), and the general workload/pace a student should expect. Write it like you're describing the course to a friend, not restating the catalog description.
+
+2. A list of "important notes" - specific things a student could genuinely get burned by if they missed them. Only include things with real consequences, not routine facts already obvious from a normal reading of any syllabus. Good candidates: strict attendance/participation policies, harsh or generous late-work rules, academic integrity language that's stricter than usual, prerequisites that aren't just "recommended," any single assignment/exam worth an unusually large chunk of the grade, required communication norms (e.g. "email only through Blackboard," response-time promises), mandatory sessions with no makeup option. Skip generic boilerplate. If the syllabus genuinely has nothing noteworthy in a category, don't force an entry for it - an empty or short list is fine.
+
+Cite specifics from the actual document (numbers, deadlines, exact policy language) rather than vague paraphrases wherever the syllabus states them.`;
+
+export const COURSE_SUMMARY_TOOL: Anthropic.Tool = {
+  name: 'record_course_summary',
+  description: 'Records a course summary and important notes extracted from a syllabus.',
+  input_schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['summary', 'importantNotes'],
+    properties: {
+      summary: {
+        type: 'string',
+        description: '2-4 sentence plain-English summary of the course.',
+      },
+      importantNotes: {
+        type: 'array',
+        description: 'Specific things a student could get burned by if they missed them.',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['category', 'note'],
+          properties: {
+            category: {
+              type: 'string',
+              enum: [
+                'attendance',
+                'grading',
+                'lateWork',
+                'academicIntegrity',
+                'prerequisite',
+                'highStakes',
+                'communication',
+                'other',
+              ],
+            },
+            note: {
+              type: 'string',
+              description: 'One specific, concrete note - cite numbers/deadlines when stated.',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/types/courseSummary.ts
+++ b/src/types/courseSummary.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/** A single thing a student should specifically watch out for - anything
+ * that carries real consequences if missed (a hard deadline policy, a
+ * mandatory session, a grade cliff) rather than routine syllabus content. */
+export const courseSummaryNoteSchema = z.object({
+  category: z.enum([
+    'attendance',
+    'grading',
+    'lateWork',
+    'academicIntegrity',
+    'prerequisite',
+    'highStakes',
+    'communication',
+    'other',
+  ]),
+  note: z.string(),
+});
+
+export const courseSummarySchema = z.object({
+  summary: z.string(),
+  importantNotes: z.array(courseSummaryNoteSchema),
+});
+
+export type CourseSummaryNote = z.infer<typeof courseSummaryNoteSchema>;
+export type CourseSummaryResult = z.infer<typeof courseSummarySchema>;
+
+/** What actually gets stored on Course.aiSummary - the model's output plus
+ * bookkeeping about when/from-what it was generated. */
+export interface CourseAiSummary extends CourseSummaryResult {
+  generatedAt: string;
+  sourceFileName: string;
+}

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,3 +1,5 @@
+import type { CourseAiSummary } from '@/types/courseSummary';
+
 /**
  * How a course's class sessions are held.
  */
@@ -49,6 +51,10 @@ export interface Course {
    * Only suppresses `meetingTimes` occurrences; never affects `ScheduleItem`
    * due dates, since a real deadline shouldn't disappear on a break. */
   skipDates?: string[];
+  /** AI-generated plain-English summary + "important notes" from the most
+   * recently summarized syllabus upload. Cached here rather than
+   * regenerated on every view - see src/app/api/syllabus/summarize. */
+  aiSummary?: CourseAiSummary;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a "Generate" action on a course's Syllabus section that reads the most recently uploaded syllabus (PDF via Claude's native document input, .docx via mammoth text extraction - same pattern as the existing extraction route) and produces:
- A 2-4 sentence plain-English course summary.
- A categorized list of "important notes" - specific things a student could get burned by missing (attendance/late-work policies, high-stakes grade weights, prerequisites, academic integrity language, communication norms), each citing concrete numbers/deadlines from the actual document rather than vague paraphrasing.

Result is tool-forced into a Zod-validated schema (`record_course_summary`, mirroring the existing syllabus-extraction tool pattern) and cached on `Course.aiSummary` via the normal `updateCourse` write, so it's not regenerated on every page view. "Regenerate" re-runs it, and a stale-source note appears if a newer syllabus has been uploaded since the cached summary was generated.

New `/api/syllabus/summarize` route follows the same auth/authorization model as the file proxy from #147: verifies the caller's Firebase ID token and checks the requested `storagePath` is under their own `users/{uid}/` prefix before reading it via the Admin SDK. Reuses the existing daily extraction rate limit rather than adding a separate one.

## Test plan
- [x] `npm run lint` - clean
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` - 186/186 passing
- [x] `npm run build` - clean production build
- [x] Live-verified against the dev-test account with a real course syllabus (CSCI313_Syllabus.pdf): generated a genuinely useful summary + 11 specific important notes (late-work penalty schedule, 24-hour illness-notification window, grade-dispute deadline, exam/project grade weights, prerequisite, academic integrity policy) all citing real numbers from the document. Confirmed the result persists across a full page reload (not just local state).