### PR TITLE
Add brand-gradient extraction spinner and staggered syllabus review reveal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,6 +124,42 @@
     color: transparent;
   }
 
+  /* Brand-gradient spinner ring: same purple-to-teal stops as
+     .bg-gradient-brand, painted as a conic sweep and masked down to a ring
+     (rather than a filled disc) so it drops into the same
+     `animate-spin`-timed element the flat border-t-primary ring used to
+     occupy. The mask's inner radius matches that ring's old 3px stroke. */
+  .spinner-gradient {
+    background-image: conic-gradient(
+      from 0deg,
+      #8c6eff 0%,
+      #5b3df5 55%,
+      #00bfa0 100%,
+      #8c6eff 100%
+    );
+    -webkit-mask-image: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+    mask-image: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+  }
+
+  /* Staggered entrance for the syllabus autofill review list: each
+     course/meeting/materials/assignment row fades and lifts in on its own
+     delay (set inline per-row) instead of the whole review screen mounting
+     in one synchronous paint. `both` fill mode holds the 0%-keyframe state
+     through the delay so rows don't flash visible before their turn. */
+  @keyframes syllabus-review-reveal {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .review-reveal {
+    animation: syllabus-review-reveal 250ms ease-out both;
+  }
+
   /* Used on the fixed Navbar, which sits above scrolling page content -
      content with a strong, saturated color (e.g. Profile's cover-banner
      gradient) can pass directly underneath it. 94% opacity alone already

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -456,7 +456,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
             {step === 'extracting' && (
               <div className="flex flex-col items-center justify-center gap-4 py-16">
                 <div className="relative h-12 w-12">
-                  <div className="absolute inset-0 animate-spin rounded-full border-[3px] border-primary/15 border-t-primary" />
+                  <div className="spinner-gradient absolute inset-0 animate-spin rounded-full" />
                 </div>
                 <div className="text-center">
                   <p className="text-sm font-semibold text-foreground">
@@ -471,7 +471,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
             {(step === 'review' || step === 'saving') && course && (
               <div className="space-y-6">
-                <section className="space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5">
+                <section
+                  className="review-reveal space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5"
+                  style={{ animationDelay: '0ms' }}
+                >
                   <div className="flex items-start gap-3">
                     <span
                       className={cn(
@@ -629,7 +632,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 </section>
 
                 {course.meetingTimes.length > 0 && (
-                  <section className="space-y-2">
+                  <section className="review-reveal space-y-2" style={{ animationDelay: '60ms' }}>
                     <h3 className="text-sm font-semibold text-foreground">Meeting times</h3>
                     {course.meetingTimes.map((m, i) => (
                       <div
@@ -679,7 +682,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 )}
 
                 {course.materials.length > 0 && (
-                  <section className="space-y-2">
+                  <section className="review-reveal space-y-2" style={{ animationDelay: '120ms' }}>
                     <h3 className="text-sm font-semibold text-foreground">
                       Materials &amp; supplies
                     </h3>
@@ -705,7 +708,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 )}
 
                 <section className="space-y-3">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div
+                    className="review-reveal flex flex-wrap items-center justify-between gap-2"
+                    style={{ animationDelay: '180ms' }}
+                  >
                     <h3 className="text-sm font-semibold text-foreground">
                       Assignments
                       <span className="ml-1.5 font-normal text-muted-foreground">
@@ -755,20 +761,24 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     )}
                   </div>
                   {items.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">
+                    <p
+                      className="review-reveal text-xs text-muted-foreground"
+                      style={{ animationDelay: '220ms' }}
+                    >
                       No dated items found in this syllabus.
                     </p>
                   ) : (
                     <div className="space-y-2">
-                      {items.map((it) => (
+                      {items.map((it, i) => (
                         <div
                           key={it.key}
                           className={cn(
-                            'rounded-xl border p-3 text-xs transition-colors',
+                            'review-reveal rounded-xl border p-3 text-xs transition-colors',
                             it.approved
                               ? 'border-border bg-card'
                               : 'border-dashed border-border/70 bg-transparent opacity-60',
                           )}
+                          style={{ animationDelay: `${Math.min(220 + i * 40, 580)}ms` }}
                         >
                           <div className="flex flex-wrap items-center gap-2">
                             <div className="flex shrink-0 overflow-hidden rounded-full border border-border">
@@ -858,7 +868,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 </section>
 
                 {unresolved.length > 0 && (
-                  <section className="rounded-xl border border-load-medium/30 bg-load-medium/10 p-3">
+                  <section
+                    className="review-reveal rounded-xl border border-load-medium/30 bg-load-medium/10 p-3"
+                    style={{ animationDelay: '580ms' }}
+                  >
                     <h3 className="text-xs font-semibold text-load-medium">
                       Couldn&apos;t determine
                     </h3>


### PR DESCRIPTION
## Summary

- **Extraction spinner**: replaces the flat `border-t-primary` spinning ring in `SyllabusAutofillModal`'s loading phase with a masked conic-gradient ring using the brand's purple→teal stops (`#8c6eff → #5b3df5 → #00bfa0`, same as `.bg-gradient-brand`/`.text-gradient-brand`). New `.spinner-gradient` utility in `globals.css`; the element keeps its existing `animate-spin` (1s linear) timing — only the fill/stroke treatment changed. Shipped as the new default, no toggle.
- **Staggered review reveal**: the review-phase list (course details, meeting times, materials, and assignment rows) now fades/slides in (`opacity 0→1`, `translateY(8px)→0`, `250ms ease-out`) instead of mounting in one synchronous paint. Header-level sections stagger 0–180ms; assignment rows stagger `220ms + index * 40ms`, capped at `580ms`. New `.review-reveal` + `@keyframes syllabus-review-reveal` in `globals.css`, applied via per-row inline `animationDelay` in the component. Only the review-phase list is touched — the loading/extraction phase (aside from the spinner) and the error state are untouched.

**Note:** an earlier "glow behind the dashboard greeting" idea was proposed and explicitly **rejected** in design review — it is intentionally **not** implemented here, and `DashboardView.tsx` (and the dashboard greeting generally) is untouched by this PR.

## Files touched
- `src/app/globals.css`
- `src/components/syllabus/SyllabusAutofillModal.tsx`

## Test plan
- [x] `npm run lint` — no warnings or errors
- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated errors in `workload.test.ts` confirmed present on the base branch too)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 215/215 tests passing across 25 files
- [x] Manual read-through of the modal's extraction and review phases to confirm only the spinner fill and review-list entrance were touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_