### PR TITLE
Fix Dashboard Courses stat ignoring the selected term

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -188,7 +188,7 @@ export function DashboardView() {
             </ProgressRing>
             <div className="grid w-full grid-cols-3 gap-2 text-center">
               <div>
-                <div className="text-lg font-bold text-primary">{courses.length}</div>
+                <div className="text-lg font-bold text-primary">{semesterCourses.length}</div>
                 <div className="text-[10px] text-muted-foreground">Courses</div>
               </div>
               <div>


### PR DESCRIPTION
## Summary
The progress-ring's Courses count read `courses.length` (every course across every term) instead of `semesterCourses.length`, the same term-scoped list Course Load already used - so it stayed at the all-terms total no matter what the term dropdown was set to, while Pending/Done right next to it correctly changed.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` - clean
- [x] `npx vitest run` - 187/187 passing
- [x] `npm run build` - clean production build
- [x] Live-verified: switching the term dropdown from All Terms to Spring 2026 moves Courses 10 -> 6, matching the courses actually listed in Course Load below it.