### PR TITLE
Replace mobile hamburger drawer with a 5-tab bottom bar

### DIFF
--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -6,6 +6,7 @@ import { AppStateProvider } from '@/context/AppStateContext';
 import AuthGuard from '@/components/auth/AuthGuard';
 import Navbar from './Navbar';
 import Sidebar from './Sidebar';
+import MobileTabBar from './MobileTabBar';
 import FirestoreSync from './FirestoreSync';
 
 export default function LayoutWrapper({ children }: { children: React.ReactNode }) {
@@ -18,10 +19,11 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
             <Navbar />
             <div className="flex flex-1 pt-20">
               <Sidebar />
-              <main className="flex-1 p-6 md:pl-72 md:p-8 max-w-7xl transition-all duration-300">
+              <main className="flex-1 p-6 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pl-72 md:p-8 md:pb-8 max-w-7xl transition-all duration-300">
                 {children}
               </main>
             </div>
+            <MobileTabBar />
           </div>
         </AppStateProvider>
       </SidebarProvider>

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+interface TabItem {
+  name: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const tabItems: TabItem[] = [
+  {
+    name: 'Dashboard',
+    href: '/dashboard',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Courses',
+    href: '/courses',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Tasks',
+    href: '/tasks',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Calendar',
+    href: '/calendar',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        />
+      </svg>
+    ),
+  },
+];
+
+const moreItems: TabItem[] = [
+  {
+    name: 'Planner',
+    href: '/planner',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10M4 18h7" />
+      </svg>
+    ),
+  },
+  {
+    name: 'Profile',
+    href: '/profile',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+        />
+      </svg>
+    ),
+  },
+];
+
+function TabLink({ item, isActive }: { item: TabItem; isActive: boolean }) {
+  return (
+    <Link
+      href={item.href}
+      className={cn(
+        'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors',
+        isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
+      )}
+      aria-current={isActive ? 'page' : undefined}
+    >
+      {item.icon}
+      <span>{item.name}</span>
+      <span
+        className={cn(
+          'h-[3px] w-[3px] rounded-full bg-primary transition-opacity',
+          isActive ? 'opacity-100' : 'opacity-0',
+        )}
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}
+
+export default function MobileTabBar() {
+  const pathname = usePathname();
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+
+  const isMoreActive = moreItems.some((item) => pathname === item.href);
+
+  return (
+    <>
+      {/* Backdrop for the "More" popover — closes on tap-outside */}
+      {isMoreOpen && (
+        <div
+          className="fixed inset-0 z-[55] bg-transparent md:hidden"
+          onClick={() => setIsMoreOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <nav
+        className="fixed bottom-0 left-0 right-0 z-50 flex h-16 items-stretch border-t border-border/40 bg-card/80 glass pb-[env(safe-area-inset-bottom)] md:hidden"
+        aria-label="Primary"
+      >
+        {tabItems.map((item) => (
+          <TabLink key={item.href} item={item} isActive={pathname === item.href} />
+        ))}
+
+        <div className="relative flex flex-1">
+          {isMoreOpen && (
+            <div
+              className="absolute bottom-full right-0 z-[56] mb-2 w-40 overflow-hidden rounded-xl border border-border/40 bg-card glass shadow-glass"
+              role="menu"
+            >
+              {moreItems.map((item) => {
+                const isActive = pathname === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setIsMoreOpen(false)}
+                    role="menuitem"
+                    className={cn(
+                      'flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors',
+                      isActive
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+                    )}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {item.icon}
+                    <span>{item.name}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => setIsMoreOpen((prev) => !prev)}
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors',
+              isMoreOpen || isMoreActive
+                ? 'text-primary'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            aria-haspopup="menu"
+            aria-expanded={isMoreOpen}
+            aria-label="More navigation options"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 12h.01M12 12h.01M18 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm6 0a1 1 0 11-2 0 1 1 0 012 0zm6 0a1 1 0 11-2 0 1 1 0 012 0z"
+              />
+            </svg>
+            <span>More</span>
+            <span
+              className={cn(
+                'h-[3px] w-[3px] rounded-full bg-primary transition-opacity',
+                isMoreActive ? 'opacity-100' : 'opacity-0',
+              )}
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,14 +3,12 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useSidebar } from './SidebarContext';
 import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
 
 export default function Navbar() {
-  const { toggle } = useSidebar();
   const { resolvedTheme, setTheme } = useTheme();
   const { user, signOut } = useAuth();
   const router = useRouter();
@@ -28,23 +26,6 @@ export default function Navbar() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 h-20 glass border-b border-border/40 bg-card/80 flex items-center justify-between px-3 sm:px-6">
       <div className="flex items-center gap-2 sm:gap-4">
-        {/* Mobile Hamburger Button */}
-        <button
-          onClick={toggle}
-          className="p-2 rounded-md hover:bg-accent text-foreground md:hidden focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
-          aria-label="Toggle Navigation Menu"
-        >
-          <svg
-            className="h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-
         {/* Logo / App Name */}
         <Link
           href="/"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useSidebar } from './SidebarContext';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -14,7 +13,6 @@ interface NavItem {
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const { isOpen, setIsOpen } = useSidebar();
 
   const navItems: NavItem[] = [
     {
@@ -130,45 +128,28 @@ export default function Sidebar() {
   ];
 
   return (
-    <>
-      {/* Mobile Sidebar Overlay Backdrop */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm md:hidden"
-          onClick={() => setIsOpen(false)}
-        />
-      )}
-
-      {/* Sidebar Drawer Container */}
-      <aside
-        className={cn(
-          'fixed top-20 bottom-0 left-0 z-[45] w-64 border-r border-border/40 bg-card/90 glass transition-transform duration-300 md:translate-x-0 md:flex md:flex-col',
-          isOpen ? 'translate-x-0' : '-translate-x-full',
-        )}
-      >
-        <nav className="flex-1 space-y-1 px-4 py-6">
-          {navItems.map((item) => {
-            const isActive = pathname === item.href;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setIsOpen(false)}
-                className={cn(
-                  'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200',
-                  isActive
-                    ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                )}
-                aria-current={isActive ? 'page' : undefined}
-              >
-                {item.icon}
-                <span>{item.name}</span>
-              </Link>
-            );
-          })}
-        </nav>
-      </aside>
-    </>
+    <aside className="hidden md:flex fixed top-20 bottom-0 left-0 z-[45] w-64 flex-col border-r border-border/40 bg-card/90 glass">
+      <nav className="flex-1 space-y-1 px-4 py-6">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200',
+                isActive
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              )}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {item.icon}
+              <span>{item.name}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a real mobile bottom tab bar (`MobileTabBar.tsx`): Dashboard, Courses, Tasks, Calendar, plus a 5th **More** tab (ellipsis) that opens a small anchored popover with Planner and Profile — closes on tap-outside via a transparent backdrop.
- Removes the mobile hamburger + full-drawer `Sidebar` path entirely on mobile. A first design draft kept the full 6-item drawer open underneath a 4-tab bar; that was rejected in review because it put the same routes on screen twice at once (the tab bar's own items duplicated inside the still-open drawer). This PR avoids that bug by construction — mobile now shows exactly one navigation surface, the 5-tab bar, and the drawer element itself no longer renders below `md:`.
- Desktop nav is untouched: `Navbar`'s desktop controls and `Sidebar`'s `nav`/`navItems`/active-link styling are unchanged, only now rendered via `hidden md:flex` instead of a translate-based drawer.
- Wires `MobileTabBar` into `LayoutWrapper` and adds mobile-only bottom padding to `main` so content isn't covered by the fixed bar (`pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pb-8`).
- Cleans up now-dead `useSidebar`/`toggle`/`isOpen`/`setIsOpen` usage in `Navbar.tsx` and `Sidebar.tsx`; `SidebarContext.tsx` is left in place per instructions.

## Files touched

- `src/components/layout/MobileTabBar.tsx` (new)
- `src/components/layout/Navbar.tsx`
- `src/components/layout/Sidebar.tsx`
- `src/components/layout/LayoutWrapper.tsx`

## Test plan

- [x] `npm run lint` — no warnings or errors
- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated `workload.test.ts` downlevel-iteration errors confirmed present on the base branch before this change too)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 25 test files / 215 tests passed, including the existing `Sidebar.test.tsx` active-route-highlighting tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_