### PR TITLE
Task rows: colored left-edge instead of icon badge (Direction B)

### DIFF
--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { courseSwatch } from '@/lib/courseColors';
+import { courseBorderColor } from '@/lib/courseColors';
 import type { AssignmentType, Priority } from '@/types/schedule';
 
 const TYPE_ICON_PATH: Record<AssignmentType, string> = {
@@ -13,15 +13,6 @@ const TYPE_ICON_PATH: Record<AssignmentType, string> = {
   reading:
     'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
   other: 'M5 13l4 4L19 7',
-};
-
-/** Priority is intentionally styled separately from workload-level color
- * (load-low/medium/high/critical) so "how urgent I marked this" never gets
- * visually confused with "how much cognitive load this actually is." */
-const PRIORITY_BORDER_CLASS: Record<Priority, string> = {
-  high: 'border-l-primary',
-  medium: 'border-l-border',
-  low: 'border-l-transparent',
 };
 
 export interface TaskRowProps {
@@ -50,9 +41,12 @@ export function TaskRow({
   trailing,
   href,
 }: TaskRowProps) {
+  // A bold, course-colored left edge is the row's primary "which class is
+  // this" signal (Direction B), replacing the old small course-colored icon
+  // badge - the type icon below is now plain/muted instead, so it doesn't
+  // compete with the edge for color attention.
   const rowClass = cn(
-    'flex items-center gap-3 py-2.5 pl-3 border-l-2 first:pt-0 last:pb-0',
-    PRIORITY_BORDER_CLASS[priority],
+    'flex items-center gap-3 py-2.5 pl-3 border-l-4 first:pt-0 last:pb-0',
     href && 'rounded-r-lg transition-colors hover:bg-accent',
   );
 
@@ -68,31 +62,34 @@ export function TaskRow({
           aria-label={`Mark ${title} complete`}
         />
       )}
-      <span
-        className={cn(
-          'h-7 w-7 rounded-lg flex items-center justify-center shrink-0 text-white',
-          courseSwatch(courseColor).className,
-        )}
-        style={courseSwatch(courseColor).style}
-      >
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground">
         <svg
-          className="h-3.5 w-3.5"
+          className="h-4 w-4"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
-          strokeWidth={2}
+          strokeWidth={1.75}
         >
           <path strokeLinecap="round" strokeLinejoin="round" d={TYPE_ICON_PATH[type]} />
         </svg>
       </span>
       <div className="min-w-0 flex-1">
-        <div
-          className={cn(
-            'text-sm font-medium truncate',
-            completed ? 'text-muted-foreground line-through' : 'text-foreground',
+        <div className="flex items-center gap-1.5">
+          {priority === 'high' && !completed && (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+              title="High priority"
+              aria-label="High priority"
+            />
           )}
-        >
-          {title}
+          <div
+            className={cn(
+              'text-sm font-medium truncate',
+              completed ? 'text-muted-foreground line-through' : 'text-foreground',
+            )}
+          >
+            {title}
+          </div>
         </div>
         {courseCode && <div className="text-xs text-muted-foreground">{courseCode}</div>}
       </div>
@@ -106,11 +103,15 @@ export function TaskRow({
 
   if (href) {
     return (
-      <Link href={href} className={rowClass}>
+      <Link href={href} className={rowClass} style={courseBorderColor(courseColor)}>
         {content}
       </Link>
     );
   }
 
-  return <div className={rowClass}>{content}</div>;
+  return (
+    <div className={rowClass} style={courseBorderColor(courseColor)}>
+      {content}
+    </div>
+  );
 }

--- a/src/lib/__tests__/TaskRow.test.tsx
+++ b/src/lib/__tests__/TaskRow.test.tsx
@@ -30,11 +30,17 @@ describe('TaskRow', () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('applies a distinct left-border class per priority', () => {
-    const { container: high } = render(<TaskRow title="High" priority="high" />);
-    const { container: low } = render(<TaskRow title="Low" priority="low" />);
-    expect((high.firstChild as HTMLElement).className).toContain('border-l-primary');
-    expect((low.firstChild as HTMLElement).className).toContain('border-l-transparent');
+  it('colors the left edge from the course color, not priority', () => {
+    const { container } = render(<TaskRow title="Colored edge" courseColor="bg-blue-500" />);
+    expect((container.firstChild as HTMLElement).style.borderLeftColor).toBe('rgb(59, 130, 246)');
+  });
+
+  it('shows a high-priority indicator only for incomplete high-priority tasks', () => {
+    render(<TaskRow title="High" priority="high" />);
+    expect(screen.getByLabelText('High priority')).toBeDefined();
+
+    const { container } = render(<TaskRow title="Low" priority="low" />);
+    expect(container.querySelector('[aria-label="High priority"]')).toBeNull();
   });
 
   it('renders trailing content when provided', () => {

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -103,16 +103,31 @@ export function getCourseChipTintClass(color: string | undefined): string {
   return courseChipTint(color).className || DEFAULT_CHIP_TINT;
 }
 
+/** Resolves any stored course color (a `bg-*` preset class or a custom hex
+ * string) down to a literal hex value - the common step behind both
+ * `courseWash` and `courseBorderColor`, since neither can express "this
+ * preset's color" as a static Tailwind class name (the class needed depends
+ * on runtime data, which Tailwind's static analysis can't see). */
+function resolveCourseHex(color: string | undefined): string {
+  return isCustomColor(color)
+    ? color
+    : (COURSE_COLOR_PRESETS.find((p) => p.value === color)?.hex ?? '#7c3aed');
+}
+
 /** A faint full-surface background wash (course cards, list rows) - subtler
  * than `courseChipTint` (no border, no text-color override, low alpha) so it
  * layers under normal-contrast foreground text instead of competing with it.
  * Always inline (rather than a static Tailwind class) since it needs to
  * resolve a hex value for presets too, not just custom colors. */
 export function courseWash(color: string | undefined, alphaHex = '12'): CSSProperties {
-  const hex = isCustomColor(color)
-    ? color
-    : (COURSE_COLOR_PRESETS.find((p) => p.value === color)?.hex ?? '#7c3aed');
-  return { backgroundColor: `${hex}${alphaHex}` };
+  return { backgroundColor: `${resolveCourseHex(color)}${alphaHex}` };
+}
+
+/** A solid course-colored left border (task/event rows) - same hex
+ * resolution as `courseWash`, full opacity, for a strong "which class is
+ * this" edge instead of a small icon badge. */
+export function courseBorderColor(color: string | undefined): CSSProperties {
+  return { borderLeftColor: resolveCourseHex(color) };
 }
 
 /**


### PR DESCRIPTION
## Summary
Per the redesign artifact's own propagation note for Direction B ("Task rows get a colored left-edge instead of a small icon badge").

- `TaskRow`'s course-colored icon badge is replaced with a bold (4px) course-colored left border - same "which class is this" signal, but reading at a glance the way the rest of the redesign already treats course color as a real surface rather than a small dot.
- The type icon becomes plain/muted (no colored background) now that color isn't competing there.
- Priority - previously encoded via the left border's color (`border-l-primary` for high) - moves to a small dot next to the title for incomplete high-priority tasks, since the left edge is now the course's.
- New `courseBorderColor()` in `courseColors.ts` resolves a course's stored color (preset class or custom hex) to a literal hex for the border, sharing the same preset-hex lookup `courseWash()` already used.

`TaskRow` is used on Dashboard, Planner, Tasks list, and Course detail - all already pass `courseColor`, so no call-site changes were needed.

## Test plan
- [x] `npm run lint` - clean
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` - 187/187 passing (updated the priority-border test to match the new left-edge/priority-dot split)
- [x] `npm run build` - clean production build
- [x] Live-verified against the dev-test account across all four consuming pages: Tasks list, Dashboard's Upcoming Tasks, Planner (hero + forecast list), Course detail's Tasks section.