### PR TITLE
Give the dashboard a real visual hierarchy: Tasks as primary, Course Load as secondary

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -179,37 +179,88 @@ export function DashboardView() {
           </div>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-[15rem_1fr]">
-          <Card accent className="flex flex-col items-center justify-center gap-4 rounded-2xl p-6">
-            <ProgressRing percent={termProgressPct} size={116} strokeWidth={10}>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-foreground">{termProgressPct}%</div>
-                <div className="text-[10px] text-muted-foreground">progress</div>
+        <div className="space-y-4">
+          <Card accent="left" className="rounded-2xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-3">
+                <SectionIcon icon="tasks" />
+                <h2 className="text-lg font-bold text-foreground">Upcoming Tasks</h2>
+                {overdueCount > 0 && (
+                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                    {overdueCount} overdue
+                  </span>
+                )}
               </div>
-            </ProgressRing>
-            <div className="grid w-full grid-cols-3 gap-2 text-center">
-              <div>
-                <div className="text-lg font-bold text-primary">{semesterCourses.length}</div>
-                <div className="text-[10px] text-muted-foreground">Courses</div>
-              </div>
-              <div>
-                <div className="text-lg font-bold text-load-medium">{pendingTasks.length}</div>
-                <div className="text-[10px] text-muted-foreground">Pending</div>
-              </div>
-              <div>
-                <div className="text-lg font-bold text-load-low">{completedTasksCount}</div>
-                <div className="text-[10px] text-muted-foreground">Done</div>
+              <div className="flex items-center gap-2">
+                <CardActionLink href="/tasks" withChevron>
+                  View all
+                </CardActionLink>
+                <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
+                  Add Task
+                </CardActionButton>
               </div>
             </div>
+            {upcomingTasks.length === 0 ? (
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                }
+                title="Nothing due"
+                description="You're all caught up."
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {upcomingTasks.map((item) => {
+                  const course = courses.find((c) => c.id === item.courseId);
+                  const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
+                  return (
+                    <TaskRow
+                      key={item.id}
+                      variant={state.preferences.taskRowVariant}
+                      title={item.title}
+                      href={'/tasks/' + item.id}
+                      type={item.type}
+                      courseCode={course ? course.code : 'General'}
+                      courseColor={course?.color}
+                      courseIcon={course?.icon}
+                      completed={item.completed}
+                      progress={item.progress}
+                      priority={item.priority}
+                      onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                      trailing={
+                        <>
+                          {overdue && (
+                            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                              Overdue
+                            </span>
+                          )}
+                          <span className="text-xs text-muted-foreground">
+                            Due {dueDateFormatter.format(new Date(item.dueDate))}
+                          </span>
+                        </>
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
           </Card>
 
-          <div className="flex flex-col gap-4">
-            <Card className="rounded-2xl p-6">
-              <div className="flex items-center justify-between mb-5">
-                <div className="flex items-center gap-3">
-                  <SectionIcon icon="courseLoad" />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Card className="rounded-2xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2.5">
+                  <SectionIcon icon="courseLoad" className="h-6 w-6" />
                   <div>
-                    <h2 className="text-base font-semibold text-foreground">Course Load</h2>
+                    <h2 className="text-sm font-semibold text-foreground">Course Load</h2>
                     {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
                   </div>
                 </div>
@@ -278,78 +329,34 @@ export function DashboardView() {
               )}
             </Card>
 
-            <Card className="rounded-2xl p-6">
-              <div className="flex items-center justify-between mb-3">
-                <div className="flex items-center gap-3">
-                  <SectionIcon icon="tasks" />
-                  <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
-                  {overdueCount > 0 && (
-                    <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                      {overdueCount} overdue
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <CardActionLink href="/tasks" withChevron>
-                    View all
-                  </CardActionLink>
-                  <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
-                    Add Task
-                  </CardActionButton>
+            <Card className="rounded-2xl p-4">
+              <div className="mb-3 flex items-center gap-2.5">
+                <SectionIcon icon="star" className="h-6 w-6" />
+                <h2 className="text-sm font-semibold text-foreground">Term Progress</h2>
+              </div>
+              <div className="flex items-center gap-4">
+                <ProgressRing percent={termProgressPct} size={80} strokeWidth={7}>
+                  <div className="text-center">
+                    <div className="text-lg font-bold text-foreground">{termProgressPct}%</div>
+                  </div>
+                </ProgressRing>
+                <div className="grid flex-1 grid-cols-3 gap-2 text-center">
+                  <div>
+                    <div className="text-base font-bold text-primary">{semesterCourses.length}</div>
+                    <div className="text-[10px] text-muted-foreground">Courses</div>
+                  </div>
+                  <div>
+                    <div className="text-base font-bold text-load-medium">
+                      {pendingTasks.length}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground">Pending</div>
+                  </div>
+                  <div>
+                    <div className="text-base font-bold text-load-low">{completedTasksCount}</div>
+                    <div className="text-[10px] text-muted-foreground">Done</div>
+                  </div>
                 </div>
               </div>
-              {upcomingTasks.length === 0 ? (
-                <EmptyState
-                  icon={
-                    <svg
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  }
-                  title="Nothing due"
-                  description="You're all caught up."
-                />
-              ) : (
-                <div className="flex flex-col gap-2">
-                  {upcomingTasks.map((item) => {
-                    const course = courses.find((c) => c.id === item.courseId);
-                    const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
-                    return (
-                      <TaskRow
-                        key={item.id}
-                        variant={state.preferences.taskRowVariant}
-                        title={item.title}
-                        href={'/tasks/' + item.id}
-                        type={item.type}
-                        courseCode={course ? course.code : 'General'}
-                        courseColor={course?.color}
-                        courseIcon={course?.icon}
-                        completed={item.completed}
-                        progress={item.progress}
-                        priority={item.priority}
-                        onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
-                        trailing={
-                          <>
-                            {overdue && (
-                              <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                                Overdue
-                              </span>
-                            )}
-                            <span className="text-xs text-muted-foreground">
-                              Due {dueDateFormatter.format(new Date(item.dueDate))}
-                            </span>
-                          </>
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              )}
             </Card>
           </div>
         </div>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -4,13 +4,20 @@ import { cn } from '@/lib/utils';
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   hoverable?: boolean;
-  /** Renders a brand-gradient bar along the card's top edge. */
-  accent?: boolean;
+  /**
+   * Renders a brand accent marking this card as visually important.
+   * `true` (or `"top"`) draws a gradient bar along the top edge; `"left"`
+   * draws a solid primary-colored border down the left edge instead - used
+   * to promote a single card as the dominant/primary one in a section.
+   */
+  accent?: boolean | 'top' | 'left';
 }
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, children, interactive, hoverable, accent, ...props }, ref) => {
     const isInteractive = interactive || hoverable;
+    const accentTop = accent === true || accent === 'top';
+    const accentLeft = accent === 'left';
     return (
       <div
         ref={ref}
@@ -18,11 +25,12 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
           'relative rounded-glass border border-border bg-card/90 backdrop-blur-md shadow-card overflow-hidden',
           isInteractive &&
             'transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-card-hover',
+          accentLeft && 'border-l-[3px] border-l-primary',
           className,
         )}
         {...props}
       >
-        {accent && <div className="absolute inset-x-0 top-0 h-1 bg-gradient-brand" />}
+        {accentTop && <div className="absolute inset-x-0 top-0 h-1 bg-gradient-brand" />}
         {children}
       </div>
     );


### PR DESCRIPTION
## Summary

This is a **second attempt** at giving the dashboard a real visual hierarchy — the first draft just resized columns/fonts inside the same `grid-cols-[15rem_1fr]` shape and still read as three same-weight sibling cards. This one is structurally different:

- Removed the `md:grid-cols-[15rem_1fr]` two-column layout entirely.
- **Upcoming Tasks** is now a full-width primary card, first in the block, promoted with a left accent border (new `accent="left"` variant on `Card`, alongside the existing top-gradient-bar `accent`) and a bolder `text-lg font-bold` heading. Its content (overdue badge, actions, `TaskRow` list, `EmptyState` fallback) is unchanged.
- **Course Load** and the **term-progress stat** (`ProgressRing` + Courses/Pending/Done) are demoted into two compact, quieter tiles in a `grid gap-4 sm:grid-cols-2` row below: no accent border, `text-sm font-semibold` headings, `p-4` padding, smaller ring/stat sizing. Existing content and logic for both are unchanged.
- Everything below this block (7-Day Load, Planner Preview, "View full calendar") is untouched.
- No data-logic changes — `termProgressPct`, `pendingTasks`, `overdueCount`, `courseLoad`, `upcomingTasks`, modals, and handlers are all identical to before.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated errors in `workload.test.ts` confirmed present on the base branch before this change)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 25 test files / 215 tests pass (no dedicated `DashboardView` tests exist to update)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_