### PR TITLE
Add reduced-motion support and a dark-mode modal elevation tier

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,6 +39,18 @@
     --card-shadow: 0 1px 2px rgba(16, 12, 30, 0.04), 0 10px 28px -8px rgba(91, 61, 245, 0.16);
     --card-shadow-hover:
       0 2px 4px rgba(16, 12, 30, 0.06), 0 18px 40px -10px rgba(91, 61, 245, 0.28);
+
+    /* Modal v1: a distinct elevation tier for true modal-overlay surfaces
+       (dialogs, sheets) that sit above cards in the stack. In light mode a
+       modal reads as "lifted" the same way a card does, so this falls back
+       to the same value as --card-shadow rather than inventing a second
+       light-mode look. */
+    --modal-shadow: var(--card-shadow);
+
+    /* Popover tier: reserved, unused. There's no custom dropdown/popover
+       component in this app yet (TermSwitcher etc. are native <select>
+       elements, which can't be styled with a custom box-shadow), so this
+       token intentionally has no consumer today. */
   }
 
   .dark {
@@ -79,6 +91,11 @@
        dark blur (which is nearly invisible against an already-dark page). */
     --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 10px 28px -8px rgba(139, 92, 246, 0.35);
     --card-shadow-hover: 0 2px 4px rgba(0, 0, 0, 0.5), 0 18px 40px -10px rgba(139, 92, 246, 0.5);
+
+    /* Modal v1: distinct from --card-shadow - a deeper, darker near shadow
+       plus a wider brand-tinted glow, so a modal reads as sitting above the
+       card tier instead of sharing its elevation. */
+    --modal-shadow: 0 4px 8px rgba(0, 0, 0, 0.5), 0 24px 60px -12px rgba(139, 92, 246, 0.45);
   }
 }
 
@@ -143,5 +160,21 @@
   .dark .glass {
     background-color: rgba(18, 18, 24, 0.94);
     border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  /* Respect the OS-level "reduce motion" preference by collapsing every
+     animation/transition down to effectively-instant. Duration is set to
+     0.01ms rather than 0 so animationend/transitionend listeners still fire
+     (some components depend on them to flip state after a transition).
+     Loading spinners (.animate-spin, Tailwind's own utility) are explicitly
+     exempted - freezing an in-progress spinner reads as "the app is stuck",
+     not as "calm", so those keep spinning regardless of this preference. */
+  @media (prefers-reduced-motion: reduce) {
+    *:not(.animate-spin, .animate-spin *) {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -459,7 +459,7 @@ export function MonthCalendar() {
               role="dialog"
               aria-modal="true"
               aria-label="Filters"
-              className="relative z-10 flex max-h-[80vh] w-full flex-col rounded-t-2xl border-t border-border bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-2xl"
+              className="relative z-10 flex max-h-[80vh] w-full flex-col rounded-t-2xl border-t border-border bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-modal"
             >
               <div className="mx-auto mb-3 h-1.5 w-10 shrink-0 rounded-full bg-border" />
               <div className="mb-4 flex items-center justify-between">

--- a/src/components/syllabus/DocumentViewerModal.tsx
+++ b/src/components/syllabus/DocumentViewerModal.tsx
@@ -182,7 +182,7 @@ export function DocumentViewerModal({ syllabus, onClose }: DocumentViewerModalPr
         role="dialog"
         aria-modal="true"
         aria-label={syllabus.fileName}
-        className="flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl"
+        className="flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-modal"
       >
         {/* Toolbar */}
         <div className="flex shrink-0 items-center gap-3 border-b border-border bg-card px-4 py-2.5">

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -367,7 +367,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         className="max-h-full w-full max-w-3xl overflow-y-auto outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-2xl">
+        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
           <div className="bg-gradient-brand px-6 py-6 text-white sm:px-8">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
               Syllabus Autofill

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,9 @@ const config: Config = {
         // (globals.css) so the same class works in light and dark.
         card: 'var(--card-shadow)',
         'card-hover': 'var(--card-shadow-hover)',
+        // Modal v1: a distinct, deeper elevation tier for true modal-overlay
+        // surfaces (dialogs, sheets), theme-aware via --modal-shadow.
+        modal: 'var(--modal-shadow)',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds a global `prefers-reduced-motion: reduce` override in `src/app/globals.css` that collapses animation/transition durations to `0.01ms` (not `0`, so `animationend`/`transitionend` listeners still fire) and forces `scroll-behavior: auto`. Loading spinners (`.animate-spin`, Tailwind's utility, used in `SyllabusAutofillModal.tsx` / `DocumentViewerModal.tsx`) are explicitly exempted via `:not(.animate-spin, .animate-spin *)` so they keep spinning instead of reading as "stuck".
- Adds a second dark-mode elevation tier, `--modal-shadow`, distinct from the existing `--card-shadow` (Card v2) — a deeper near shadow plus a wider brand-tinted glow so modals read as sitting above cards in the stack. Light mode falls back to the same value as `--card-shadow` (unchanged look). Wired into `tailwind.config.ts` as a `shadow-modal` utility, alongside the existing `shadow-card` / `shadow-card-hover`. A `--popover-shadow`-style tier is intentionally *not* added — there's no custom dropdown/popover component in the app yet (comment left in place noting this).
- Swapped the flat `shadow-2xl` utility for the new `shadow-modal` on the three genuine modal-overlay surfaces found via grep across `src/components/**/*.tsx`: `SyllabusAutofillModal.tsx`, `DocumentViewerModal.tsx`, and `MonthCalendar.tsx`'s filter bottom sheet (`role="dialog" aria-modal="true"`). No other `shadow-2xl` usages exist in the codebase.

## Test plan

- [x] `npm run lint` — no warnings or errors
- [x] `npx tsc --noEmit` — clean (two pre-existing, unrelated `workload.test.ts` errors confirmed present on the base branch before this change)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 25 test files / 215 tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_