### PR TITLE
Add dramatic task-completion animation, 44px touch targets, and single-glyph priority indicators

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,6 +111,95 @@
     }
   }
 
+  /* Task-completion micro-interaction (TaskRow checkboxes, both the card
+     and touch variants): checking a task plays a pop + two staggered
+     ripple rings + a checkmark reveal + a brief row-background glow, all
+     keyed off hsl(var(--primary)) - deliberately NOT the load-level green
+     (--load-low), which already means "workload is light" elsewhere and
+     would send the wrong signal reused here. Unchecking is intentionally
+     understated (fast fade, no ripple, no glow) so undoing a task never
+     reads as an accomplishment. The checkmark reveals via opacity+scale,
+     not a stroke-dasharray "draw" - at the ~11-16px real render size a
+     dasharray draw looked like a distorted blob in an earlier pass.
+     `prefers-reduced-motion` handling lives in a sibling PR that zeroes
+     animation/transition durations globally, so nothing extra is needed
+     here. */
+  @keyframes task-check-pop {
+    0% {
+      transform: scale(1);
+    }
+    40% {
+      transform: scale(1.35);
+    }
+    70% {
+      transform: scale(0.96);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  .animate-task-check-pop {
+    animation: task-check-pop 480ms ease-in-out;
+  }
+
+  @keyframes task-check-ripple {
+    0% {
+      transform: scale(0.6);
+      opacity: 0.55;
+    }
+    100% {
+      transform: scale(2.4);
+      opacity: 0;
+    }
+  }
+  .animate-task-check-ripple {
+    animation: task-check-ripple 500ms ease-out;
+  }
+  .animate-task-check-ripple-delayed {
+    animation: task-check-ripple 500ms ease-out 80ms;
+    animation-fill-mode: both;
+  }
+
+  @keyframes task-check-mark-in {
+    0% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  .animate-task-check-mark-in {
+    animation: task-check-mark-in 150ms ease-out 70ms both;
+  }
+
+  @keyframes task-check-mark-out {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+  }
+  .animate-task-check-mark-out {
+    animation: task-check-mark-out 100ms ease-in both;
+  }
+
+  @keyframes task-row-glow {
+    0% {
+      background-color: hsl(var(--primary) / 0.08);
+    }
+    100% {
+      background-color: hsl(var(--primary) / 0);
+    }
+  }
+  .animate-task-row-glow {
+    animation: task-row-glow 500ms ease-out;
+  }
+
   /* Matches the Logo mark's own gradient (Logo.tsx) so brand color isn't
      confined to the icon - hero panels, progress rings, and CTAs can pick up
      the same identity. */

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { courseChipTint, courseSwatch, courseWash } from '@/lib/courseColors';
@@ -15,6 +17,40 @@ const TYPE_LABEL: Record<AssignmentType, string> = {
   reading: 'Reading',
   other: 'Other',
 };
+
+type CheckAnimState = 'idle' | 'checked' | 'unchecked';
+
+/** Time to hold the 'checked' animation state open: long enough for the
+ * pop (480ms), the later of the two staggered ripple rings (80ms delay +
+ * 500ms = 580ms), and the checkmark reveal (70ms delay + 150ms = 220ms) to
+ * all finish before the transient classes are torn down. */
+const CHECK_ANIM_HOLD_MS = 580;
+const UNCHECK_ANIM_HOLD_MS = 100;
+
+/** Tracks the transient completion-animation state for a checkbox:
+ * 'checked' for a moment right after a task is marked done (pop + ripple +
+ * checkmark reveal + row glow), 'unchecked' for a moment right after it's
+ * marked undone (quick checkmark fade, no ripple/glow), 'idle' otherwise.
+ * Skips animating on first mount so a task that's already completed when
+ * the row renders doesn't replay the completion animation. */
+function useCheckAnimState(completed: boolean): CheckAnimState {
+  const [animState, setAnimState] = useState<CheckAnimState>('idle');
+  const prevCompleted = useRef(completed);
+
+  useEffect(() => {
+    if (prevCompleted.current === completed) return;
+    prevCompleted.current = completed;
+    const nextState: CheckAnimState = completed ? 'checked' : 'unchecked';
+    setAnimState(nextState);
+    const timer = setTimeout(
+      () => setAnimState('idle'),
+      completed ? CHECK_ANIM_HOLD_MS : UNCHECK_ANIM_HOLD_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [completed]);
+
+  return animState;
+}
 
 export interface TaskRowProps {
   title: string;
@@ -162,31 +198,83 @@ function CardRow({
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
+  const checkAnim = useCheckAnimState(completed);
   const rowClass = cn(
     'flex items-start gap-3 rounded-xl border border-border/60 p-3',
     href && 'transition-colors hover:border-border',
+    checkAnim === 'checked' && 'animate-task-row-glow',
   );
 
   const content = (
     <>
       {onToggleComplete && (
-        <input
-          type="checkbox"
-          checked={completed}
-          onChange={onToggleComplete}
+        <label
+          className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
           onClick={(e) => e.stopPropagation()}
-          className="mt-0.5 h-4 w-4 shrink-0 rounded border-border accent-primary"
-          aria-label={`Mark ${title} complete`}
-        />
+        >
+          <input
+            type="checkbox"
+            checked={completed}
+            onChange={onToggleComplete}
+            className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label={`Mark ${title} complete`}
+          />
+          {checkAnim === 'checked' && (
+            <>
+              <span
+                aria-hidden="true"
+                className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+              />
+              <span
+                aria-hidden="true"
+                className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+              />
+            </>
+          )}
+          <span
+            className={cn(
+              'flex h-4 w-4 items-center justify-center rounded border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
+              completed && 'border-primary bg-primary',
+              checkAnim === 'checked' && 'animate-task-check-pop',
+            )}
+          >
+            {(completed || checkAnim === 'unchecked') && (
+              <svg
+                className={cn(
+                  'h-2.5 w-2.5 stroke-primary-foreground',
+                  checkAnim === 'checked' && 'animate-task-check-mark-in',
+                  checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                )}
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={4}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </span>
+        </label>
       )}
       <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={7} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           {priority === 'high' && !completed && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
-              title="High priority"
+            <svg
+              className="h-2 w-2 shrink-0"
+              viewBox="0 0 12 12"
+              role="img"
               aria-label="High priority"
+            >
+              <title>High priority</title>
+              <path d="M6 1l5 9H1z" fill="hsl(var(--primary))" />
+            </svg>
+          )}
+          {priority === 'medium' && !completed && (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/70"
+              title="Medium priority"
+              aria-label="Medium priority"
             />
           )}
           <div
@@ -250,9 +338,11 @@ function TouchRow({
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
+  const checkAnim = useCheckAnimState(completed);
   const outerClass = cn(
     'flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-accent/30',
     href && 'transition-colors hover:bg-accent/50',
+    checkAnim === 'checked' && 'animate-task-row-glow',
   );
   const swatch = courseSwatch(courseColor);
 
@@ -262,7 +352,7 @@ function TouchRow({
       <div className="flex items-center gap-3 px-3.5 py-3">
         {onToggleComplete && (
           <label
-            className="relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center"
+            className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
             onClick={(e) => e.stopPropagation()}
           >
             <input
@@ -272,18 +362,36 @@ function TouchRow({
               className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
               aria-label={`Mark ${title} complete`}
             />
+            {checkAnim === 'checked' && (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                />
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                />
+              </>
+            )}
             <span
               className={cn(
                 'flex h-6 w-6 items-center justify-center rounded-full border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
                 completed && 'border-primary bg-primary',
+                checkAnim === 'checked' && 'animate-task-check-pop',
               )}
             >
-              {completed && (
+              {(completed || checkAnim === 'unchecked') && (
                 <svg
-                  className="h-3.5 w-3.5 stroke-primary-foreground"
+                  className={cn(
+                    'h-3.5 w-3.5 stroke-primary-foreground',
+                    checkAnim === 'checked' && 'animate-task-check-mark-in',
+                    checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                  )}
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth={3}
+                  aria-hidden="true"
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                 </svg>


### PR DESCRIPTION
## Summary

Two UI changes to `src/components/ui/TaskRow.tsx` (both `CardRow` and `TouchRow`):

**1. Task-completion micro-interaction** — checking a task off now plays:
- a pop scale on the checkbox (1 → 1.35 → 0.96 → 1, ~480ms, staged keyframes for the elastic feel)
- two staggered ripple rings (scale 0.6→2.4, opacity 0.55→0, 80ms apart), colored `hsl(var(--primary))` — not the load-level green, which already means "workload is light" elsewhere
- a checkmark reveal via opacity+scale (not `stroke-dasharray` — that distorted at real 11–16px render size in an earlier pass)
- a brief row-background glow to `primary` at ~8% opacity, fading over ~500ms

Unchecking is intentionally quick and understated: a ~100ms checkmark fade/scale-down, no ripple, no glow. All of it is CSS `@keyframes` in `src/app/globals.css`, triggered by a transient animation-state class (`useState` + `useEffect` + `setTimeout`) shared by both row variants via one hook. The sibling `prefers-reduced-motion` PR (`ui/reduced-motion-and-dark-elevation`) handles zeroing durations globally, so nothing reduced-motion-specific is added here.

**2. 44×44px touch target + single-glyph priority indicator**
- Both checkboxes are now wrapped in a `<label>` with a `min-h-11 min-w-11` invisible hit area (visible checkbox size unchanged).
- `CardRow`'s high-priority dot is now a filled triangle SVG glyph; a new muted-circle glyph appears for medium priority (previously nothing rendered); low priority still renders nothing. Exactly one glyph per level. `TouchRow` doesn't render a priority indicator and was left alone.

Note: this only implements the priority-dot half of the colorblind-redundancy work — workload/load-level chip glyphs elsewhere are a separate follow-up.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean for `TaskRow.tsx` (two pre-existing, unrelated `workload.test.ts` iterator errors confirmed present on the base branch before this change)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 215/215 passing across 25 files, including all 9 `TaskRow.test.tsx` cases unmodified (the medium-priority glyph is a plain `<span>`, not an `<svg>`, so it doesn't trip the existing "book glyph has no other svg primitives" assertion)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_