### PR TITLE
UI wireframe review: 7 PRs — motion, mobile nav, dashboard hierarchy, slider, priority glyphs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,6 +39,18 @@
     --card-shadow: 0 1px 2px rgba(16, 12, 30, 0.04), 0 10px 28px -8px rgba(91, 61, 245, 0.16);
     --card-shadow-hover:
       0 2px 4px rgba(16, 12, 30, 0.06), 0 18px 40px -10px rgba(91, 61, 245, 0.28);
+
+    /* Modal v1: a distinct elevation tier for true modal-overlay surfaces
+       (dialogs, sheets) that sit above cards in the stack. In light mode a
+       modal reads as "lifted" the same way a card does, so this falls back
+       to the same value as --card-shadow rather than inventing a second
+       light-mode look. */
+    --modal-shadow: var(--card-shadow);
+
+    /* Popover tier: reserved, unused. There's no custom dropdown/popover
+       component in this app yet (TermSwitcher etc. are native <select>
+       elements, which can't be styled with a custom box-shadow), so this
+       token intentionally has no consumer today. */
   }
 
   .dark {
@@ -79,6 +91,11 @@
        dark blur (which is nearly invisible against an already-dark page). */
     --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 10px 28px -8px rgba(139, 92, 246, 0.35);
     --card-shadow-hover: 0 2px 4px rgba(0, 0, 0, 0.5), 0 18px 40px -10px rgba(139, 92, 246, 0.5);
+
+    /* Modal v1: distinct from --card-shadow - a deeper, darker near shadow
+       plus a wider brand-tinted glow, so a modal reads as sitting above the
+       card tier instead of sharing its elevation. */
+    --modal-shadow: 0 4px 8px rgba(0, 0, 0, 0.5), 0 24px 60px -12px rgba(139, 92, 246, 0.45);
   }
 }
 
@@ -143,5 +160,21 @@
   .dark .glass {
     background-color: rgba(18, 18, 24, 0.94);
     border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  /* Respect the OS-level "reduce motion" preference by collapsing every
+     animation/transition down to effectively-instant. Duration is set to
+     0.01ms rather than 0 so animationend/transitionend listeners still fire
+     (some components depend on them to flip state after a transition).
+     Loading spinners (.animate-spin, Tailwind's own utility) are explicitly
+     exempted - freezing an in-progress spinner reads as "the app is stuck",
+     not as "calm", so those keep spinning regardless of this preference. */
+  @media (prefers-reduced-motion: reduce) {
+    *:not(.animate-spin, .animate-spin *) {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,6 +141,42 @@
     color: transparent;
   }
 
+  /* Brand-gradient spinner ring: same purple-to-teal stops as
+     .bg-gradient-brand, painted as a conic sweep and masked down to a ring
+     (rather than a filled disc) so it drops into the same
+     `animate-spin`-timed element the flat border-t-primary ring used to
+     occupy. The mask's inner radius matches that ring's old 3px stroke. */
+  .spinner-gradient {
+    background-image: conic-gradient(
+      from 0deg,
+      #8c6eff 0%,
+      #5b3df5 55%,
+      #00bfa0 100%,
+      #8c6eff 100%
+    );
+    -webkit-mask-image: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+    mask-image: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+  }
+
+  /* Staggered entrance for the syllabus autofill review list: each
+     course/meeting/materials/assignment row fades and lifts in on its own
+     delay (set inline per-row) instead of the whole review screen mounting
+     in one synchronous paint. `both` fill mode holds the 0%-keyframe state
+     through the delay so rows don't flash visible before their turn. */
+  @keyframes syllabus-review-reveal {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .review-reveal {
+    animation: syllabus-review-reveal 250ms ease-out both;
+  }
+
   /* Used on the fixed Navbar, which sits above scrolling page content -
      content with a strong, saturated color (e.g. Profile's cover-banner
      gradient) can pass directly underneath it. 94% opacity alone already

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -128,6 +128,95 @@
     }
   }
 
+  /* Task-completion micro-interaction (TaskRow checkboxes, both the card
+     and touch variants): checking a task plays a pop + two staggered
+     ripple rings + a checkmark reveal + a brief row-background glow, all
+     keyed off hsl(var(--primary)) - deliberately NOT the load-level green
+     (--load-low), which already means "workload is light" elsewhere and
+     would send the wrong signal reused here. Unchecking is intentionally
+     understated (fast fade, no ripple, no glow) so undoing a task never
+     reads as an accomplishment. The checkmark reveals via opacity+scale,
+     not a stroke-dasharray "draw" - at the ~11-16px real render size a
+     dasharray draw looked like a distorted blob in an earlier pass.
+     `prefers-reduced-motion` handling lives in a sibling PR that zeroes
+     animation/transition durations globally, so nothing extra is needed
+     here. */
+  @keyframes task-check-pop {
+    0% {
+      transform: scale(1);
+    }
+    40% {
+      transform: scale(1.35);
+    }
+    70% {
+      transform: scale(0.96);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  .animate-task-check-pop {
+    animation: task-check-pop 480ms ease-in-out;
+  }
+
+  @keyframes task-check-ripple {
+    0% {
+      transform: scale(0.6);
+      opacity: 0.55;
+    }
+    100% {
+      transform: scale(2.4);
+      opacity: 0;
+    }
+  }
+  .animate-task-check-ripple {
+    animation: task-check-ripple 500ms ease-out;
+  }
+  .animate-task-check-ripple-delayed {
+    animation: task-check-ripple 500ms ease-out 80ms;
+    animation-fill-mode: both;
+  }
+
+  @keyframes task-check-mark-in {
+    0% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  .animate-task-check-mark-in {
+    animation: task-check-mark-in 150ms ease-out 70ms both;
+  }
+
+  @keyframes task-check-mark-out {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+  }
+  .animate-task-check-mark-out {
+    animation: task-check-mark-out 100ms ease-in both;
+  }
+
+  @keyframes task-row-glow {
+    0% {
+      background-color: hsl(var(--primary) / 0.08);
+    }
+    100% {
+      background-color: hsl(var(--primary) / 0);
+    }
+  }
+  .animate-task-row-glow {
+    animation: task-row-glow 500ms ease-out;
+  }
+
   /* Matches the Logo mark's own gradient (Logo.tsx) so brand color isn't
      confined to the icon - hero panels, progress rings, and CTAs can pick up
      the same identity. */

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -738,11 +738,13 @@ export function MonthCalendar() {
                       return (
                         <TaskRow
                           key={item.id}
+                          variant={state.preferences.taskRowVariant}
                           title={item.title}
                           href={`/tasks/${item.id}`}
                           type={item.type}
                           courseCode={course ? course.code : 'General'}
                           courseColor={course?.color}
+                          courseIcon={course?.icon}
                           completed={item.completed}
                           progress={item.progress}
                           priority={item.priority}
@@ -842,6 +844,8 @@ function DayDetailCard({
   courseOf: (item: ScheduleItem) => Course | undefined;
   onToggleComplete?: (item: ScheduleItem) => void;
 }) {
+  const { state } = useAppState();
+
   return (
     <Card className="rounded-2xl p-6">
       <h3 className="text-base font-semibold text-foreground mb-3">
@@ -917,12 +921,13 @@ function DayDetailCard({
                   return (
                     <TaskRow
                       key={item.id}
-                      variant="touch"
+                      variant={state.preferences.taskRowVariant}
                       title={item.title}
                       href={`/tasks/${item.id}`}
                       type={item.type}
                       courseCode={course ? course.code : 'General'}
                       courseColor={course?.color}
+                      courseIcon={course?.icon}
                       completed={item.completed}
                       progress={item.progress}
                       priority={item.priority}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -459,7 +459,7 @@ export function MonthCalendar() {
               role="dialog"
               aria-modal="true"
               aria-label="Filters"
-              className="relative z-10 flex max-h-[80vh] w-full flex-col rounded-t-2xl border-t border-border bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-2xl"
+              className="relative z-10 flex max-h-[80vh] w-full flex-col rounded-t-2xl border-t border-border bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-modal"
             >
               <div className="mx-auto mb-3 h-1.5 w-10 shrink-0 rounded-full bg-border" />
               <div className="mb-4 flex items-center justify-between">

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -910,12 +910,13 @@ function DayDetailCard({
               <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
                 Due
               </h4>
-              <div className="divide-y divide-border">
+              <div className="flex flex-col gap-2">
                 {items.map((item) => {
                   const course = courseOf(item);
                   return (
                     <TaskRow
                       key={item.id}
+                      variant="touch"
                       title={item.title}
                       href={`/tasks/${item.id}`}
                       type={item.type}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -744,6 +744,7 @@ export function MonthCalendar() {
                           courseCode={course ? course.code : 'General'}
                           courseColor={course?.color}
                           completed={item.completed}
+                          progress={item.progress}
                           priority={item.priority}
                           onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                         />
@@ -923,14 +924,26 @@ function DayDetailCard({
                       courseCode={course ? course.code : 'General'}
                       courseColor={course?.color}
                       completed={item.completed}
+                      progress={item.progress}
                       priority={item.priority}
                       onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
                       trailing={
                         <div className="flex items-center gap-1">
-                          <a
-                            href={generateGoogleCalendarUrl(item, course)}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          {/* <button>, not <a href>: this trailing content
+                              renders inside the row's own <Link> (the row
+                              itself navigates to the task on click) - an
+                              <a> nested inside an <a> is invalid HTML and
+                              gets silently unnested by the browser's parser,
+                              breaking both links' click targets. */}
+                          <button
+                            type="button"
+                            onClick={() =>
+                              window.open(
+                                generateGoogleCalendarUrl(item, course),
+                                '_blank',
+                                'noopener,noreferrer',
+                              )
+                            }
                             title="Add to Google Calendar"
                             className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
                           >
@@ -947,16 +960,21 @@ function DayDetailCard({
                                 d="M12 4v16m8-8H4"
                               />
                             </svg>
-                          </a>
-                          <a
-                            href={generateOutlookCalendarUrl(item, course)}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              window.open(
+                                generateOutlookCalendarUrl(item, course),
+                                '_blank',
+                                'noopener,noreferrer',
+                              )
+                            }
                             title="Add to Outlook"
                             className="rounded-md p-1 text-[9px] font-bold text-muted-foreground hover:bg-accent hover:text-foreground"
                           >
                             O
-                          </a>
+                          </button>
                         </div>
                       }
                     />

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -201,9 +201,13 @@ export function WeekView({
                   </span>
                 ))}
                 {items.length > 3 && (
-                  <span className="block text-[9px] font-semibold text-muted-foreground">
+                  <button
+                    type="button"
+                    onClick={() => onSelectDay(day)}
+                    className="block w-full text-left text-[9px] font-semibold text-muted-foreground hover:text-primary hover:underline"
+                  >
                     +{items.length - 3} more due
-                  </span>
+                  </button>
                 )}
               </div>
             );

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -125,6 +125,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.progress ? { progress: Number(values.progress) } : {}),
       },
       dispatch,
     );
@@ -331,6 +332,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     type={item.type}
                     courseColor={course.color}
                     completed={item.completed}
+                    progress={item.progress}
                     priority={item.priority}
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                     trailing={

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -77,6 +77,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         code: values.code,
         title: values.title,
         color: values.color,
+        icon: values.icon,
         meetingTimes: values.meetingTimes ?? [],
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
@@ -321,16 +322,18 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
               action={{ label: '+ Add Task', onClick: () => setAddTaskOpen(true) }}
             />
           ) : (
-            <div className="divide-y divide-border">
+            <div className="flex flex-col gap-2">
               {items.map((item) => {
                 const overdue = !item.completed && new Date(item.dueDate) < new Date();
                 return (
                   <TaskRow
                     key={item.id}
+                    variant={state.preferences.taskRowVariant}
                     title={item.title}
                     href={'/tasks/' + item.id}
                     type={item.type}
                     courseColor={course.color}
+                    courseIcon={course.icon}
                     completed={item.completed}
                     progress={item.progress}
                     priority={item.priority}

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -15,6 +15,8 @@ import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useAppState } from '@/context/AppStateContext';
 import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
+import { COURSE_ICON_PRESETS, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
+import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
 
 const isCustomColor = (color: string) => color.startsWith('#');
 
@@ -55,6 +57,7 @@ const emptyValues: CourseFormValues = {
   instructor: '',
   term: '',
   color: COURSE_COLOR_PRESETS[0].value,
+  icon: DEFAULT_COURSE_ICON,
   modality: undefined,
   meetingTimes: [],
 };
@@ -83,6 +86,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             instructor: initialCourse.instructor ?? '',
             term: initialCourse.term ?? '',
             color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
+            icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
             modality: initialCourse.modality,
             meetingTimes: initialCourse.meetingTimes ?? [],
           }
@@ -273,6 +277,29 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
                       onChange={(e) => setValues((s) => ({ ...s, color: e.target.value }))}
                     />
                   </label>
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-sm font-medium text-foreground">Icon</span>
+                <div className="flex flex-wrap gap-2">
+                  {COURSE_ICON_PRESETS.map((preset) => (
+                    <button
+                      key={preset.value}
+                      type="button"
+                      title={preset.label}
+                      aria-label={preset.label}
+                      onClick={() => setValues((s) => ({ ...s, icon: preset.value }))}
+                      className={cn(
+                        'flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground transition-colors',
+                        values.icon === preset.value
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border hover:bg-accent',
+                      )}
+                    >
+                      <CourseIconGlyph icon={preset.value} className="h-4 w-4" />
+                    </button>
+                  ))}
                 </div>
               </div>
 

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -79,6 +79,7 @@ export function CoursesListView() {
         code: values.code,
         title: values.title,
         color: values.color,
+        icon: values.icon,
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
         ...(values.modality ? { modality: values.modality } : {}),

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -101,6 +101,7 @@ export function DashboardView() {
         code: values.code,
         title: values.title,
         color: values.color,
+        icon: values.icon,
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
       },
@@ -321,12 +322,13 @@ export function DashboardView() {
                     return (
                       <TaskRow
                         key={item.id}
-                        variant="card"
+                        variant={state.preferences.taskRowVariant}
                         title={item.title}
                         href={'/tasks/' + item.id}
                         type={item.type}
                         courseCode={course ? course.code : 'General'}
                         courseColor={course?.color}
+                        courseIcon={course?.icon}
                         completed={item.completed}
                         progress={item.progress}
                         priority={item.priority}
@@ -427,12 +429,13 @@ export function DashboardView() {
                 return (
                   <TaskRow
                     key={item.id}
-                    variant="card"
+                    variant={state.preferences.taskRowVariant}
                     title={item.title}
                     href={'/tasks/' + item.id}
                     type={item.type}
                     courseCode={course ? course.code : 'General'}
                     courseColor={course?.color}
+                    courseIcon={course?.icon}
                     completed={item.completed}
                     progress={item.progress}
                     priority={item.priority}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -179,37 +179,88 @@ export function DashboardView() {
           </div>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-[15rem_1fr]">
-          <Card accent className="flex flex-col items-center justify-center gap-4 rounded-2xl p-6">
-            <ProgressRing percent={termProgressPct} size={116} strokeWidth={10}>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-foreground">{termProgressPct}%</div>
-                <div className="text-[10px] text-muted-foreground">progress</div>
+        <div className="space-y-4">
+          <Card accent="left" className="rounded-2xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-3">
+                <SectionIcon icon="tasks" />
+                <h2 className="text-lg font-bold text-foreground">Upcoming Tasks</h2>
+                {overdueCount > 0 && (
+                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                    {overdueCount} overdue
+                  </span>
+                )}
               </div>
-            </ProgressRing>
-            <div className="grid w-full grid-cols-3 gap-2 text-center">
-              <div>
-                <div className="text-lg font-bold text-primary">{semesterCourses.length}</div>
-                <div className="text-[10px] text-muted-foreground">Courses</div>
-              </div>
-              <div>
-                <div className="text-lg font-bold text-load-medium">{pendingTasks.length}</div>
-                <div className="text-[10px] text-muted-foreground">Pending</div>
-              </div>
-              <div>
-                <div className="text-lg font-bold text-load-low">{completedTasksCount}</div>
-                <div className="text-[10px] text-muted-foreground">Done</div>
+              <div className="flex items-center gap-2">
+                <CardActionLink href="/tasks" withChevron>
+                  View all
+                </CardActionLink>
+                <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
+                  Add Task
+                </CardActionButton>
               </div>
             </div>
+            {upcomingTasks.length === 0 ? (
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                }
+                title="Nothing due"
+                description="You're all caught up."
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {upcomingTasks.map((item) => {
+                  const course = courses.find((c) => c.id === item.courseId);
+                  const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
+                  return (
+                    <TaskRow
+                      key={item.id}
+                      variant={state.preferences.taskRowVariant}
+                      title={item.title}
+                      href={'/tasks/' + item.id}
+                      type={item.type}
+                      courseCode={course ? course.code : 'General'}
+                      courseColor={course?.color}
+                      courseIcon={course?.icon}
+                      completed={item.completed}
+                      progress={item.progress}
+                      priority={item.priority}
+                      onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                      trailing={
+                        <>
+                          {overdue && (
+                            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                              Overdue
+                            </span>
+                          )}
+                          <span className="text-xs text-muted-foreground">
+                            Due {dueDateFormatter.format(new Date(item.dueDate))}
+                          </span>
+                        </>
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
           </Card>
 
-          <div className="flex flex-col gap-4">
-            <Card className="rounded-2xl p-6">
-              <div className="flex items-center justify-between mb-5">
-                <div className="flex items-center gap-3">
-                  <SectionIcon icon="courseLoad" />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Card className="rounded-2xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2.5">
+                  <SectionIcon icon="courseLoad" className="h-6 w-6" />
                   <div>
-                    <h2 className="text-base font-semibold text-foreground">Course Load</h2>
+                    <h2 className="text-sm font-semibold text-foreground">Course Load</h2>
                     {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
                   </div>
                 </div>
@@ -278,78 +329,34 @@ export function DashboardView() {
               )}
             </Card>
 
-            <Card className="rounded-2xl p-6">
-              <div className="flex items-center justify-between mb-3">
-                <div className="flex items-center gap-3">
-                  <SectionIcon icon="tasks" />
-                  <h2 className="text-base font-semibold text-foreground">Upcoming Tasks</h2>
-                  {overdueCount > 0 && (
-                    <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                      {overdueCount} overdue
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <CardActionLink href="/tasks" withChevron>
-                    View all
-                  </CardActionLink>
-                  <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
-                    Add Task
-                  </CardActionButton>
+            <Card className="rounded-2xl p-4">
+              <div className="mb-3 flex items-center gap-2.5">
+                <SectionIcon icon="star" className="h-6 w-6" />
+                <h2 className="text-sm font-semibold text-foreground">Term Progress</h2>
+              </div>
+              <div className="flex items-center gap-4">
+                <ProgressRing percent={termProgressPct} size={80} strokeWidth={7}>
+                  <div className="text-center">
+                    <div className="text-lg font-bold text-foreground">{termProgressPct}%</div>
+                  </div>
+                </ProgressRing>
+                <div className="grid flex-1 grid-cols-3 gap-2 text-center">
+                  <div>
+                    <div className="text-base font-bold text-primary">{semesterCourses.length}</div>
+                    <div className="text-[10px] text-muted-foreground">Courses</div>
+                  </div>
+                  <div>
+                    <div className="text-base font-bold text-load-medium">
+                      {pendingTasks.length}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground">Pending</div>
+                  </div>
+                  <div>
+                    <div className="text-base font-bold text-load-low">{completedTasksCount}</div>
+                    <div className="text-[10px] text-muted-foreground">Done</div>
+                  </div>
                 </div>
               </div>
-              {upcomingTasks.length === 0 ? (
-                <EmptyState
-                  icon={
-                    <svg
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  }
-                  title="Nothing due"
-                  description="You're all caught up."
-                />
-              ) : (
-                <div className="flex flex-col gap-2">
-                  {upcomingTasks.map((item) => {
-                    const course = courses.find((c) => c.id === item.courseId);
-                    const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
-                    return (
-                      <TaskRow
-                        key={item.id}
-                        variant={state.preferences.taskRowVariant}
-                        title={item.title}
-                        href={'/tasks/' + item.id}
-                        type={item.type}
-                        courseCode={course ? course.code : 'General'}
-                        courseColor={course?.color}
-                        courseIcon={course?.icon}
-                        completed={item.completed}
-                        progress={item.progress}
-                        priority={item.priority}
-                        onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
-                        trailing={
-                          <>
-                            {overdue && (
-                              <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                                Overdue
-                              </span>
-                            )}
-                            <span className="text-xs text-muted-foreground">
-                              Due {dueDateFormatter.format(new Date(item.dueDate))}
-                            </span>
-                          </>
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              )}
             </Card>
           </div>
         </div>

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -328,6 +328,7 @@ export function DashboardView() {
                         courseCode={course ? course.code : 'General'}
                         courseColor={course?.color}
                         completed={item.completed}
+                        progress={item.progress}
                         priority={item.priority}
                         onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                         trailing={
@@ -433,6 +434,7 @@ export function DashboardView() {
                     courseCode={course ? course.code : 'General'}
                     courseColor={course?.color}
                     completed={item.completed}
+                    progress={item.progress}
                     priority={item.priority}
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                     trailing={

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -314,13 +314,14 @@ export function DashboardView() {
                   description="You're all caught up."
                 />
               ) : (
-                <div className="divide-y divide-border">
+                <div className="flex flex-col gap-2">
                   {upcomingTasks.map((item) => {
                     const course = courses.find((c) => c.id === item.courseId);
                     const overdue = !item.completed && new Date(item.dueDate).getTime() < now;
                     return (
                       <TaskRow
                         key={item.id}
+                        variant="card"
                         title={item.title}
                         href={'/tasks/' + item.id}
                         type={item.type}
@@ -418,13 +419,14 @@ export function DashboardView() {
               description="Check the calendar for what's ahead."
             />
           ) : (
-            <div className="divide-y divide-border">
+            <div className="flex flex-col gap-2">
               {plannerPreview.map(({ item, startDate, overloaded }) => {
                 const course = courses.find((c) => c.id === item.courseId);
                 const startsToday = startDate <= plan.weekLoad[0].key;
                 return (
                   <TaskRow
                     key={item.id}
+                    variant="card"
                     title={item.title}
                     href={'/tasks/' + item.id}
                     type={item.type}

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -6,6 +6,7 @@ import { AppStateProvider } from '@/context/AppStateContext';
 import AuthGuard from '@/components/auth/AuthGuard';
 import Navbar from './Navbar';
 import Sidebar from './Sidebar';
+import MobileTabBar from './MobileTabBar';
 import FirestoreSync from './FirestoreSync';
 
 export default function LayoutWrapper({ children }: { children: React.ReactNode }) {
@@ -18,10 +19,11 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
             <Navbar />
             <div className="flex flex-1 pt-20">
               <Sidebar />
-              <main className="flex-1 p-6 md:pl-72 md:p-8 max-w-7xl transition-all duration-300">
+              <main className="flex-1 p-6 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pl-72 md:p-8 md:pb-8 max-w-7xl transition-all duration-300">
                 {children}
               </main>
             </div>
+            <MobileTabBar />
           </div>
         </AppStateProvider>
       </SidebarProvider>

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+interface TabItem {
+  name: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const tabItems: TabItem[] = [
+  {
+    name: 'Dashboard',
+    href: '/dashboard',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Courses',
+    href: '/courses',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Tasks',
+    href: '/tasks',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: 'Calendar',
+    href: '/calendar',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        />
+      </svg>
+    ),
+  },
+];
+
+const moreItems: TabItem[] = [
+  {
+    name: 'Planner',
+    href: '/planner',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10M4 18h7" />
+      </svg>
+    ),
+  },
+  {
+    name: 'Profile',
+    href: '/profile',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+        />
+      </svg>
+    ),
+  },
+];
+
+function TabLink({ item, isActive }: { item: TabItem; isActive: boolean }) {
+  return (
+    <Link
+      href={item.href}
+      className={cn(
+        'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors',
+        isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
+      )}
+      aria-current={isActive ? 'page' : undefined}
+    >
+      {item.icon}
+      <span>{item.name}</span>
+      <span
+        className={cn(
+          'h-[3px] w-[3px] rounded-full bg-primary transition-opacity',
+          isActive ? 'opacity-100' : 'opacity-0',
+        )}
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}
+
+export default function MobileTabBar() {
+  const pathname = usePathname();
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+
+  const isMoreActive = moreItems.some((item) => pathname === item.href);
+
+  return (
+    <>
+      {/* Backdrop for the "More" popover — closes on tap-outside */}
+      {isMoreOpen && (
+        <div
+          className="fixed inset-0 z-[55] bg-transparent md:hidden"
+          onClick={() => setIsMoreOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <nav
+        className="fixed bottom-0 left-0 right-0 z-50 flex h-16 items-stretch border-t border-border/40 bg-card/80 glass pb-[env(safe-area-inset-bottom)] md:hidden"
+        aria-label="Primary"
+      >
+        {tabItems.map((item) => (
+          <TabLink key={item.href} item={item} isActive={pathname === item.href} />
+        ))}
+
+        <div className="relative flex flex-1">
+          {isMoreOpen && (
+            <div
+              className="absolute bottom-full right-0 z-[56] mb-2 w-40 overflow-hidden rounded-xl border border-border/40 bg-card glass shadow-glass"
+              role="menu"
+            >
+              {moreItems.map((item) => {
+                const isActive = pathname === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setIsMoreOpen(false)}
+                    role="menuitem"
+                    className={cn(
+                      'flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors',
+                      isActive
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+                    )}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {item.icon}
+                    <span>{item.name}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => setIsMoreOpen((prev) => !prev)}
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors',
+              isMoreOpen || isMoreActive
+                ? 'text-primary'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            aria-haspopup="menu"
+            aria-expanded={isMoreOpen}
+            aria-label="More navigation options"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 12h.01M12 12h.01M18 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm6 0a1 1 0 11-2 0 1 1 0 012 0zm6 0a1 1 0 11-2 0 1 1 0 012 0z"
+              />
+            </svg>
+            <span>More</span>
+            <span
+              className={cn(
+                'h-[3px] w-[3px] rounded-full bg-primary transition-opacity',
+                isMoreActive ? 'opacity-100' : 'opacity-0',
+              )}
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,14 +3,12 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useSidebar } from './SidebarContext';
 import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
 
 export default function Navbar() {
-  const { toggle } = useSidebar();
   const { resolvedTheme, setTheme } = useTheme();
   const { user, signOut } = useAuth();
   const router = useRouter();
@@ -28,23 +26,6 @@ export default function Navbar() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 h-20 glass border-b border-border/40 bg-card/80 flex items-center justify-between px-3 sm:px-6">
       <div className="flex items-center gap-2 sm:gap-4">
-        {/* Mobile Hamburger Button */}
-        <button
-          onClick={toggle}
-          className="p-2 rounded-md hover:bg-accent text-foreground md:hidden focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
-          aria-label="Toggle Navigation Menu"
-        >
-          <svg
-            className="h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-
         {/* Logo / App Name */}
         <Link
           href="/"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useSidebar } from './SidebarContext';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -14,7 +13,6 @@ interface NavItem {
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const { isOpen, setIsOpen } = useSidebar();
 
   const navItems: NavItem[] = [
     {
@@ -130,45 +128,28 @@ export default function Sidebar() {
   ];
 
   return (
-    <>
-      {/* Mobile Sidebar Overlay Backdrop */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm md:hidden"
-          onClick={() => setIsOpen(false)}
-        />
-      )}
-
-      {/* Sidebar Drawer Container */}
-      <aside
-        className={cn(
-          'fixed top-20 bottom-0 left-0 z-[45] w-64 border-r border-border/40 bg-card/90 glass transition-transform duration-300 md:translate-x-0 md:flex md:flex-col',
-          isOpen ? 'translate-x-0' : '-translate-x-full',
-        )}
-      >
-        <nav className="flex-1 space-y-1 px-4 py-6">
-          {navItems.map((item) => {
-            const isActive = pathname === item.href;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setIsOpen(false)}
-                className={cn(
-                  'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200',
-                  isActive
-                    ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                )}
-                aria-current={isActive ? 'page' : undefined}
-              >
-                {item.icon}
-                <span>{item.name}</span>
-              </Link>
-            );
-          })}
-        </nav>
-      </aside>
-    </>
+    <aside className="hidden md:flex fixed top-20 bottom-0 left-0 z-[45] w-64 flex-col border-r border-border/40 bg-card/90 glass">
+      <nav className="flex-1 space-y-1 px-4 py-6">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200',
+                isActive
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              )}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {item.icon}
+              <span>{item.name}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
   );
 }

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -123,7 +123,7 @@ export function SmartPlanner() {
             {plan.startToday.map(({ item, overloaded, overdue }) => (
               <PlannedTaskRow
                 key={item.id}
-                variant="card"
+                variant={state.preferences.taskRowVariant}
                 item={item}
                 course={courses.find((c) => c.id === item.courseId)}
                 overloaded={overloaded}
@@ -189,12 +189,13 @@ export function SmartPlanner() {
                 {selectedDayItems.map((item) => (
                   <TaskRow
                     key={item.id}
-                    variant="card"
+                    variant={state.preferences.taskRowVariant}
                     title={item.title}
                     href={`/tasks/${item.id}`}
                     type={item.type}
                     courseCode={courses.find((c) => c.id === item.courseId)?.code ?? 'General'}
                     courseColor={courses.find((c) => c.id === item.courseId)?.color}
+                    courseIcon={courses.find((c) => c.id === item.courseId)?.icon}
                     completed={item.completed}
                     progress={item.progress}
                     priority={item.priority}
@@ -213,12 +214,14 @@ export function SmartPlanner() {
             title="Start This Week"
             items={plan.startThisWeek}
             courses={courses}
+            variant={state.preferences.taskRowVariant}
             onToggleComplete={user ? handleToggleComplete : undefined}
           />
           <PlanSection
             title="Later"
             items={plan.startLater}
             courses={courses}
+            variant={state.preferences.taskRowVariant}
             onToggleComplete={user ? handleToggleComplete : undefined}
           />
         </>
@@ -240,7 +243,7 @@ function PlannedTaskRow({
   overloaded: boolean;
   overdue: boolean;
   onToggleComplete?: () => void;
-  variant?: 'compact' | 'card' | 'touch';
+  variant?: 'card' | 'touch';
 }) {
   return (
     <TaskRow
@@ -250,6 +253,7 @@ function PlannedTaskRow({
       type={item.type}
       courseCode={course ? course.code : 'General'}
       courseColor={course?.color}
+      courseIcon={course?.icon}
       completed={item.completed}
       progress={item.progress}
       priority={item.priority}
@@ -280,11 +284,13 @@ function PlanSection({
   title,
   items,
   courses,
+  variant,
   onToggleComplete,
 }: {
   title: string;
   items: PlannedItem[];
   courses: Course[];
+  variant?: 'card' | 'touch';
   onToggleComplete?: (item: ScheduleItem) => void;
 }) {
   if (items.length === 0) return null;
@@ -292,7 +298,7 @@ function PlanSection({
   return (
     <Card className="rounded-2xl p-6">
       <h2 className="mb-3 text-sm font-semibold text-foreground">{title}</h2>
-      <div className="divide-y divide-border">
+      <div className="flex flex-col gap-2">
         {items.map(({ item, overloaded, overdue }) => (
           <PlannedTaskRow
             key={item.id}
@@ -300,6 +306,7 @@ function PlanSection({
             course={courses.find((c) => c.id === item.courseId)}
             overloaded={overloaded}
             overdue={overdue}
+            variant={variant}
             onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
           />
         ))}

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -196,6 +196,7 @@ export function SmartPlanner() {
                     courseCode={courses.find((c) => c.id === item.courseId)?.code ?? 'General'}
                     courseColor={courses.find((c) => c.id === item.courseId)?.color}
                     completed={item.completed}
+                    progress={item.progress}
                     priority={item.priority}
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                   />
@@ -250,6 +251,7 @@ function PlannedTaskRow({
       courseCode={course ? course.code : 'General'}
       courseColor={course?.color}
       completed={item.completed}
+      progress={item.progress}
       priority={item.priority}
       onToggleComplete={onToggleComplete}
       trailing={

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -119,10 +119,11 @@ export function SmartPlanner() {
             description="You're caught up - check back tomorrow."
           />
         ) : (
-          <div className="divide-y divide-border">
+          <div className="flex flex-col gap-2">
             {plan.startToday.map(({ item, overloaded, overdue }) => (
               <PlannedTaskRow
                 key={item.id}
+                variant="card"
                 item={item}
                 course={courses.find((c) => c.id === item.courseId)}
                 overloaded={overloaded}
@@ -184,10 +185,11 @@ export function SmartPlanner() {
             {selectedDayItems.length === 0 ? (
               <p className="text-sm text-muted-foreground">Nothing due this day.</p>
             ) : (
-              <div className="divide-y divide-border">
+              <div className="flex flex-col gap-2">
                 {selectedDayItems.map((item) => (
                   <TaskRow
                     key={item.id}
+                    variant="card"
                     title={item.title}
                     href={`/tasks/${item.id}`}
                     type={item.type}
@@ -230,15 +232,18 @@ function PlannedTaskRow({
   overloaded,
   overdue,
   onToggleComplete,
+  variant,
 }: {
   item: PlannedItem['item'];
   course: Course | undefined;
   overloaded: boolean;
   overdue: boolean;
   onToggleComplete?: () => void;
+  variant?: 'compact' | 'card' | 'touch';
 }) {
   return (
     <TaskRow
+      variant={variant}
       title={item.title}
       href={`/tasks/${item.id}`}
       type={item.type}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -4,9 +4,10 @@ import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { SectionIcon } from '@/components/ui/SectionIcon';
+import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
-import { useUserPreferences, type UserPreferences } from '@/lib/firestore/preferences';
+import { updateUserPreferences, type UserPreferences } from '@/lib/firestore/preferences';
 import { cn } from '@/lib/utils';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -15,7 +16,52 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-const PREFERENCE_ROWS: { key: keyof UserPreferences; label: string; description: string }[] = [
+/** Sample tasks with no relation to the signed-in student's real courses -
+ * used only to render a live Card vs. Touch comparison below, so the
+ * choice can be judged by seeing it, not by reading a description. */
+const PREVIEW_TASKS = [
+  {
+    title: 'Problem Set 4',
+    type: 'assignment' as const,
+    courseCode: 'MATH 201',
+    courseColor: 'bg-blue-500',
+    courseIcon: 'calculator',
+    completed: false,
+    priority: 'high' as const,
+  },
+  {
+    title: 'Lab Report: Titration',
+    type: 'project' as const,
+    courseCode: 'CHEM 110',
+    courseColor: 'bg-teal-500',
+    courseIcon: 'flask',
+    completed: false,
+    progress: 55,
+  },
+];
+
+const ROW_VARIANT_OPTIONS: {
+  value: UserPreferences['taskRowVariant'];
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'card',
+    label: 'Card',
+    description: 'A tinted background per task and a bit more room - easiest to scan on a laptop.',
+  },
+  {
+    value: 'touch',
+    label: 'Touch',
+    description: 'A top accent bar and a large circular checkbox - built for tapping on a phone.',
+  },
+];
+
+const PREFERENCE_ROWS: {
+  key: Exclude<keyof UserPreferences, 'taskRowVariant'>;
+  label: string;
+  description: string;
+}[] = [
   {
     key: 'dailyDigest',
     label: 'Daily digest email',
@@ -35,14 +81,32 @@ const PREFERENCE_ROWS: { key: keyof UserPreferences; label: string; description:
 
 export function ProfileView() {
   const { user, error, updateDisplayName, signOut, clearError } = useAuth();
-  const { state } = useAppState();
+  const { state, dispatch } = useAppState();
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(user?.displayName ?? '');
   const [saving, setSaving] = useState(false);
-  const [preferences] = useUserPreferences(user?.uid);
+  // Read from AppStateContext (kept live by useFirestoreSync's `users/{uid}`
+  // listener) rather than opening a second onSnapshot here - one realtime
+  // subscription per account, shared by every view that reads a preference.
+  const { preferences } = state;
 
   if (!user) return null;
+
+  const handleSelectRowVariant = async (variant: UserPreferences['taskRowVariant']) => {
+    const next = { ...preferences, taskRowVariant: variant };
+    // Optimistic: every TaskRow on screen (including the previews below)
+    // switches instantly. The write below persists it to the account and
+    // realtime-syncs it to any other open session; onSnapshot reconciles
+    // this optimistic value with the server's shortly after regardless.
+    dispatch({ type: 'SET_PREFERENCES', payload: next });
+    try {
+      await updateUserPreferences(user.uid, next);
+    } catch {
+      // Non-fatal: the realtime listener will correct the UI to whatever
+      // actually made it to Firestore if this particular write failed.
+    }
+  };
 
   const initial = (user.displayName || user.email || '?').charAt(0).toUpperCase();
   const joined = user.metadata.creationTime
@@ -165,6 +229,69 @@ export function ProfileView() {
 
       <Card className="rounded-2xl p-6">
         <div className="flex items-center gap-3">
+          <SectionIcon icon="tasks" />
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Task Row Style</h2>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              How every task looks across Dashboard, Tasks, Planner, and Calendar - on this device
+              and every other one you sign into.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {ROW_VARIANT_OPTIONS.map((option) => {
+            const selected = preferences.taskRowVariant === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleSelectRowVariant(option.value)}
+                aria-pressed={selected}
+                className={cn(
+                  'rounded-2xl border-2 p-3.5 text-left transition-colors',
+                  selected ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/60',
+                )}
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="text-sm font-semibold text-foreground">{option.label}</span>
+                  <span
+                    className={cn(
+                      'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2',
+                      selected
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-border text-transparent',
+                    )}
+                  >
+                    <svg
+                      className="h-3 w-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  </span>
+                </div>
+                <div className="pointer-events-none flex flex-col gap-2">
+                  {PREVIEW_TASKS.map((task) => (
+                    <TaskRow key={task.title} variant={option.value} {...task} />
+                  ))}
+                </div>
+                <p className="mt-3 text-xs text-muted-foreground">{option.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-4 border-t border-border pt-4 text-xs text-muted-foreground">
+          Applied instantly, saved to your account, and synced to any other device you&apos;re
+          signed into in real time - no page refresh needed on either end.
+        </p>
+      </Card>
+
+      <Card className="rounded-2xl p-6">
+        <div className="flex items-center gap-3">
           <SectionIcon icon="settings" />
           <div>
             <h2 className="text-base font-semibold text-foreground">
@@ -188,7 +315,7 @@ export function ProfileView() {
                 </div>
                 <div className="text-xs text-muted-foreground">{row.description}</div>
               </div>
-              <Toggle checked={preferences ? preferences[row.key] : false} />
+              <Toggle checked={preferences[row.key]} />
             </div>
           ))}
         </div>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -17,8 +17,8 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 /** Sample tasks with no relation to the signed-in student's real courses -
- * used only to render a live Card vs. Touch comparison below, so the
- * choice can be judged by seeing it, not by reading a description. */
+ * used only to render a live Comfortable vs. Touch comparison below, so
+ * the choice can be judged by seeing it, not by reading a description. */
 const PREVIEW_TASKS = [
   {
     title: 'Problem Set 4',
@@ -47,7 +47,7 @@ const ROW_VARIANT_OPTIONS: {
 }[] = [
   {
     value: 'card',
-    label: 'Card',
+    label: 'Comfortable',
     description: 'A tinted background per task and a bit more room - easiest to scan on a laptop.',
   },
   {

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { courseSwatch } from '@/lib/courseColors';
+import { clampProgress } from '@/lib/taskStatus';
 import { cn } from '@/lib/utils';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { ScheduleItem, AssignmentType } from '@/types/schedule';
@@ -19,8 +20,8 @@ const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day:
 type StatusFilter = 'all' | 'pending' | 'completed';
 /** What organizes the list into sections. 'date' buckets by due-date
  * proximity (Overdue/Today/This Week/Later), 'course' buckets by class,
- * 'status' buckets by Overdue/Upcoming/Completed, 'flat' renders one
- * unsectioned list (today's original behavior). */
+ * 'status' buckets by Overdue/In Progress/Upcoming/Completed, 'flat' renders
+ * one unsectioned list (today's original behavior). */
 type GroupBy = 'date' | 'course' | 'status' | 'flat';
 /** Ordering applied within each group (and across the whole list when
  * groupBy is 'flat'). Exposed as its own control mainly so a course group
@@ -64,12 +65,15 @@ function dayDiff(dueDate: string, today: Date): number {
   return Math.round((dueMidnight.getTime() - todayMidnight.getTime()) / 86_400_000);
 }
 
-/** Overdue first, then everything still open, then completed - the same
- * three-way status split used for 'status' grouping, reused here so 'Then
- * by: Status' produces a consistent order whatever it's layered onto. */
+/** Overdue, then started-but-not-done, then not-yet-started, then completed
+ * - the same four-way status split used for 'status' grouping, reused here
+ * so 'Then by: Status' produces a consistent order whatever it's layered
+ * onto (e.g. a course group sorted by status surfaces overdue and
+ * in-progress work first, regardless of due date). */
 function statusRank(item: ScheduleItem, today: Date): number {
-  if (item.completed) return 2;
-  return isOverdue(item, today) ? 0 : 1;
+  if (item.completed) return 3;
+  if (isOverdue(item, today)) return 0;
+  return clampProgress(item.progress ?? 0) > 0 ? 1 : 2;
 }
 
 function compareWithin(sort: WithinSort, a: ScheduleItem, b: ScheduleItem, today: Date): number {
@@ -159,19 +163,26 @@ export function PlannerView() {
     }
 
     if (groupBy === 'status') {
-      const buckets: Record<'overdue' | 'upcoming' | 'completed', ScheduleItem[]> = {
+      const buckets: Record<'overdue' | 'inProgress' | 'upcoming' | 'completed', ScheduleItem[]> = {
         overdue: [],
+        inProgress: [],
         upcoming: [],
         completed: [],
       };
       for (const item of filteredItems) {
         if (item.completed) buckets.completed.push(item);
         else if (isOverdue(item, today)) buckets.overdue.push(item);
+        else if (clampProgress(item.progress ?? 0) > 0) buckets.inProgress.push(item);
         else buckets.upcoming.push(item);
       }
-      const order: { key: 'overdue' | 'upcoming' | 'completed'; label: string; dot: string }[] = [
+      const order: {
+        key: 'overdue' | 'inProgress' | 'upcoming' | 'completed';
+        label: string;
+        dot: string;
+      }[] = [
         { key: 'overdue', label: 'Overdue', dot: 'bg-destructive' },
-        { key: 'upcoming', label: 'Upcoming', dot: 'bg-primary' },
+        { key: 'inProgress', label: 'In Progress', dot: 'bg-primary' },
+        { key: 'upcoming', label: 'Upcoming', dot: 'bg-muted-foreground' },
         { key: 'completed', label: 'Completed', dot: 'bg-load-low' },
       ];
       return order
@@ -243,6 +254,7 @@ export function PlannerView() {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.progress ? { progress: Number(values.progress) } : {}),
       },
       dispatch,
     );
@@ -419,6 +431,7 @@ export function PlannerView() {
                             }
                             courseColor={course?.color}
                             completed={item.completed}
+                            progress={item.progress}
                             priority={item.priority}
                             onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                             trailing={

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -414,22 +414,20 @@ export function PlannerView() {
                         </span>
                       </div>
                     )}
-                    <div className="divide-y divide-border">
+                    <div className="flex flex-col gap-2">
                       {group.items.map((item) => {
                         const course = courses.find((c) => c.id === item.courseId);
                         const overdue = isOverdue(item, today);
                         return (
                           <TaskRow
                             key={item.id}
+                            variant={state.preferences.taskRowVariant}
                             title={item.title}
                             href={'/tasks/' + item.id}
                             type={item.type}
-                            courseCode={
-                              course
-                                ? `${course.code} · ${TYPE_LABELS[item.type]}`
-                                : TYPE_LABELS[item.type]
-                            }
+                            courseCode={course ? course.code : 'General'}
                             courseColor={course?.color}
+                            courseIcon={course?.icon}
                             completed={item.completed}
                             progress={item.progress}
                             priority={item.priority}

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -9,13 +9,23 @@ import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
+import { courseSwatch } from '@/lib/courseColors';
+import { cn } from '@/lib/utils';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { ScheduleItem, AssignmentType } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 
 type StatusFilter = 'all' | 'pending' | 'completed';
-type SortMode = 'dueDate' | 'priority';
+/** What organizes the list into sections. 'date' buckets by due-date
+ * proximity (Overdue/Today/This Week/Later), 'course' buckets by class,
+ * 'status' buckets by Overdue/Upcoming/Completed, 'flat' renders one
+ * unsectioned list (today's original behavior). */
+type GroupBy = 'date' | 'course' | 'status' | 'flat';
+/** Ordering applied within each group (and across the whole list when
+ * groupBy is 'flat'). Exposed as its own control mainly so a course group
+ * can be re-ordered by status instead of just due date. */
+type WithinSort = 'dueDate' | 'priority' | 'status';
 
 const TYPE_LABELS: Record<AssignmentType, string> = {
   assignment: 'Assignment',
@@ -26,10 +36,62 @@ const TYPE_LABELS: Record<AssignmentType, string> = {
   other: 'Other',
 };
 
+const GROUP_BY_LABELS: Record<GroupBy, string> = {
+  date: 'Due Date',
+  course: 'Course',
+  status: 'Status',
+  flat: 'Flat',
+};
+
+const WITHIN_SORT_LABELS: Record<WithinSort, string> = {
+  dueDate: 'Due Date',
+  priority: 'Priority',
+  status: 'Status',
+};
+
 const PRIORITY_RANK = { high: 0, medium: 1, low: 2 };
 
 function isOverdue(item: ScheduleItem, today: Date): boolean {
   return !item.completed && new Date(item.dueDate) < today;
+}
+
+/** Days between an item's due date and `today`, ignoring time of day, so
+ * "Today"/"This Week" buckets don't depend on what hour it currently is. */
+function dayDiff(dueDate: string, today: Date): number {
+  const due = new Date(dueDate);
+  const dueMidnight = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  return Math.round((dueMidnight.getTime() - todayMidnight.getTime()) / 86_400_000);
+}
+
+/** Overdue first, then everything still open, then completed - the same
+ * three-way status split used for 'status' grouping, reused here so 'Then
+ * by: Status' produces a consistent order whatever it's layered onto. */
+function statusRank(item: ScheduleItem, today: Date): number {
+  if (item.completed) return 2;
+  return isOverdue(item, today) ? 0 : 1;
+}
+
+function compareWithin(sort: WithinSort, a: ScheduleItem, b: ScheduleItem, today: Date): number {
+  if (sort === 'priority') {
+    const rankA = PRIORITY_RANK[a.priority ?? 'medium'];
+    const rankB = PRIORITY_RANK[b.priority ?? 'medium'];
+    if (rankA !== rankB) return rankA - rankB;
+  } else if (sort === 'status') {
+    const rankA = statusRank(a, today);
+    const rankB = statusRank(b, today);
+    if (rankA !== rankB) return rankA - rankB;
+  }
+  return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+}
+
+interface ItemGroup {
+  key: string;
+  /** null renders no header at all (the 'flat' group). */
+  label: string | null;
+  courseColor?: string;
+  dotClassName?: string;
+  items: ScheduleItem[];
 }
 
 export function PlannerView() {
@@ -40,7 +102,8 @@ export function PlannerView() {
   const [courseFilter, setCourseFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState<'all' | AssignmentType>('all');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [sortMode, setSortMode] = useState<SortMode>('dueDate');
+  const [groupBy, setGroupBy] = useState<GroupBy>('date');
+  const [withinSort, setWithinSort] = useState<WithinSort>('dueDate');
   const [editingItem, setEditingItem] = useState<ScheduleItem | null>(null);
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
 
@@ -64,17 +127,102 @@ export function PlannerView() {
     if (statusFilter === 'pending') items = items.filter((i) => !i.completed);
     if (statusFilter === 'completed') items = items.filter((i) => i.completed);
 
-    items.sort((a, b) => {
-      if (sortMode === 'priority') {
-        const rankA = PRIORITY_RANK[a.priority ?? 'medium'];
-        const rankB = PRIORITY_RANK[b.priority ?? 'medium'];
-        if (rankA !== rankB) return rankA - rankB;
-      }
-      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
-    });
-
     return items;
-  }, [scheduleItems, courseFilter, typeFilter, statusFilter, sortMode]);
+  }, [scheduleItems, courseFilter, typeFilter, statusFilter]);
+
+  const groups = useMemo<ItemGroup[]>(() => {
+    const sortedWithin = (items: ScheduleItem[]) =>
+      items.slice().sort((a, b) => compareWithin(withinSort, a, b, today));
+
+    if (groupBy === 'flat') {
+      return [{ key: 'flat', label: null, items: sortedWithin(filteredItems) }];
+    }
+
+    if (groupBy === 'course') {
+      const byCourse = new Map<string, ScheduleItem[]>();
+      for (const item of filteredItems) {
+        const list = byCourse.get(item.courseId);
+        if (list) list.push(item);
+        else byCourse.set(item.courseId, [item]);
+      }
+      return Array.from(byCourse.entries())
+        .map(([courseId, items]) => {
+          const course = courses.find((c) => c.id === courseId);
+          return {
+            key: courseId,
+            label: course ? course.code : 'General',
+            courseColor: course?.color,
+            items: sortedWithin(items),
+          };
+        })
+        .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+    }
+
+    if (groupBy === 'status') {
+      const buckets: Record<'overdue' | 'upcoming' | 'completed', ScheduleItem[]> = {
+        overdue: [],
+        upcoming: [],
+        completed: [],
+      };
+      for (const item of filteredItems) {
+        if (item.completed) buckets.completed.push(item);
+        else if (isOverdue(item, today)) buckets.overdue.push(item);
+        else buckets.upcoming.push(item);
+      }
+      const order: { key: 'overdue' | 'upcoming' | 'completed'; label: string; dot: string }[] = [
+        { key: 'overdue', label: 'Overdue', dot: 'bg-destructive' },
+        { key: 'upcoming', label: 'Upcoming', dot: 'bg-primary' },
+        { key: 'completed', label: 'Completed', dot: 'bg-load-low' },
+      ];
+      return order
+        .filter((g) => buckets[g.key].length > 0)
+        .map((g) => ({
+          key: g.key,
+          label: g.label,
+          dotClassName: g.dot,
+          items: sortedWithin(buckets[g.key]),
+        }));
+    }
+
+    // date
+    const buckets: Record<'overdue' | 'today' | 'week' | 'later' | 'completed', ScheduleItem[]> = {
+      overdue: [],
+      today: [],
+      week: [],
+      later: [],
+      completed: [],
+    };
+    for (const item of filteredItems) {
+      if (item.completed) {
+        buckets.completed.push(item);
+        continue;
+      }
+      const diff = dayDiff(item.dueDate, today);
+      if (diff < 0) buckets.overdue.push(item);
+      else if (diff === 0) buckets.today.push(item);
+      else if (diff < 7) buckets.week.push(item);
+      else buckets.later.push(item);
+    }
+    const order: {
+      key: 'overdue' | 'today' | 'week' | 'later' | 'completed';
+      label: string;
+      dot: string;
+    }[] = [
+      { key: 'overdue', label: 'Overdue', dot: 'bg-destructive' },
+      { key: 'today', label: 'Today', dot: 'bg-primary' },
+      { key: 'week', label: 'This Week', dot: 'bg-muted-foreground' },
+      { key: 'later', label: 'Later', dot: 'bg-border' },
+      { key: 'completed', label: 'Completed', dot: 'bg-load-low' },
+    ];
+    return order
+      .filter((g) => buckets[g.key].length > 0)
+      .map((g) => ({
+        key: g.key,
+        label: g.label,
+        dotClassName: g.dot,
+        items: sortedWithin(buckets[g.key]),
+      }));
+  }, [filteredItems, groupBy, withinSort, today, courses]);
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
@@ -180,12 +328,27 @@ export function PlannerView() {
           </select>
 
           <select
-            value={sortMode}
-            onChange={(e) => setSortMode(e.target.value as SortMode)}
+            value={groupBy}
+            onChange={(e) => setGroupBy(e.target.value as GroupBy)}
             className={selectClass}
           >
-            <option value="dueDate">Sort: Due Date</option>
-            <option value="priority">Sort: Priority</option>
+            {Object.entries(GROUP_BY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                Group: {label}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={withinSort}
+            onChange={(e) => setWithinSort(e.target.value as WithinSort)}
+            className={selectClass}
+          >
+            {Object.entries(WITHIN_SORT_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                Then by: {label}
+              </option>
+            ))}
           </select>
         </div>
 
@@ -214,65 +377,96 @@ export function PlannerView() {
               description="Try widening your filters, or add a task from a course page."
             />
           ) : (
-            <div className="divide-y divide-border">
-              {filteredItems.map((item) => {
-                const course = courses.find((c) => c.id === item.courseId);
-                const overdue = isOverdue(item, today);
+            <div className="space-y-5">
+              {groups.map((group) => {
+                const swatch = group.courseColor ? courseSwatch(group.courseColor) : null;
                 return (
-                  <TaskRow
-                    key={item.id}
-                    title={item.title}
-                    href={'/tasks/' + item.id}
-                    type={item.type}
-                    courseCode={
-                      course ? `${course.code} · ${TYPE_LABELS[item.type]}` : TYPE_LABELS[item.type]
-                    }
-                    courseColor={course?.color}
-                    completed={item.completed}
-                    priority={item.priority}
-                    onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
-                    trailing={
-                      <>
-                        {overdue && (
-                          <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                            Overdue
-                          </span>
-                        )}
-                        <span className="text-xs text-muted-foreground">
-                          Due {dueDateFormatter.format(new Date(item.dueDate))}
-                        </span>
-                        <button
-                          onClick={() => setEditingItem(item)}
-                          className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
-                        >
-                          Edit
-                        </button>
-                        {confirmingDeleteId === item.id ? (
-                          <div className="flex items-center gap-2 text-xs">
-                            <button
-                              onClick={() => handleDeleteTask(item)}
-                              className="font-semibold text-destructive hover:underline"
-                            >
-                              Confirm
-                            </button>
-                            <button
-                              onClick={() => setConfirmingDeleteId(null)}
-                              className="text-muted-foreground hover:underline"
-                            >
-                              Cancel
-                            </button>
-                          </div>
+                  <div key={group.key}>
+                    {group.label && (
+                      <div className="mb-1.5 flex items-baseline gap-2 px-1">
+                        {swatch ? (
+                          <span
+                            className={cn('h-2 w-2 shrink-0 rounded-full', swatch.className)}
+                            style={swatch.style}
+                          />
                         ) : (
-                          <button
-                            onClick={() => setConfirmingDeleteId(item.id)}
-                            className="text-xs font-semibold text-destructive hover:underline"
-                          >
-                            Delete
-                          </button>
+                          group.dotClassName && (
+                            <span
+                              className={cn('h-2 w-2 shrink-0 rounded-full', group.dotClassName)}
+                            />
+                          )
                         )}
-                      </>
-                    }
-                  />
+                        <h3 className="text-xs font-semibold text-foreground">{group.label}</h3>
+                        <span className="text-[11px] text-muted-foreground">
+                          {group.items.length}
+                        </span>
+                      </div>
+                    )}
+                    <div className="divide-y divide-border">
+                      {group.items.map((item) => {
+                        const course = courses.find((c) => c.id === item.courseId);
+                        const overdue = isOverdue(item, today);
+                        return (
+                          <TaskRow
+                            key={item.id}
+                            title={item.title}
+                            href={'/tasks/' + item.id}
+                            type={item.type}
+                            courseCode={
+                              course
+                                ? `${course.code} · ${TYPE_LABELS[item.type]}`
+                                : TYPE_LABELS[item.type]
+                            }
+                            courseColor={course?.color}
+                            completed={item.completed}
+                            priority={item.priority}
+                            onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+                            trailing={
+                              <>
+                                {overdue && (
+                                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                                    Overdue
+                                  </span>
+                                )}
+                                <span className="text-xs text-muted-foreground">
+                                  Due {dueDateFormatter.format(new Date(item.dueDate))}
+                                </span>
+                                <button
+                                  onClick={() => setEditingItem(item)}
+                                  className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                                >
+                                  Edit
+                                </button>
+                                {confirmingDeleteId === item.id ? (
+                                  <div className="flex items-center gap-2 text-xs">
+                                    <button
+                                      onClick={() => handleDeleteTask(item)}
+                                      className="font-semibold text-destructive hover:underline"
+                                    >
+                                      Confirm
+                                    </button>
+                                    <button
+                                      onClick={() => setConfirmingDeleteId(null)}
+                                      className="text-muted-foreground hover:underline"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </div>
+                                ) : (
+                                  <button
+                                    onClick={() => setConfirmingDeleteId(item.id)}
+                                    className="text-xs font-semibold text-destructive hover:underline"
+                                  >
+                                    Delete
+                                  </button>
+                                )}
+                              </>
+                            }
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
                 );
               })}
             </div>

--- a/src/components/syllabus/DocumentViewerModal.tsx
+++ b/src/components/syllabus/DocumentViewerModal.tsx
@@ -182,7 +182,7 @@ export function DocumentViewerModal({ syllabus, onClose }: DocumentViewerModalPr
         role="dialog"
         aria-modal="true"
         aria-label={syllabus.fileName}
-        className="flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl"
+        className="flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-modal"
       >
         {/* Toolbar */}
         <div className="flex shrink-0 items-center gap-3 border-b border-border bg-card px-4 py-2.5">

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -367,7 +367,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         className="max-h-full w-full max-w-3xl overflow-y-auto outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-2xl">
+        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
           <div className="bg-gradient-brand px-6 py-6 text-white sm:px-8">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
               Syllabus Autofill

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -456,7 +456,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
             {step === 'extracting' && (
               <div className="flex flex-col items-center justify-center gap-4 py-16">
                 <div className="relative h-12 w-12">
-                  <div className="absolute inset-0 animate-spin rounded-full border-[3px] border-primary/15 border-t-primary" />
+                  <div className="spinner-gradient absolute inset-0 animate-spin rounded-full" />
                 </div>
                 <div className="text-center">
                   <p className="text-sm font-semibold text-foreground">
@@ -471,7 +471,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
             {(step === 'review' || step === 'saving') && course && (
               <div className="space-y-6">
-                <section className="space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5">
+                <section
+                  className="review-reveal space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5"
+                  style={{ animationDelay: '0ms' }}
+                >
                   <div className="flex items-start gap-3">
                     <span
                       className={cn(
@@ -629,7 +632,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 </section>
 
                 {course.meetingTimes.length > 0 && (
-                  <section className="space-y-2">
+                  <section className="review-reveal space-y-2" style={{ animationDelay: '60ms' }}>
                     <h3 className="text-sm font-semibold text-foreground">Meeting times</h3>
                     {course.meetingTimes.map((m, i) => (
                       <div
@@ -679,7 +682,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 )}
 
                 {course.materials.length > 0 && (
-                  <section className="space-y-2">
+                  <section className="review-reveal space-y-2" style={{ animationDelay: '120ms' }}>
                     <h3 className="text-sm font-semibold text-foreground">
                       Materials &amp; supplies
                     </h3>
@@ -705,7 +708,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 )}
 
                 <section className="space-y-3">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div
+                    className="review-reveal flex flex-wrap items-center justify-between gap-2"
+                    style={{ animationDelay: '180ms' }}
+                  >
                     <h3 className="text-sm font-semibold text-foreground">
                       Assignments
                       <span className="ml-1.5 font-normal text-muted-foreground">
@@ -755,20 +761,24 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     )}
                   </div>
                   {items.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">
+                    <p
+                      className="review-reveal text-xs text-muted-foreground"
+                      style={{ animationDelay: '220ms' }}
+                    >
                       No dated items found in this syllabus.
                     </p>
                   ) : (
                     <div className="space-y-2">
-                      {items.map((it) => (
+                      {items.map((it, i) => (
                         <div
                           key={it.key}
                           className={cn(
-                            'rounded-xl border p-3 text-xs transition-colors',
+                            'review-reveal rounded-xl border p-3 text-xs transition-colors',
                             it.approved
                               ? 'border-border bg-card'
                               : 'border-dashed border-border/70 bg-transparent opacity-60',
                           )}
+                          style={{ animationDelay: `${Math.min(220 + i * 40, 580)}ms` }}
                         >
                           <div className="flex flex-wrap items-center gap-2">
                             <div className="flex shrink-0 overflow-hidden rounded-full border border-border">
@@ -858,7 +868,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 </section>
 
                 {unresolved.length > 0 && (
-                  <section className="rounded-xl border border-load-medium/30 bg-load-medium/10 p-3">
+                  <section
+                    className="review-reveal rounded-xl border border-load-medium/30 bg-load-medium/10 p-3"
+                    style={{ animationDelay: '580ms' }}
+                  >
                     <h3 className="text-xs font-semibold text-load-medium">
                       Couldn&apos;t determine
                     </h3>

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -17,7 +17,7 @@ import { scheduleItemFormSchema } from '@/lib/validation/scheduleItem';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
-import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
+import { COURSE_COLOR_PRESETS, pickSuggestedCourseColor } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import type {
   ExtractedMeetingTime,
@@ -96,6 +96,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   } | null>(null);
   const [items, setItems] = useState<DraftItem[]>([]);
   const [unresolved, setUnresolved] = useState<string[]>([]);
+  const [suggestedFileName, setSuggestedFileName] = useState<string | null>(null);
 
   const reset = () => {
     setStep('upload');
@@ -104,6 +105,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setCourse(null);
     setItems([]);
     setUnresolved([]);
+    setSuggestedFileName(null);
   };
 
   const handleClose = () => {
@@ -147,11 +149,12 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         title: result.course.title,
         instructor: result.course.instructor ?? '',
         term: result.course.term ?? '',
-        // Auto-assigned to whichever preset is least represented among the
-        // user's existing courses, so extracted courses don't all default
-        // to the same blue - the user can still change it on the review
-        // screen before confirming.
-        color: pickNextCourseColor(state.courses),
+        // Claude's subject-matched suggestion when it made one and it isn't
+        // already taken by another of the user's courses; otherwise falls
+        // back to whichever preset is least represented so extracted
+        // courses don't all default to the same blue. Either way, the user
+        // can still change it on the review screen before confirming.
+        color: pickSuggestedCourseColor(state.courses, result.course.suggestedColor),
         modality: result.course.modality ?? undefined,
         meetingTimes: result.course.meetingTimes.map((m: ExtractedMeetingTime) => ({
           dayOfWeek: m.dayOfWeek,
@@ -171,6 +174,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         })),
       );
       setUnresolved(result.unresolved);
+      setSuggestedFileName(result.course.suggestedFileName ?? null);
       setStep('review');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Extraction failed. Please try again.');
@@ -286,7 +290,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
       if (file) {
         try {
-          await saveSyllabusPdf(user.uid, newCourse.id, file);
+          await saveSyllabusPdf(
+            user.uid,
+            newCourse.id,
+            withSuggestedFileName(file, suggestedFileName),
+          );
         } catch {
           // Non-fatal: the course and tasks are already saved. The user can
           // re-upload the PDF from the course page if this fails.
@@ -450,6 +458,17 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                       />
                     </label>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    Color and file name are Claude&apos;s suggestions based on the syllabus &mdash;
+                    change them however you like.
+                    {suggestedFileName && (
+                      <>
+                        {' '}
+                        Saving as{' '}
+                        <span className="font-medium text-foreground">{suggestedFileName}</span>.
+                      </>
+                    )}
+                  </p>
                 </section>
 
                 {course.meetingTimes.length > 0 && (
@@ -653,6 +672,18 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       </div>
     </div>
   );
+}
+
+/** Renames a File to Claude's suggested display name (keeping the original
+ * extension), so the syllabus shows up in the course's file list as e.g.
+ * "ECON 201 - Fall 2026 Syllabus.pdf" instead of whatever the source file
+ * happened to be called. Falls back to the original file untouched when
+ * there's no suggestion. */
+function withSuggestedFileName(file: File, suggestedName: string | null): File {
+  if (!suggestedName) return file;
+  const dotIndex = file.name.lastIndexOf('.');
+  const extension = dotIndex > -1 ? file.name.slice(dotIndex) : '';
+  return new File([file], `${suggestedName}${extension}`, { type: file.type });
 }
 
 /** Wraps the existing resumable-upload hook for a one-shot call outside of

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -2,14 +2,7 @@
 
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardFooter,
-} from '@/components/ui/Card';
+import { Card, CardContent, CardFooter } from '@/components/ui/Card';
 import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
 import { createCourseWithScheduleItems } from '@/lib/firestore/courses';
 import { courseFormSchema } from '@/lib/validation/course';
@@ -17,7 +10,9 @@ import { scheduleItemFormSchema } from '@/lib/validation/scheduleItem';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
-import { COURSE_COLOR_PRESETS, pickSuggestedCourseColor } from '@/lib/courseColors';
+import { COURSE_COLOR_PRESETS, courseSwatch, pickSuggestedCourseColor } from '@/lib/courseColors';
+import { COURSE_ICON_PRESETS, pickSuggestedCourseIcon } from '@/lib/courseIcons';
+import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
 import { cn } from '@/lib/utils';
 import type {
   ExtractedMeetingTime,
@@ -45,13 +40,20 @@ const TYPE_LABELS: Record<AssignmentType, string> = {
 
 type Step = 'upload' | 'extracting' | 'review' | 'saving';
 
+const STEPS: { key: Step; label: string }[] = [
+  { key: 'upload', label: 'Upload' },
+  { key: 'extracting', label: 'Parse' },
+  { key: 'review', label: 'Review' },
+  { key: 'saving', label: 'Save' },
+];
+
 interface DraftItem extends ExtractedScheduleItem {
   /** Local id for React keys/editing - not persisted as-is. */
   key: string;
   /** Whether this item will be created when the user confirms. Items with
-   * no resolvable date start unchecked and locked until a date is filled
+   * no resolvable date start rejected and locked until a date is filled
    * in, so nothing with a fabricated date silently lands on the calendar. */
-  include: boolean;
+  approved: boolean;
 }
 
 function fileToBase64(file: File): Promise<string> {
@@ -80,6 +82,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   const [dragActive, setDragActive] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [rerunCount, setRerunCount] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [course, setCourse] = useState<{
@@ -88,6 +91,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     instructor: string;
     term: string;
     color: string;
+    icon: string;
     modality: CourseModality | undefined;
     meetingTimes: MeetingTime[];
     materials: string[];
@@ -96,7 +100,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   } | null>(null);
   const [items, setItems] = useState<DraftItem[]>([]);
   const [unresolved, setUnresolved] = useState<string[]>([]);
-  const [suggestedFileName, setSuggestedFileName] = useState<string | null>(null);
+  /** Claude's suggested syllabus file name, freely editable - not just a
+   * caption. Empty string is valid input mid-edit; falls back to the
+   * original upload's name at save time if left blank. */
+  const [fileName, setFileName] = useState('');
 
   const reset = () => {
     setStep('upload');
@@ -105,7 +112,8 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setCourse(null);
     setItems([]);
     setUnresolved([]);
-    setSuggestedFileName(null);
+    setFileName('');
+    setRerunCount(0);
   };
 
   const handleClose = () => {
@@ -121,16 +129,9 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
   if (!open) return null;
 
-  const handleFile = async (selected: File) => {
-    const result = validateSyllabusFile(selected);
-    if (!result.valid) {
-      setError(result.error ?? 'Invalid file.');
-      return;
-    }
+  const runExtraction = async (selected: File) => {
     setError(null);
-    setFile(selected);
     setStep('extracting');
-
     try {
       if (!user) throw new Error('You must be signed in.');
       const idToken = await user.getIdToken();
@@ -155,6 +156,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         // courses don't all default to the same blue. Either way, the user
         // can still change it on the review screen before confirming.
         color: pickSuggestedCourseColor(state.courses, result.course.suggestedColor),
+        icon: pickSuggestedCourseIcon(result.course.suggestedIcon),
         modality: result.course.modality ?? undefined,
         meetingTimes: result.course.meetingTimes.map((m: ExtractedMeetingTime) => ({
           dayOfWeek: m.dayOfWeek,
@@ -170,16 +172,36 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         result.scheduleItems.map((item, i) => ({
           ...item,
           key: `${i}-${item.title}`,
-          include: item.dueDate !== null,
+          approved: item.dueDate !== null,
         })),
       );
       setUnresolved(result.unresolved);
-      setSuggestedFileName(result.course.suggestedFileName ?? null);
+      setFileName(result.course.suggestedFileName ?? '');
       setStep('review');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Extraction failed. Please try again.');
-      setStep('upload');
+      setStep(course ? 'review' : 'upload');
     }
+  };
+
+  const handleFile = async (selected: File) => {
+    const result = validateSyllabusFile(selected);
+    if (!result.valid) {
+      setError(result.error ?? 'Invalid file.');
+      return;
+    }
+    setFile(selected);
+    await runExtraction(selected);
+  };
+
+  /** "Reject and send it back to the AI": discards the current draft and
+   * re-runs extraction on the same uploaded file. A fresh pass can land
+   * differently since the model isn't deterministic, and it's cheaper than
+   * asking the student to re-upload. */
+  const handleRerun = async () => {
+    if (!file) return;
+    setRerunCount((n) => n + 1);
+    await runExtraction(file);
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -191,6 +213,14 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
   const updateItem = (key: string, patch: Partial<DraftItem>) => {
     setItems((prev) => prev.map((it) => (it.key === key ? { ...it, ...patch } : it)));
+  };
+
+  const approveAll = () => {
+    setItems((prev) => prev.map((it) => ({ ...it, approved: it.dueDate !== null })));
+  };
+
+  const rejectAll = () => {
+    setItems((prev) => prev.map((it) => ({ ...it, approved: false })));
   };
 
   const updateMeeting = (index: number, patch: Partial<MeetingTime>) => {
@@ -219,6 +249,8 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setCourse((c) => (c ? { ...c, materials: c.materials.filter((_, i) => i !== index) } : c));
   };
 
+  const approvedCount = items.filter((i) => i.approved).length;
+
   const handleConfirm = async () => {
     if (!course || !user) return;
 
@@ -232,7 +264,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       return;
     }
     for (const it of items) {
-      if (!it.include || !it.dueDate) continue;
+      if (!it.approved || !it.dueDate) continue;
       const itemCheck = scheduleItemFormSchema.safeParse({
         title: it.title,
         type: it.type,
@@ -257,6 +289,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         code: course.code,
         title: course.title,
         color: course.color,
+        icon: course.icon,
         source: 'ai',
         ...(course.instructor ? { instructor: course.instructor } : {}),
         ...(course.term ? { term: course.term } : {}),
@@ -266,8 +299,8 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         ...(course.skipDates.length ? { skipDates: course.skipDates } : {}),
         ...(course.notes ? { notes: course.notes } : {}),
       };
-      const included = items.filter((it) => it.include && it.dueDate);
-      const scheduleItems: ScheduleItem[] = included.map((it) => ({
+      const approved = items.filter((it) => it.approved && it.dueDate);
+      const scheduleItems: ScheduleItem[] = approved.map((it) => ({
         id: crypto.randomUUID(),
         courseId: newCourse.id,
         title: it.title,
@@ -290,11 +323,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
       if (file) {
         try {
-          await saveSyllabusPdf(
-            user.uid,
-            newCourse.id,
-            withSuggestedFileName(file, suggestedFileName),
-          );
+          await saveSyllabusPdf(user.uid, newCourse.id, withFileName(file, fileName));
         } catch {
           // Non-fatal: the course and tasks are already saved. The user can
           // re-upload the PDF from the course page if this fails.
@@ -311,7 +340,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4 py-8"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4 py-8 backdrop-blur-[2px]"
       role="dialog"
       aria-modal="true"
       aria-labelledby="autofill-title"
@@ -320,21 +349,43 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="max-h-full w-full max-w-2xl overflow-y-auto outline-none"
+        className="max-h-full w-full max-w-3xl overflow-y-auto outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
-          <CardHeader>
-            <CardTitle id="autofill-title">Autofill from Syllabus</CardTitle>
-            <CardDescription>
-              Upload a syllabus PDF or Word doc and review what Claude found before it&apos;s added.
-            </CardDescription>
-          </CardHeader>
+        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-2xl">
+          <div className="bg-gradient-brand px-6 py-6 text-white sm:px-8">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+              Syllabus Autofill
+            </p>
+            <h2 id="autofill-title" className="mt-1 text-xl font-bold tracking-tight sm:text-2xl">
+              Let Claude read it, you decide what sticks
+            </h2>
+            <p className="mt-1.5 max-w-xl text-sm text-white/80">
+              Upload a syllabus, review every field and assignment Claude drafted, and approve only
+              what you want on your calendar.
+            </p>
+            <div className="mt-5">
+              <StepIndicator step={step} />
+            </div>
+          </div>
 
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-5 p-6 sm:p-8">
             {error && (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {error}
+              <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3.5 py-2.5 text-sm text-destructive">
+                <svg
+                  className="mt-0.5 h-4 w-4 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <span>{error}</span>
               </div>
             )}
 
@@ -350,11 +401,26 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 role="button"
                 tabIndex={0}
                 className={cn(
-                  'flex flex-col items-center justify-center gap-1 rounded-xl border-2 border-dashed px-4 py-10 text-center cursor-pointer transition-colors',
-                  dragActive ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent',
+                  'flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed px-4 py-16 text-center cursor-pointer transition-colors',
+                  dragActive ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/60',
                 )}
               >
-                <span className="text-sm font-medium text-foreground">
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <svg
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.75}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M12 12v9m0-9l-3 3m3-3l3 3"
+                    />
+                  </svg>
+                </span>
+                <span className="text-sm font-semibold text-foreground">
                   Drop a syllabus PDF or Word doc here, or click to browse
                 </span>
                 <span className="text-xs text-muted-foreground">PDF or .docx, up to 10MB</span>
@@ -373,102 +439,178 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
             )}
 
             {step === 'extracting' && (
-              <div className="flex flex-col items-center justify-center gap-3 py-14">
-                <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-                <p className="text-sm text-muted-foreground">Reading your syllabus...</p>
+              <div className="flex flex-col items-center justify-center gap-4 py-16">
+                <div className="relative h-12 w-12">
+                  <div className="absolute inset-0 animate-spin rounded-full border-[3px] border-primary/15 border-t-primary" />
+                </div>
+                <div className="text-center">
+                  <p className="text-sm font-semibold text-foreground">
+                    {rerunCount > 0 ? 'Giving it another pass...' : 'Reading your syllabus...'}
+                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    Finding the course details, every assignment, and a color and icon that fit.
+                  </p>
+                </div>
               </div>
             )}
 
             {(step === 'review' || step === 'saving') && course && (
               <div className="space-y-6">
-                <section className="space-y-3">
-                  <h3 className="text-sm font-semibold text-foreground">Course</h3>
-                  <div className="grid grid-cols-2 gap-3">
-                    <TextField
-                      id="autofill-course-code"
-                      label="Code"
-                      value={course.code}
-                      onChange={(v) => setCourse((c) => c && { ...c, code: v })}
-                    />
-                    <TextField
-                      id="autofill-course-term"
-                      label="Term"
-                      value={course.term}
-                      onChange={(v) => setCourse((c) => c && { ...c, term: v })}
-                    />
+                <section className="space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5">
+                  <div className="flex items-start gap-3">
+                    <span
+                      className={cn(
+                        'flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl text-white shadow-sm',
+                        courseSwatch(course.color).className,
+                      )}
+                      style={courseSwatch(course.color).style}
+                    >
+                      <CourseIconGlyph icon={course.icon} className="h-6 w-6" />
+                    </span>
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div className="grid grid-cols-2 gap-2.5">
+                        <TextField
+                          id="autofill-course-code"
+                          label="Code"
+                          value={course.code}
+                          onChange={(v) => setCourse((c) => c && { ...c, code: v })}
+                        />
+                        <TextField
+                          id="autofill-course-term"
+                          label="Term"
+                          value={course.term}
+                          onChange={(v) => setCourse((c) => c && { ...c, term: v })}
+                        />
+                      </div>
+                      <TextField
+                        id="autofill-course-title"
+                        label="Title"
+                        value={course.title}
+                        onChange={(v) => setCourse((c) => c && { ...c, title: v })}
+                      />
+                    </div>
                   </div>
-                  <TextField
-                    id="autofill-course-title"
-                    label="Title"
-                    value={course.title}
-                    onChange={(v) => setCourse((c) => c && { ...c, title: v })}
-                  />
+
                   <TextField
                     id="autofill-course-instructor"
                     label="Instructor"
                     value={course.instructor}
                     onChange={(v) => setCourse((c) => c && { ...c, instructor: v })}
                   />
-                  <div className="flex flex-wrap gap-2">
-                    {COURSE_COLOR_PRESETS.map((preset) => (
-                      <button
-                        key={preset.value}
-                        type="button"
-                        aria-label={preset.value}
-                        onClick={() => setCourse((c) => c && { ...c, color: preset.value })}
+
+                  <div className="space-y-1.5">
+                    <span className="text-xs font-semibold text-muted-foreground">Color</span>
+                    <div className="flex flex-wrap gap-2">
+                      {COURSE_COLOR_PRESETS.map((preset) => (
+                        <button
+                          key={preset.value}
+                          type="button"
+                          aria-label={preset.value}
+                          onClick={() => setCourse((c) => c && { ...c, color: preset.value })}
+                          className={cn(
+                            'h-7 w-7 rounded-full transition-transform',
+                            preset.value,
+                            course.color === preset.value
+                              ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
+                              : 'hover:scale-110',
+                          )}
+                        />
+                      ))}
+                      <label
+                        aria-label="Custom color"
+                        title="Custom color"
                         className={cn(
-                          'h-6 w-6 rounded-full transition-transform',
-                          preset.value,
-                          course.color === preset.value
-                            ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
-                            : 'hover:scale-110',
+                          'relative flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
+                          course.color.startsWith('#') &&
+                            'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
                         )}
-                      />
-                    ))}
-                    <label
-                      aria-label="Custom color"
-                      title="Custom color"
-                      className={cn(
-                        'relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
-                        course.color.startsWith('#') &&
-                          'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
-                      )}
-                      style={
-                        course.color.startsWith('#')
-                          ? { backgroundColor: course.color, borderStyle: 'solid' }
-                          : undefined
-                      }
-                    >
-                      {!course.color.startsWith('#') && (
-                        <svg
-                          className="h-3 w-3"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                        </svg>
-                      )}
-                      <input
-                        type="color"
-                        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-                        value={course.color.startsWith('#') ? course.color : '#7c3aed'}
-                        onChange={(e) => setCourse((c) => c && { ...c, color: e.target.value })}
-                      />
-                    </label>
+                        style={
+                          course.color.startsWith('#')
+                            ? { backgroundColor: course.color, borderStyle: 'solid' }
+                            : undefined
+                        }
+                      >
+                        {!course.color.startsWith('#') && (
+                          <svg
+                            className="h-3.5 w-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                          </svg>
+                        )}
+                        <input
+                          type="color"
+                          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                          value={course.color.startsWith('#') ? course.color : '#7c3aed'}
+                          onChange={(e) => setCourse((c) => c && { ...c, color: e.target.value })}
+                        />
+                      </label>
+                    </div>
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    Color and file name are Claude&apos;s suggestions based on the syllabus &mdash;
-                    change them however you like.
-                    {suggestedFileName && (
-                      <>
-                        {' '}
-                        Saving as{' '}
-                        <span className="font-medium text-foreground">{suggestedFileName}</span>.
-                      </>
-                    )}
-                  </p>
+
+                  <div className="space-y-1.5">
+                    <span className="text-xs font-semibold text-muted-foreground">Icon</span>
+                    <div className="flex flex-wrap gap-2">
+                      {COURSE_ICON_PRESETS.map((preset) => (
+                        <button
+                          key={preset.value}
+                          type="button"
+                          title={preset.label}
+                          aria-label={preset.label}
+                          onClick={() => setCourse((c) => c && { ...c, icon: preset.value })}
+                          className={cn(
+                            'flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground transition-colors',
+                            course.icon === preset.value
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border bg-card hover:bg-accent',
+                          )}
+                        >
+                          <CourseIconGlyph icon={preset.value} className="h-4 w-4" />
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="autofill-filename"
+                      className="text-xs font-semibold text-muted-foreground"
+                    >
+                      Syllabus file name
+                    </label>
+                    <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+                      <svg
+                        className="h-4 w-4 shrink-0 text-muted-foreground"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.75}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                        />
+                      </svg>
+                      <input
+                        id="autofill-filename"
+                        value={fileName}
+                        onChange={(e) => setFileName(e.target.value)}
+                        placeholder={file?.name ?? 'Syllabus'}
+                        className="min-w-0 flex-1 bg-transparent text-sm text-foreground focus:outline-none"
+                      />
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {extensionOf(file?.name)}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Color, icon, and this file name are Claude&apos;s suggestions &mdash; every
+                      one is editable.
+                    </p>
+                  </div>
                 </section>
 
                 {course.meetingTimes.length > 0 && (
@@ -547,11 +689,56 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   </section>
                 )}
 
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    Schedule items ({items.filter((i) => i.include).length} of {items.length}{' '}
-                    selected)
-                  </h3>
+                <section className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold text-foreground">
+                      Assignments
+                      <span className="ml-1.5 font-normal text-muted-foreground">
+                        {approvedCount} of {items.length} approved
+                      </span>
+                    </h3>
+                    {items.length > 0 && (
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          type="button"
+                          onClick={approveAll}
+                          className="rounded-full border border-border px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:bg-accent"
+                        >
+                          Approve all
+                        </button>
+                        <button
+                          type="button"
+                          onClick={rejectAll}
+                          className="rounded-full border border-border px-2.5 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent"
+                        >
+                          Reject all
+                        </button>
+                        {file && (
+                          <button
+                            type="button"
+                            onClick={handleRerun}
+                            className="ml-1 flex items-center gap-1 rounded-full border border-dashed border-primary/40 px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                            title="Not right? Discard this draft and ask Claude to re-read the file."
+                          >
+                            <svg
+                              className="h-3 w-3"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2.25}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                              />
+                            </svg>
+                            Not right? Re-run AI
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
                   {items.length === 0 ? (
                     <p className="text-xs text-muted-foreground">
                       No dated items found in this syllabus.
@@ -562,18 +749,40 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                         <div
                           key={it.key}
                           className={cn(
-                            'rounded-lg border p-2.5 text-xs',
-                            it.include ? 'border-border' : 'border-dashed border-border opacity-70',
+                            'rounded-xl border p-3 text-xs transition-colors',
+                            it.approved
+                              ? 'border-border bg-card'
+                              : 'border-dashed border-border/70 bg-transparent opacity-60',
                           )}
                         >
-                          <div className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={it.include}
-                              disabled={!it.dueDate}
-                              onChange={(e) => updateItem(it.key, { include: e.target.checked })}
-                              className="h-3.5 w-3.5 rounded border-border accent-primary"
-                            />
+                          <div className="flex flex-wrap items-center gap-2">
+                            <div className="flex shrink-0 overflow-hidden rounded-full border border-border">
+                              <button
+                                type="button"
+                                onClick={() => updateItem(it.key, { approved: true })}
+                                disabled={!it.dueDate}
+                                className={cn(
+                                  'px-2.5 py-1 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40',
+                                  it.approved
+                                    ? 'bg-primary text-primary-foreground'
+                                    : 'bg-card text-muted-foreground hover:bg-accent',
+                                )}
+                              >
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => updateItem(it.key, { approved: false })}
+                                className={cn(
+                                  'border-l border-border px-2.5 py-1 font-semibold transition-colors',
+                                  !it.approved
+                                    ? 'bg-destructive/10 text-destructive'
+                                    : 'bg-card text-muted-foreground hover:bg-accent',
+                                )}
+                              >
+                                Reject
+                              </button>
+                            </div>
                             <input
                               value={it.title}
                               onChange={(e) => updateItem(it.key, { title: e.target.value })}
@@ -598,13 +807,13 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                               onChange={(e) =>
                                 updateItem(it.key, {
                                   dueDate: e.target.value || null,
-                                  include: e.target.value ? it.include : false,
+                                  approved: e.target.value ? it.approved : false,
                                 })
                               }
                               className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground"
                             />
                           </div>
-                          <div className="mt-1.5 flex flex-wrap items-center gap-1.5 pl-6">
+                          <div className="mt-2 flex flex-wrap items-center gap-1.5 pl-[4.5rem]">
                             {it.dateConfidence === 'approximate' && (
                               <span className="rounded-full bg-load-medium/10 px-2 py-0.5 font-semibold text-load-medium">
                                 ~ approximate date, please confirm
@@ -612,7 +821,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                             )}
                             {it.dateConfidence === 'unknown' && (
                               <span className="rounded-full bg-accent px-2 py-0.5 font-medium text-muted-foreground">
-                                No date found - add one to include this
+                                No date found - add one to approve this
                               </span>
                             )}
                             {it.highStakes && (
@@ -634,7 +843,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 </section>
 
                 {unresolved.length > 0 && (
-                  <section className="rounded-lg border border-load-medium/30 bg-load-medium/10 p-3">
+                  <section className="rounded-xl border border-load-medium/30 bg-load-medium/10 p-3">
                     <h3 className="text-xs font-semibold text-load-medium">
                       Couldn&apos;t determine
                     </h3>
@@ -650,7 +859,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
           </CardContent>
 
           {(step === 'review' || step === 'saving') && (
-            <CardFooter className="justify-end gap-2">
+            <CardFooter className="flex-wrap justify-end gap-2 border-t border-border bg-accent/20 px-6 py-4 sm:px-8">
               <button
                 type="button"
                 onClick={handleClose}
@@ -664,7 +873,9 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                 disabled={step === 'saving' || !course?.code || !course?.title}
                 className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
               >
-                {step === 'saving' ? 'Saving...' : 'Add Course & Tasks'}
+                {step === 'saving'
+                  ? 'Saving...'
+                  : `Add Course & ${approvedCount} Task${approvedCount === 1 ? '' : 's'}`}
               </button>
             </CardFooter>
           )}
@@ -674,16 +885,70 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   );
 }
 
-/** Renames a File to Claude's suggested display name (keeping the original
- * extension), so the syllabus shows up in the course's file list as e.g.
- * "ECON 201 - Fall 2026 Syllabus.pdf" instead of whatever the source file
- * happened to be called. Falls back to the original file untouched when
- * there's no suggestion. */
-function withSuggestedFileName(file: File, suggestedName: string | null): File {
-  if (!suggestedName) return file;
-  const dotIndex = file.name.lastIndexOf('.');
-  const extension = dotIndex > -1 ? file.name.slice(dotIndex) : '';
-  return new File([file], `${suggestedName}${extension}`, { type: file.type });
+function StepIndicator({ step }: { step: Step }) {
+  const currentIndex = STEPS.findIndex((s) => s.key === step);
+  return (
+    <ol className="flex items-center gap-2">
+      {STEPS.map((s, i) => (
+        <li key={s.key} className="flex flex-1 items-center gap-2 last:flex-none">
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span
+              className={cn(
+                'flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold transition-colors',
+                i < currentIndex
+                  ? 'bg-white text-primary'
+                  : i === currentIndex
+                    ? 'bg-white/25 text-white ring-2 ring-white'
+                    : 'bg-white/15 text-white/60',
+              )}
+            >
+              {i < currentIndex ? (
+                <svg
+                  className="h-3 w-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={3}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              ) : (
+                i + 1
+              )}
+            </span>
+            <span
+              className={cn(
+                'text-xs font-semibold whitespace-nowrap',
+                i <= currentIndex ? 'text-white' : 'text-white/50',
+              )}
+            >
+              {s.label}
+            </span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <div className={cn('h-px flex-1', i < currentIndex ? 'bg-white/70' : 'bg-white/20')} />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function extensionOf(name: string | undefined): string {
+  if (!name) return '';
+  const dotIndex = name.lastIndexOf('.');
+  return dotIndex > -1 ? name.slice(dotIndex) : '';
+}
+
+/** Renames a File to the (editable) suggested display name, keeping the
+ * original extension, so the syllabus shows up in the course's file list
+ * as e.g. "ECON 201 - Fall 2026 Syllabus.pdf" instead of whatever the
+ * source file happened to be called. Falls back to the original file
+ * untouched when the field was left blank. */
+function withFileName(file: File, name: string): File {
+  const trimmed = name.trim();
+  if (!trimmed) return file;
+  return new File([file], `${trimmed}${extensionOf(file.name)}`, { type: file.type });
 }
 
 /** Wraps the existing resumable-upload hook for a one-shot call outside of
@@ -724,14 +989,14 @@ function TextField({
 }) {
   return (
     <div className="space-y-1">
-      <label htmlFor={id} className="text-xs font-medium text-foreground">
+      <label htmlFor={id} className="text-xs font-semibold text-muted-foreground">
         {label}
       </label>
       <input
         id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+        className="w-full rounded-lg border border-border bg-card px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
       />
     </div>
   );

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -151,12 +151,20 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         instructor: result.course.instructor ?? '',
         term: result.course.term ?? '',
         // Claude's subject-matched suggestion when it made one and it isn't
-        // already taken by another of the user's courses; otherwise falls
+        // already taken by another of this term's courses; otherwise falls
         // back to whichever preset is least represented so extracted
         // courses don't all default to the same blue. Either way, the user
         // can still change it on the review screen before confirming.
-        color: pickSuggestedCourseColor(state.courses, result.course.suggestedColor),
-        icon: pickSuggestedCourseIcon(result.course.suggestedIcon),
+        color: pickSuggestedCourseColor(
+          state.courses,
+          result.course.term,
+          result.course.suggestedColor,
+        ),
+        icon: pickSuggestedCourseIcon(
+          state.courses,
+          result.course.term,
+          result.course.suggestedIcon,
+        ),
         modality: result.course.modality ?? undefined,
         meetingTimes: result.course.meetingTimes.map((m: ExtractedMeetingTime) => ({
           dayOfWeek: m.dayOfWeek,
@@ -176,7 +184,14 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         })),
       );
       setUnresolved(result.unresolved);
-      setFileName(result.course.suggestedFileName ?? '');
+      setFileName(
+        dedupeSuggestedFileName(
+          state.courses,
+          result.course.term,
+          result.course.code,
+          result.course.suggestedFileName,
+        ),
+      );
       setStep('review');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Extraction failed. Please try again.');
@@ -932,6 +947,22 @@ function StepIndicator({ step }: { step: Step }) {
       ))}
     </ol>
   );
+}
+
+/** Suffixes Claude's suggested file name with a small disambiguator when
+ * another course this term already shares this course's code (e.g. two
+ * sections of the same class) - not a guarantee against every possible
+ * collision, just enough that the common case doesn't quietly produce two
+ * identically-named syllabus files. The user can still edit it either way. */
+function dedupeSuggestedFileName(
+  existingCourses: Pick<Course, 'code' | 'term'>[],
+  term: string | null | undefined,
+  code: string | undefined,
+  suggested: string | null | undefined,
+): string {
+  if (!suggested || !code) return suggested ?? '';
+  const collisions = existingCourses.filter((c) => c.term === term && c.code === code).length;
+  return collisions > 0 ? `${suggested} (${collisions + 1})` : suggested;
 }
 
 function extensionOf(name: string | undefined): string {

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -8,11 +8,15 @@ import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
+import { ProgressRing } from '@/components/ui/ProgressRing';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
 import { ICON_PATHS } from '@/lib/icons';
+import { clampProgress, getTaskStatus, TASK_STATUS_LABEL } from '@/lib/taskStatus';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { AssignmentType } from '@/types/schedule';
 import { cn } from '@/lib/utils';
+
+const PROGRESS_PRESETS = [0, 25, 50, 75, 100];
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -66,6 +70,18 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
     await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
   };
 
+  const handleSetProgress = async (value: number) => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, progress: clampProgress(value) }, dispatch);
+  };
+
+  const status = getTaskStatus(item);
+  const progressPct = clampProgress(item.progress ?? 0);
+  const remainingHours =
+    item.estimatedHours != null
+      ? Math.round(item.estimatedHours * (1 - progressPct / 100) * 10) / 10
+      : null;
+
   const handleEditTask = async (values: ScheduleItemFormValues) => {
     if (!user) throw new Error('You must be signed in to edit a task.');
     await updateScheduleItem(
@@ -80,6 +96,7 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.progress ? { progress: Number(values.progress) } : {}),
       },
       dispatch,
     );
@@ -169,6 +186,54 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
             </span>
           )}
         </div>
+
+        {!item.completed && (
+          <div className="border-t border-border pt-5">
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Progress</span>
+              <span
+                className={cn(
+                  'rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                  status === 'in_progress'
+                    ? 'bg-primary/10 text-primary'
+                    : 'bg-accent text-muted-foreground',
+                )}
+              >
+                {TASK_STATUS_LABEL[status]}
+              </span>
+            </div>
+            <div className="flex items-center gap-4">
+              <ProgressRing percent={progressPct} size={56} strokeWidth={6}>
+                <span className="text-xs font-bold text-foreground">{progressPct}%</span>
+              </ProgressRing>
+              <div className="flex flex-1 flex-wrap gap-1.5">
+                {PROGRESS_PRESETS.map((pct) => (
+                  <button
+                    key={pct}
+                    type="button"
+                    onClick={() => handleSetProgress(pct)}
+                    disabled={!user}
+                    className={cn(
+                      'rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                      progressPct === pct
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border text-muted-foreground hover:bg-accent',
+                    )}
+                  >
+                    {pct}%
+                  </button>
+                ))}
+              </div>
+            </div>
+            {remainingHours !== null && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                {status === 'in_progress'
+                  ? `~${remainingHours}h of estimated effort left - your workload forecast already counts only the remainder.`
+                  : `Estimated at ${item.estimatedHours}h. Log progress and your workload forecast will count only what's left.`}
+              </p>
+            )}
+          </div>
+        )}
 
         <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5 text-sm">
           <div>

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -33,6 +33,17 @@ const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
+/** Which workload-ramp CSS var a given progress percentage should render
+ * as, for the slider's fill/thumb color. Quartile-banded rather than a
+ * continuous gradient so the color reads as a discrete signal ("just
+ * crossed into the next band") instead of a smear. */
+function progressColorVar(pct: number): string {
+  if (pct >= 75) return '--load-low';
+  if (pct >= 50) return '--load-medium';
+  if (pct >= 25) return '--load-high';
+  return '--load-critical';
+}
+
 const TYPE_LABELS: Record<AssignmentType, string> = {
   assignment: 'Assignment',
   exam: 'Exam',
@@ -65,6 +76,10 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
    * settled, at which point the committed item.progress is authoritative. */
   const [draftProgress, setDraftProgress] = useState<number | null>(null);
   const progressCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Purely visual - whether the slider's thumb should render in its
+   * "active" (larger, haloed) state. Driven by pointer down/up on the real
+   * input, independent of the debounce/commit state above. */
+  const [isDraggingProgress, setIsDraggingProgress] = useState(false);
   /** Same pattern as draftProgress, for the estimated-effort input - the
    * raw text the student is typing, kept separate so a half-typed "1."
    * doesn't get coerced mid-keystroke. null once the debounced write lands. */
@@ -324,17 +339,87 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
                     <ProgressRing percent={displayProgress} size={52} strokeWidth={6}>
                       <span className="text-xs font-bold text-foreground">{displayProgress}%</span>
                     </ProgressRing>
-                    <input
-                      type="range"
-                      min={0}
-                      max={100}
-                      step={PROGRESS_STEP}
-                      value={displayProgress}
-                      onChange={(e) => handleSliderChange(Number(e.target.value))}
-                      disabled={!user}
-                      aria-label="Task progress percentage"
-                      className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-card accent-primary disabled:cursor-not-allowed"
-                    />
+                    {/* Custom visual layer over a real native range input -
+                     * see the wrapper below for why the layering order
+                     * matters (input must stay topmost, everything else
+                     * pointer-events: none). */}
+                    <div className={cn('relative h-11 flex-1', !user && 'opacity-50')}>
+                      {/* Ticks at 25/50/75%. z-2: above the track/fill/thumb,
+                       * below the real input. */}
+                      {[25, 50, 75].map((tick) => (
+                        <span
+                          key={tick}
+                          aria-hidden="true"
+                          className="pointer-events-none absolute top-1/2 z-[2] w-px -translate-x-1/2 -translate-y-1/2 bg-[rgba(0,0,0,0.28)] dark:bg-[rgba(255,255,255,0.32)]"
+                          style={{ left: `${tick}%`, height: 6 }}
+                        />
+                      ))}
+
+                      {/* Track + fill. Width is set imperatively (not
+                       * transitioned) so a fast drag never lags behind the
+                       * pointer - only the fill's color eases across
+                       * quartile boundaries. */}
+                      <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute left-0 right-0 top-1/2 z-[1] h-2 -translate-y-1/2 overflow-hidden rounded-full bg-card"
+                      >
+                        <div
+                          className="h-full rounded-full"
+                          style={{
+                            width: `${displayProgress}%`,
+                            backgroundColor: `hsl(var(${progressColorVar(displayProgress)}))`,
+                            transition: 'background-color 150ms ease-out',
+                          }}
+                        />
+                      </div>
+
+                      {/* Decorative thumb, tracking the fill's edge. Grows
+                       * and gains a halo while dragging; position itself is
+                       * never transitioned, for the same lag-avoidance
+                       * reason as the fill above. */}
+                      <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute z-[1] rounded-full border-2 border-card shadow-sm"
+                        style={{
+                          top: '50%',
+                          left: `calc(${displayProgress}% - ${(isDraggingProgress ? 20 : 16) / 2}px)`,
+                          width: isDraggingProgress ? 20 : 16,
+                          height: isDraggingProgress ? 20 : 16,
+                          transform: 'translateY(-50%)',
+                          backgroundColor: `hsl(var(${progressColorVar(displayProgress)}))`,
+                          boxShadow: isDraggingProgress
+                            ? `0 0 0 6px hsl(var(${progressColorVar(displayProgress)}) / 0.28)`
+                            : undefined,
+                          transition:
+                            'width 120ms cubic-bezier(0.34, 1.56, 0.64, 1), height 120ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 120ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+                        }}
+                      />
+
+                      {/* The actual interactive/accessible element. Fully
+                       * transparent and absolutely positioned over the
+                       * whole wrapper (a real 44px tall hit area, not just
+                       * the ~8-20px of visible track), and given the
+                       * HIGHEST z-index of every layer here on purpose: if
+                       * a decorative layer above it were ever topmost, it
+                       * would silently swallow all pointer events and the
+                       * slider would stop being interactive - that bug has
+                       * shipped once already. */}
+                      <input
+                        type="range"
+                        min={0}
+                        max={100}
+                        step={PROGRESS_STEP}
+                        value={displayProgress}
+                        onChange={(e) => handleSliderChange(Number(e.target.value))}
+                        onPointerDown={() => setIsDraggingProgress(true)}
+                        onPointerUp={() => setIsDraggingProgress(false)}
+                        onPointerCancel={() => setIsDraggingProgress(false)}
+                        onBlur={() => setIsDraggingProgress(false)}
+                        disabled={!user}
+                        aria-label="Task progress percentage"
+                        className="absolute inset-0 z-[3] w-full cursor-pointer appearance-none opacity-0 disabled:cursor-not-allowed"
+                      />
+                    </div>
                   </div>
                   {remainingHoursAt(displayProgress) !== null && (
                     <p className="mt-3 text-xs text-muted-foreground">

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { BackLink } from '@/components/ui/BackLink';
@@ -9,14 +9,20 @@ import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { ProgressRing } from '@/components/ui/ProgressRing';
+import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
-import { ICON_PATHS } from '@/lib/icons';
-import { clampProgress, getTaskStatus, TASK_STATUS_LABEL } from '@/lib/taskStatus';
+import { clampProgress, TASK_STATUS_LABEL } from '@/lib/taskStatus';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { AssignmentType } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 
-const PROGRESS_PRESETS = [0, 25, 50, 75, 100];
+/** 5-point steps rather than 1% - self-reported task progress is never
+ * that precise, and 1% increments would turn a drag into 100 discrete
+ * writes' worth of visual noise for no real gain in accuracy. */
+const PROGRESS_STEP = 5;
+/** How long to let a drag settle before writing to Firestore, so dragging
+ * across the slider fires one write instead of one per tick. */
+const COMMIT_DEBOUNCE_MS = 400;
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -48,6 +54,15 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   const [editOpen, setEditOpen] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  /** Local-only "I want to track this" flag - separate from the task's
+   * actual progress, so opening the slider doesn't itself write anything
+   * until the student actually moves it above 0. */
+  const [trackingOpen, setTrackingOpen] = useState(false);
+  /** The slider's live value while a drag/commit is in flight, so the UI
+   * feels instant even though the Firestore write is debounced. null once
+   * settled, at which point the committed item.progress is authoritative. */
+  const [draftProgress, setDraftProgress] = useState<number | null>(null);
+  const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const item = state.scheduleItems.find((i) => i.id === taskId);
   const course = item ? state.courses.find((c) => c.id === item.courseId) : undefined;
@@ -75,11 +90,25 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
     await updateScheduleItem(user.uid, item, { ...item, progress: clampProgress(value) }, dispatch);
   };
 
-  const status = getTaskStatus(item);
+  const handleSliderChange = (value: number) => {
+    setDraftProgress(value);
+    if (commitTimer.current) clearTimeout(commitTimer.current);
+    commitTimer.current = setTimeout(() => {
+      handleSetProgress(value);
+      commitTimer.current = null;
+      setDraftProgress(null);
+    }, COMMIT_DEBOUNCE_MS);
+  };
+
   const progressPct = clampProgress(item.progress ?? 0);
-  const remainingHours =
+  // The slider's own value while dragging/settling, so the ring, the %
+  // label, and the remaining-hours estimate all track the drag live
+  // instead of waiting for the debounced write to land.
+  const displayProgress = draftProgress ?? progressPct;
+  const isTracking = trackingOpen || progressPct > 0;
+  const remainingHoursAt = (pct: number) =>
     item.estimatedHours != null
-      ? Math.round(item.estimatedHours * (1 - progressPct / 100) * 10) / 10
+      ? Math.round(item.estimatedHours * (1 - pct / 100) * 10) / 10
       : null;
 
   const handleEditTask = async (values: ScheduleItemFormValues) => {
@@ -121,15 +150,7 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
                 course?.color || 'bg-primary',
               )}
             >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d={ICON_PATHS.tasks} />
-              </svg>
+              <CourseIconGlyph icon={course?.icon} className="h-5 w-5" />
             </span>
             <div>
               <h1
@@ -189,48 +210,67 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
         {!item.completed && (
           <div className="border-t border-border pt-5">
-            <div className="mb-3 flex items-center justify-between">
-              <span className="text-xs text-muted-foreground">Progress</span>
-              <span
-                className={cn(
-                  'rounded-full px-2 py-0.5 text-[10px] font-semibold',
-                  status === 'in_progress'
-                    ? 'bg-primary/10 text-primary'
-                    : 'bg-accent text-muted-foreground',
-                )}
+            {!isTracking ? (
+              // Nothing logged yet: no ring, no "0%" - the task is simply
+              // done or not done until the student opts into tracking it.
+              <button
+                type="button"
+                onClick={() => setTrackingOpen(true)}
+                disabled={!user}
+                className="flex items-center gap-2 text-xs font-semibold text-primary transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {TASK_STATUS_LABEL[status]}
-              </span>
-            </div>
-            <div className="flex items-center gap-4">
-              <ProgressRing percent={progressPct} size={56} strokeWidth={6}>
-                <span className="text-xs font-bold text-foreground">{progressPct}%</span>
-              </ProgressRing>
-              <div className="flex flex-1 flex-wrap gap-1.5">
-                {PROGRESS_PRESETS.map((pct) => (
-                  <button
-                    key={pct}
-                    type="button"
-                    onClick={() => handleSetProgress(pct)}
-                    disabled={!user}
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+                Track progress
+              </button>
+            ) : (
+              <>
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">Progress</span>
+                  <span
                     className={cn(
-                      'rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-                      progressPct === pct
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-border text-muted-foreground hover:bg-accent',
+                      'rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                      displayProgress > 0
+                        ? 'bg-primary/10 text-primary'
+                        : 'bg-accent text-muted-foreground',
                     )}
                   >
-                    {pct}%
-                  </button>
-                ))}
-              </div>
-            </div>
-            {remainingHours !== null && (
-              <p className="mt-3 text-xs text-muted-foreground">
-                {status === 'in_progress'
-                  ? `~${remainingHours}h of estimated effort left - your workload forecast already counts only the remainder.`
-                  : `Estimated at ${item.estimatedHours}h. Log progress and your workload forecast will count only what's left.`}
-              </p>
+                    {displayProgress > 0
+                      ? TASK_STATUS_LABEL.in_progress
+                      : TASK_STATUS_LABEL.not_started}
+                  </span>
+                </div>
+                <div className="flex items-center gap-4">
+                  <ProgressRing percent={displayProgress} size={52} strokeWidth={6}>
+                    <span className="text-xs font-bold text-foreground">{displayProgress}%</span>
+                  </ProgressRing>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={PROGRESS_STEP}
+                    value={displayProgress}
+                    onChange={(e) => handleSliderChange(Number(e.target.value))}
+                    disabled={!user}
+                    aria-label="Task progress percentage"
+                    className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-accent accent-primary disabled:cursor-not-allowed"
+                  />
+                </div>
+                {remainingHoursAt(displayProgress) !== null && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {displayProgress > 0
+                      ? `~${remainingHoursAt(displayProgress)}h of estimated effort left - your workload forecast already counts only the remainder.`
+                      : `Estimated at ${item.estimatedHours}h. Drag the slider and your workload forecast will count only what's left.`}
+                  </p>
+                )}
+              </>
             )}
           </div>
         )}

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { BackLink } from '@/components/ui/BackLink';
+import { Card } from '@/components/ui/Card';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
@@ -20,8 +21,9 @@ import { cn } from '@/lib/utils';
  * that precise, and 1% increments would turn a drag into 100 discrete
  * writes' worth of visual noise for no real gain in accuracy. */
 const PROGRESS_STEP = 5;
-/** How long to let a drag settle before writing to Firestore, so dragging
- * across the slider fires one write instead of one per tick. */
+/** How long to let a drag/keystroke settle before writing to Firestore, so
+ * dragging the slider or typing an hour value fires one write instead of
+ * one per tick/keystroke. */
 const COMMIT_DEBOUNCE_MS = 400;
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -62,7 +64,12 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
    * feels instant even though the Firestore write is debounced. null once
    * settled, at which point the committed item.progress is authoritative. */
   const [draftProgress, setDraftProgress] = useState<number | null>(null);
-  const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const progressCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Same pattern as draftProgress, for the estimated-effort input - the
+   * raw text the student is typing, kept separate so a half-typed "1."
+   * doesn't get coerced mid-keystroke. null once the debounced write lands. */
+  const [hoursDraft, setHoursDraft] = useState<string | null>(null);
+  const hoursCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const item = state.scheduleItems.find((i) => i.id === taskId);
   const course = item ? state.courses.find((c) => c.id === item.courseId) : undefined;
@@ -92,11 +99,29 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   const handleSliderChange = (value: number) => {
     setDraftProgress(value);
-    if (commitTimer.current) clearTimeout(commitTimer.current);
-    commitTimer.current = setTimeout(() => {
+    if (progressCommitTimer.current) clearTimeout(progressCommitTimer.current);
+    progressCommitTimer.current = setTimeout(() => {
       handleSetProgress(value);
-      commitTimer.current = null;
+      progressCommitTimer.current = null;
       setDraftProgress(null);
+    }, COMMIT_DEBOUNCE_MS);
+  };
+
+  const handleSetEstimatedHours = async (value: number) => {
+    if (!user) return;
+    await updateScheduleItem(user.uid, item, { ...item, estimatedHours: value }, dispatch);
+  };
+
+  const handleHoursInputChange = (raw: string) => {
+    setHoursDraft(raw);
+    if (hoursCommitTimer.current) clearTimeout(hoursCommitTimer.current);
+    hoursCommitTimer.current = setTimeout(() => {
+      const parsed = Number(raw);
+      if (raw.trim() !== '' && Number.isFinite(parsed) && parsed > 0) {
+        handleSetEstimatedHours(Math.round(parsed * 10) / 10);
+      }
+      hoursCommitTimer.current = null;
+      setHoursDraft(null);
     }, COMMIT_DEBOUNCE_MS);
   };
 
@@ -106,9 +131,16 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
   // instead of waiting for the debounced write to land.
   const displayProgress = draftProgress ?? progressPct;
   const isTracking = trackingOpen || progressPct > 0;
+  // Same idea for the hours field: reflect what's being typed immediately,
+  // even before the debounced write (or a still-invalid partial number)
+  // has landed.
+  const displayHoursText =
+    hoursDraft ?? (item.estimatedHours != null ? String(item.estimatedHours) : '');
+  const effectiveEstimatedHours =
+    hoursDraft !== null ? Number(hoursDraft) || item.estimatedHours : item.estimatedHours;
   const remainingHoursAt = (pct: number) =>
-    item.estimatedHours != null
-      ? Math.round(item.estimatedHours * (1 - pct / 100) * 10) / 10
+    effectiveEstimatedHours != null
+      ? Math.round(effectiveEstimatedHours * (1 - pct / 100) * 10) / 10
       : null;
 
   const handleEditTask = async (values: ScheduleItemFormValues) => {
@@ -139,218 +171,281 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   return (
     <>
-      <div className="max-w-2xl space-y-6">
+      <div className="max-w-2xl space-y-4">
         <BackLink href="/tasks">Back to tasks</BackLink>
 
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-4">
-            <span
-              className={cn(
-                'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-white shadow-sm',
-                course?.color || 'bg-primary',
-              )}
-            >
-              <CourseIconGlyph icon={course?.icon} className="h-5 w-5" />
-            </span>
-            <div>
-              <h1
+        <Card className="divide-y divide-border" accent>
+          <div className="space-y-4 p-6">
+            <div className="flex items-start gap-4">
+              <span
                 className={cn(
-                  'text-2xl font-bold tracking-tight text-foreground',
-                  item.completed && 'text-muted-foreground line-through',
+                  'flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl text-white shadow-sm',
+                  course?.color || 'bg-primary',
                 )}
               >
-                {item.title}
-              </h1>
-              {course && (
-                <Link
-                  href={`/courses/${course.id}`}
-                  className="text-sm text-muted-foreground hover:text-primary hover:underline"
+                <CourseIconGlyph icon={course?.icon} className="h-6 w-6" />
+              </span>
+              <div className="min-w-0">
+                <h1
+                  className={cn(
+                    'text-2xl font-bold leading-tight tracking-tight text-foreground',
+                    item.completed && 'text-muted-foreground line-through',
+                  )}
                 >
-                  {course.code} · {course.title}
-                </Link>
+                  {item.title}
+                </h1>
+                {course && (
+                  <Link
+                    href={`/courses/${course.id}`}
+                    className="text-sm text-muted-foreground hover:text-primary hover:underline"
+                  >
+                    {course.code} · {course.title}
+                  </Link>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                {TYPE_LABELS[item.type]}
+              </span>
+              {item.priority && (
+                <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium capitalize text-muted-foreground">
+                  {item.priority} priority
+                </span>
+              )}
+              {overdue && (
+                <span className="rounded-full bg-load-critical/10 px-2.5 py-1 text-xs font-semibold text-load-critical">
+                  Overdue
+                </span>
+              )}
+              {item.gradeWeight !== undefined && (
+                <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+                  {item.gradeWeight}% of grade{item.gradeCategory ? ` · ${item.gradeCategory}` : ''}
+                </span>
+              )}
+              {item.source === 'ai' && (
+                <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  From syllabus
+                </span>
               )}
             </div>
           </div>
-          <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={item.completed}
-              onChange={handleToggleComplete}
-              className="h-4 w-4 rounded border-border accent-primary"
-            />
-            Done
-          </label>
-        </div>
 
-        <div className="flex flex-wrap gap-2">
-          <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
-            {TYPE_LABELS[item.type]}
-          </span>
-          {item.priority && (
-            <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium capitalize text-muted-foreground">
-              {item.priority} priority
-            </span>
-          )}
-          {overdue && (
-            <span className="rounded-full bg-load-critical/10 px-2.5 py-1 text-xs font-semibold text-load-critical">
-              Overdue
-            </span>
-          )}
-          {item.gradeWeight !== undefined && (
-            <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
-              {item.gradeWeight}% of grade{item.gradeCategory ? ` · ${item.gradeCategory}` : ''}
-            </span>
-          )}
-          {item.source === 'ai' && (
-            <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
-              From syllabus
-            </span>
-          )}
-        </div>
-
-        {!item.completed && (
-          <div className="border-t border-border pt-5">
-            {!isTracking ? (
-              // Nothing logged yet: no ring, no "0%" - the task is simply
-              // done or not done until the student opts into tracking it.
-              <button
-                type="button"
-                onClick={() => setTrackingOpen(true)}
-                disabled={!user}
-                className="flex items-center gap-2 text-xs font-semibold text-primary transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <svg
-                  className="h-3.5 w-3.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                </svg>
-                Track progress
-              </button>
-            ) : (
-              <>
-                <div className="mb-3 flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">Progress</span>
-                  <span
-                    className={cn(
-                      'rounded-full px-2 py-0.5 text-[10px] font-semibold',
-                      displayProgress > 0
-                        ? 'bg-primary/10 text-primary'
-                        : 'bg-accent text-muted-foreground',
-                    )}
+          {/* The single most important action on this page gets a full-width
+           * button of its own instead of a small corner checkbox, so
+           * marking a task done (or undoing that) is unmissable. */}
+          <div className="p-6">
+            <button
+              type="button"
+              onClick={handleToggleComplete}
+              disabled={!user}
+              className={cn(
+                'flex w-full items-center justify-center gap-2 rounded-xl border-2 py-3 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                item.completed
+                  ? 'border-load-low/40 bg-load-low/10 text-load-low hover:bg-load-low/15'
+                  : 'border-primary/30 bg-primary/5 text-primary hover:bg-primary/10',
+              )}
+            >
+              {item.completed ? (
+                <>
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
                   >
-                    {displayProgress > 0
-                      ? TASK_STATUS_LABEL.in_progress
-                      : TASK_STATUS_LABEL.not_started}
-                  </span>
-                </div>
-                <div className="flex items-center gap-4">
-                  <ProgressRing percent={displayProgress} size={52} strokeWidth={6}>
-                    <span className="text-xs font-bold text-foreground">{displayProgress}%</span>
-                  </ProgressRing>
-                  <input
-                    type="range"
-                    min={0}
-                    max={100}
-                    step={PROGRESS_STEP}
-                    value={displayProgress}
-                    onChange={(e) => handleSliderChange(Number(e.target.value))}
-                    disabled={!user}
-                    aria-label="Task progress percentage"
-                    className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-accent accent-primary disabled:cursor-not-allowed"
-                  />
-                </div>
-                {remainingHoursAt(displayProgress) !== null && (
-                  <p className="mt-3 text-xs text-muted-foreground">
-                    {displayProgress > 0
-                      ? `~${remainingHoursAt(displayProgress)}h of estimated effort left - your workload forecast already counts only the remainder.`
-                      : `Estimated at ${item.estimatedHours}h. Drag the slider and your workload forecast will count only what's left.`}
-                  </p>
-                )}
-              </>
-            )}
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  Done - tap to undo
+                </>
+              ) : (
+                <>
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                  </svg>
+                  Mark as done
+                </>
+              )}
+            </button>
           </div>
-        )}
 
-        <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5 text-sm">
-          <div>
-            <dt className="text-xs text-muted-foreground">Due</dt>
-            <dd className="mt-0.5 font-medium text-foreground">
-              {dueDateFormatter.format(new Date(item.dueDate))}
-            </dd>
-          </div>
-          {item.estimatedHours !== undefined && (
-            <div>
-              <dt className="text-xs text-muted-foreground">Estimated effort</dt>
-              <dd className="mt-0.5 font-medium text-foreground">{item.estimatedHours}h</dd>
+          {!item.completed && (
+            <div className="p-6">
+              {!isTracking ? (
+                // Nothing logged yet: no ring, no "0%" - the task is simply
+                // done or not done until the student opts into tracking it.
+                <button
+                  type="button"
+                  onClick={() => setTrackingOpen(true)}
+                  disabled={!user}
+                  className="flex items-center gap-2 text-xs font-semibold text-primary transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                  </svg>
+                  Track progress
+                </button>
+              ) : (
+                <div className="rounded-xl bg-accent/40 p-4">
+                  <div className="mb-3 flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground">Progress</span>
+                    <span
+                      className={cn(
+                        'rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                        displayProgress > 0
+                          ? 'bg-primary/10 text-primary'
+                          : 'bg-card text-muted-foreground',
+                      )}
+                    >
+                      {displayProgress > 0
+                        ? TASK_STATUS_LABEL.in_progress
+                        : TASK_STATUS_LABEL.not_started}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <ProgressRing percent={displayProgress} size={52} strokeWidth={6}>
+                      <span className="text-xs font-bold text-foreground">{displayProgress}%</span>
+                    </ProgressRing>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={PROGRESS_STEP}
+                      value={displayProgress}
+                      onChange={(e) => handleSliderChange(Number(e.target.value))}
+                      disabled={!user}
+                      aria-label="Task progress percentage"
+                      className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-card accent-primary disabled:cursor-not-allowed"
+                    />
+                  </div>
+                  {remainingHoursAt(displayProgress) !== null && (
+                    <p className="mt-3 text-xs text-muted-foreground">
+                      {displayProgress > 0
+                        ? `~${remainingHoursAt(displayProgress)}h of estimated effort left - your workload forecast already counts only the remainder.`
+                        : `Estimated at ${effectiveEstimatedHours}h. Drag the slider and your workload forecast will count only what's left.`}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
-        </dl>
 
-        {item.notes && (
-          <div className="border-t border-border pt-5">
-            <dt className="text-xs text-muted-foreground">Notes</dt>
-            <dd className="mt-1 whitespace-pre-wrap text-sm text-foreground">{item.notes}</dd>
-          </div>
-        )}
-
-        <div className="flex flex-wrap items-center gap-2 border-t border-border pt-5">
-          <button onClick={() => setEditOpen(true)} className={solidButtonClass}>
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-              />
-            </svg>
-            Edit
-          </button>
-          <a
-            href={generateGoogleCalendarUrl(item, course)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={outlineButtonClass}
-          >
-            Google Calendar
-          </a>
-          <a
-            href={generateOutlookCalendarUrl(item, course)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={outlineButtonClass}
-          >
-            Outlook
-          </a>
-          <div className="ml-auto">
-            {confirmingDelete ? (
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-muted-foreground">Delete this task?</span>
-                <button
-                  onClick={handleDelete}
-                  className="rounded-lg bg-destructive px-3.5 py-2 font-semibold text-destructive-foreground transition-opacity hover:opacity-90"
-                >
-                  Confirm
-                </button>
-                <button onClick={() => setConfirmingDelete(false)} className={outlineButtonClass}>
-                  Cancel
-                </button>
+          <div className="grid grid-cols-2 gap-4 p-6 text-sm">
+            <div>
+              <dt className="text-xs text-muted-foreground">Due</dt>
+              <dd className="mt-0.5 font-medium text-foreground">
+                {dueDateFormatter.format(new Date(item.dueDate))}
+              </dd>
+            </div>
+            <div>
+              <label htmlFor="task-estimated-hours" className="text-xs text-muted-foreground">
+                Estimated effort
+              </label>
+              {/* Always editable, not just displayed - the first estimate is
+               * often a guess, and a special case (a longer reading than
+               * usual, a group project that fell through) should be a
+               * two-second fix, not a trip through the full edit form. */}
+              <div className="mt-0.5 flex items-center gap-1">
+                <input
+                  id="task-estimated-hours"
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={displayHoursText}
+                  onChange={(e) => handleHoursInputChange(e.target.value)}
+                  disabled={!user}
+                  placeholder="Add"
+                  aria-label="Estimated effort in hours"
+                  className="w-14 rounded-md border border-transparent bg-transparent font-medium text-foreground placeholder:font-normal placeholder:text-muted-foreground focus:border-border focus:bg-card focus:px-1.5 focus:py-0.5 focus:outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed"
+                />
+                <span className="text-sm font-medium text-muted-foreground">h</span>
               </div>
-            ) : (
-              <button onClick={() => setConfirmingDelete(true)} className={destructiveButtonClass}>
-                Delete
-              </button>
-            )}
+            </div>
           </div>
-        </div>
+
+          {item.notes && (
+            <div className="p-6">
+              <dt className="text-xs text-muted-foreground">Notes</dt>
+              <dd className="mt-1 whitespace-pre-wrap text-sm text-foreground">{item.notes}</dd>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2 p-6">
+            <button onClick={() => setEditOpen(true)} className={solidButtonClass}>
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                />
+              </svg>
+              Edit
+            </button>
+            <a
+              href={generateGoogleCalendarUrl(item, course)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={outlineButtonClass}
+            >
+              Google Calendar
+            </a>
+            <a
+              href={generateOutlookCalendarUrl(item, course)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={outlineButtonClass}
+            >
+              Outlook
+            </a>
+            <div className="ml-auto">
+              {confirmingDelete ? (
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="text-muted-foreground">Delete this task?</span>
+                  <button
+                    onClick={handleDelete}
+                    className="rounded-lg bg-destructive px-3.5 py-2 font-semibold text-destructive-foreground transition-opacity hover:opacity-90"
+                  >
+                    Confirm
+                  </button>
+                  <button onClick={() => setConfirmingDelete(false)} className={outlineButtonClass}>
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmingDelete(true)}
+                  className={destructiveButtonClass}
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          </div>
+        </Card>
       </div>
 
       <TaskFormModal

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -46,6 +46,7 @@ function emptyValues(defaultCourseId: string): ScheduleItemFormValues {
     estimatedHours: '',
     priority: 'medium',
     notes: '',
+    progress: '',
   };
 }
 
@@ -73,6 +74,7 @@ export function TaskFormModal({
             estimatedHours: initialItem.estimatedHours?.toString() ?? '',
             priority: initialItem.priority ?? 'medium',
             notes: initialItem.notes ?? '',
+            progress: initialItem.progress?.toString() ?? '',
           }
         : emptyValues(courses[0]?.id ?? ''),
     );
@@ -239,6 +241,34 @@ export function TaskFormModal({
                       ))}
                     </div>
                   </div>
+
+                  {initialItem && (
+                    <div className="space-y-1.5">
+                      <label htmlFor="progress" className="text-sm font-medium text-foreground">
+                        Progress
+                      </label>
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="progress"
+                          type="number"
+                          min={0}
+                          max={100}
+                          step={5}
+                          value={values.progress ?? ''}
+                          placeholder="0"
+                          onChange={(e) => updateField('progress', e.target.value)}
+                          className={cn(
+                            'w-24 rounded-lg border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
+                            errors.progress ? 'border-destructive' : 'border-border',
+                          )}
+                        />
+                        <span className="text-sm text-muted-foreground">% complete</span>
+                      </div>
+                      {errors.progress && (
+                        <p className="text-xs text-destructive">{errors.progress}</p>
+                      )}
+                    </div>
+                  )}
 
                   <Field
                     id="notes"

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -4,13 +4,20 @@ import { cn } from '@/lib/utils';
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   hoverable?: boolean;
-  /** Renders a brand-gradient bar along the card's top edge. */
-  accent?: boolean;
+  /**
+   * Renders a brand accent marking this card as visually important.
+   * `true` (or `"top"`) draws a gradient bar along the top edge; `"left"`
+   * draws a solid primary-colored border down the left edge instead - used
+   * to promote a single card as the dominant/primary one in a section.
+   */
+  accent?: boolean | 'top' | 'left';
 }
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, children, interactive, hoverable, accent, ...props }, ref) => {
     const isInteractive = interactive || hoverable;
+    const accentTop = accent === true || accent === 'top';
+    const accentLeft = accent === 'left';
     return (
       <div
         ref={ref}
@@ -18,11 +25,12 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
           'relative rounded-glass border border-border bg-card/90 backdrop-blur-md shadow-card overflow-hidden',
           isInteractive &&
             'transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-card-hover',
+          accentLeft && 'border-l-[3px] border-l-primary',
           className,
         )}
         {...props}
       >
-        {accent && <div className="absolute inset-x-0 top-0 h-1 bg-gradient-brand" />}
+        {accentTop && <div className="absolute inset-x-0 top-0 h-1 bg-gradient-brand" />}
         {children}
       </div>
     );

--- a/src/components/ui/CourseIconGlyph.tsx
+++ b/src/components/ui/CourseIconGlyph.tsx
@@ -1,0 +1,140 @@
+import { resolveCourseIcon } from '@/lib/courseIcons';
+
+export interface CourseIconGlyphProps {
+  icon: string | undefined;
+  className?: string;
+}
+
+/** Renders one of COURSE_ICON_PRESETS as a stroked SVG glyph, at the same
+ * 24x24/currentColor convention as TYPE_ICON_PATH and lib/icons.ts - built
+ * as JSX (not path-string data) because a couple of these compose more
+ * than one primitive (a chart's three bars, a globe's meridian), which is
+ * simpler to get right as real SVG elements than as one <path> string. */
+export function CourseIconGlyph({ icon, className = 'h-4 w-4' }: CourseIconGlyphProps) {
+  const resolved = resolveCourseIcon(icon);
+  const common = {
+    className,
+    viewBox: '0 0 24 24',
+    fill: 'none' as const,
+    stroke: 'currentColor',
+    strokeWidth: 1.75,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
+
+  switch (resolved) {
+    case 'calculator':
+      return (
+        <svg {...common}>
+          <rect x="6" y="3" width="12" height="18" rx="2" />
+          <line x1="9" y1="7" x2="15" y2="7" />
+          <circle cx="9" cy="12" r="0.6" fill="currentColor" stroke="none" />
+          <circle cx="12" cy="12" r="0.6" fill="currentColor" stroke="none" />
+          <circle cx="15" cy="12" r="0.6" fill="currentColor" stroke="none" />
+          <circle cx="9" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
+          <circle cx="12" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
+          <circle cx="15" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case 'flask':
+      return (
+        <svg {...common}>
+          <path d="M9 3h6M10 3v5.5L4.5 18a2 2 0 001.7 3h11.6a2 2 0 001.7-3L14 8.5V3" />
+          <line x1="7.5" y1="14" x2="16.5" y2="14" />
+        </svg>
+      );
+    case 'globe':
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <ellipse cx="12" cy="12" rx="4" ry="9" />
+        </svg>
+      );
+    case 'chat':
+      return (
+        <svg {...common}>
+          <path d="M4 7a2 2 0 012-2h12a2 2 0 012 2v8a2 2 0 01-2 2H10l-4 3v-3H6a2 2 0 01-2-2V7z" />
+        </svg>
+      );
+    case 'code':
+      return (
+        <svg {...common}>
+          <path d="M9 8l-5 4 5 4M15 8l5 4-5 4" />
+        </svg>
+      );
+    case 'chart':
+      return (
+        <svg {...common}>
+          <line x1="3" y1="20" x2="21" y2="20" />
+          <line x1="6" y1="20" x2="6" y2="14" />
+          <line x1="12" y1="20" x2="12" y2="9" />
+          <line x1="18" y1="20" x2="18" y2="5" />
+        </svg>
+      );
+    case 'palette':
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="8" />
+          <circle cx="9" cy="9.5" r="1" fill="currentColor" stroke="none" />
+          <circle cx="15" cy="9.5" r="1" fill="currentColor" stroke="none" />
+          <circle cx="9.5" cy="15" r="1" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case 'music':
+      return (
+        <svg {...common}>
+          <circle cx="9" cy="18" r="2.2" />
+          <path d="M11.2 18V4l7-1.5v4" />
+        </svg>
+      );
+    case 'film':
+      return (
+        <svg {...common}>
+          <rect x="3" y="5" width="18" height="14" rx="2" />
+          <line x1="7" y1="5" x2="7" y2="19" />
+          <line x1="17" y1="5" x2="17" y2="19" />
+          <line x1="3" y1="10" x2="7" y2="10" />
+          <line x1="3" y1="14" x2="7" y2="14" />
+          <line x1="17" y1="10" x2="21" y2="10" />
+          <line x1="17" y1="14" x2="21" y2="14" />
+        </svg>
+      );
+    case 'heart':
+      return (
+        <svg {...common}>
+          <circle cx="9" cy="9" r="3.2" />
+          <circle cx="15" cy="9" r="3.2" />
+          <path d="M5.8 11.5L12 19l6.2-7.5" />
+        </svg>
+      );
+    case 'scale':
+      return (
+        <svg {...common}>
+          <line x1="12" y1="3" x2="12" y2="21" />
+          <line x1="4" y1="7" x2="20" y2="7" />
+          <line x1="7" y1="21" x2="17" y2="21" />
+          <path d="M4 7l-2 5h4l-2-5zM20 7l-2 5h4l-2-5z" />
+        </svg>
+      );
+    case 'bolt':
+      return (
+        <svg {...common}>
+          <path d="M13 2L4 14h6l-1 8 9-13h-6l1-7z" />
+        </svg>
+      );
+    case 'puzzle':
+      return (
+        <svg {...common}>
+          <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      );
+    case 'book':
+    default:
+      return (
+        <svg {...common}>
+          <path d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        </svg>
+      );
+  }
+}

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils';
+
+export interface ProgressBarProps {
+  /** 0-100 */
+  percent: number;
+  className?: string;
+  /** Fill color. Defaults to the brand primary; callers pass a course hex
+   * so the bar reads as "this task's" progress rather than a generic one. */
+  color?: string;
+}
+
+/** Thin linear progress indicator for list rows, where a ProgressRing would
+ * be too heavy. Track uses the same muted surface as the rest of the row
+ * chrome; fill defaults to primary but accepts a course color so it can
+ * double as a quiet course cue in dense lists. */
+export function ProgressBar({ percent, className, color }: ProgressBarProps) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={cn('h-1 w-full overflow-hidden rounded-full bg-muted', className)}
+    >
+      <div
+        className="h-full rounded-full transition-[width] duration-300 ease-out"
+        style={{ width: `${clamped}%`, backgroundColor: color ?? 'hsl(var(--primary))' }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { courseBorderColor, courseSwatch, courseWash } from '@/lib/courseColors';
+import { clampProgress, getTaskStatus } from '@/lib/taskStatus';
+import { ProgressBar } from '@/components/ui/ProgressBar';
 import type { AssignmentType, Priority } from '@/types/schedule';
 
 const TYPE_ICON_PATH: Record<AssignmentType, string> = {
@@ -30,6 +32,11 @@ export interface TaskRowProps {
   courseCode?: string;
   courseColor?: string;
   completed?: boolean;
+  /** Self-reported completion progress, 0-100. Undefined/0 with `completed`
+   * false renders as not-started (no visual change from before this
+   * existed); a value above 0 shows a small in-progress indicator. See
+   * lib/taskStatus.ts. */
+  progress?: number;
   priority?: Priority;
   onToggleComplete?: () => void;
   /** Right-aligned custom content: due labels, badges, edit/delete links. */
@@ -52,6 +59,7 @@ export function TaskRow({
   courseCode,
   courseColor,
   completed = false,
+  progress,
   priority = 'medium',
   onToggleComplete,
   trailing,
@@ -66,6 +74,7 @@ export function TaskRow({
         courseCode={courseCode}
         courseColor={courseColor}
         completed={completed}
+        progress={progress}
         priority={priority}
         onToggleComplete={onToggleComplete}
         trailing={trailing}
@@ -82,12 +91,16 @@ export function TaskRow({
         courseCode={courseCode}
         courseColor={courseColor}
         completed={completed}
+        progress={progress}
         onToggleComplete={onToggleComplete}
         trailing={trailing}
         href={href}
       />
     );
   }
+  const status = getTaskStatus({ completed, progress });
+  const progressPct = clampProgress(progress ?? 0);
+
   // A bold, course-colored left edge is the row's primary "which class is
   // this" signal (Direction B), replacing the old small course-colored icon
   // badge - the type icon below is now plain/muted instead, so it doesn't
@@ -139,6 +152,14 @@ export function TaskRow({
           </div>
         </div>
         {courseCode && <div className="text-xs text-muted-foreground">{courseCode}</div>}
+        {status === 'in_progress' && (
+          <div className="mt-1 flex items-center gap-1.5">
+            <ProgressBar percent={progressPct} className="max-w-20" />
+            <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+              {Math.round(progressPct)}%
+            </span>
+          </div>
+        )}
       </div>
       {trailing && (
         <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
@@ -173,12 +194,18 @@ function CardRow({
   courseCode,
   courseColor,
   completed,
+  progress,
   priority,
   onToggleComplete,
   trailing,
   href,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed' | 'priority'>> &
-  Pick<TaskRowProps, 'courseCode' | 'courseColor' | 'onToggleComplete' | 'trailing' | 'href'>) {
+  Pick<
+    TaskRowProps,
+    'courseCode' | 'courseColor' | 'progress' | 'onToggleComplete' | 'trailing' | 'href'
+  >) {
+  const status = getTaskStatus({ completed, progress });
+  const progressPct = clampProgress(progress ?? 0);
   const rowClass = cn(
     'flex items-start gap-3 rounded-xl border border-border/60 p-3',
     href && 'transition-colors hover:border-border',
@@ -215,6 +242,14 @@ function CardRow({
           </div>
         </div>
         <div className="mt-1 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+        {status === 'in_progress' && (
+          <div className="mt-1.5 flex items-center gap-2">
+            <ProgressBar percent={progressPct} className="max-w-32" />
+            <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
+              {Math.round(progressPct)}%
+            </span>
+          </div>
+        )}
       </div>
       {trailing && (
         <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
@@ -247,11 +282,17 @@ function TouchRow({
   courseCode,
   courseColor,
   completed,
+  progress,
   onToggleComplete,
   trailing,
   href,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed'>> &
-  Pick<TaskRowProps, 'courseCode' | 'courseColor' | 'onToggleComplete' | 'trailing' | 'href'>) {
+  Pick<
+    TaskRowProps,
+    'courseCode' | 'courseColor' | 'progress' | 'onToggleComplete' | 'trailing' | 'href'
+  >) {
+  const status = getTaskStatus({ completed, progress });
+  const progressPct = clampProgress(progress ?? 0);
   const outerClass = cn(
     'flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-accent/30',
     href && 'transition-colors hover:bg-accent/50',
@@ -303,6 +344,14 @@ function TouchRow({
             {title}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+          {status === 'in_progress' && (
+            <div className="mt-1.5 flex items-center gap-2">
+              <ProgressBar percent={progressPct} className="max-w-32" />
+              <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
+                {Math.round(progressPct)}%
+              </span>
+            </div>
+          )}
         </div>
         {trailing && (
           <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,21 +1,11 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { courseBorderColor, courseSwatch, courseWash } from '@/lib/courseColors';
+import { courseChipTint, courseSwatch, courseWash } from '@/lib/courseColors';
 import { clampProgress, getTaskStatus } from '@/lib/taskStatus';
 import { ProgressBar } from '@/components/ui/ProgressBar';
+import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
 import type { AssignmentType, Priority } from '@/types/schedule';
-
-const TYPE_ICON_PATH: Record<AssignmentType, string> = {
-  assignment:
-    'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
-  exam: 'M9 12l2 2 4-4m5 2a9 9 0 11-18 0 9 9 0 0118 0z',
-  quiz: 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-  project: 'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4',
-  reading:
-    'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
-  other: 'M5 13l4 4L19 7',
-};
 
 const TYPE_LABEL: Record<AssignmentType, string> = {
   assignment: 'Assignment',
@@ -31,11 +21,14 @@ export interface TaskRowProps {
   type?: AssignmentType;
   courseCode?: string;
   courseColor?: string;
+  /** One of COURSE_ICON_PRESETS (lib/courseIcons.ts). Missing/unrecognized
+   * values resolve to the default glyph via CourseIconGlyph. */
+  courseIcon?: string;
   completed?: boolean;
   /** Self-reported completion progress, 0-100. Undefined/0 with `completed`
-   * false renders as not-started (no visual change from before this
-   * existed); a value above 0 shows a small in-progress indicator. See
-   * lib/taskStatus.ts. */
+   * false renders as not-started (no visual change - no progress UI shows
+   * at all until a task actually has some); a value above 0 shows a small
+   * in-progress indicator. See lib/taskStatus.ts. */
   progress?: number;
   priority?: Priority;
   onToggleComplete?: () => void;
@@ -44,13 +37,13 @@ export interface TaskRowProps {
   /** When present, the row navigates to this URL on click (e.g. a task
    * detail page), while the checkbox stays independently clickable. */
   href?: string;
-  /** Visual density. 'compact' (default) is the thin, left-bordered line
-   * built for long lists (Tasks, course detail). 'card' gives the row a
-   * course-tinted background and more breathing room, for short,
-   * high-attention lists (Dashboard, Planner's "Today"). 'touch' swaps the
-   * course-color surface for a top accent bar plus a larger circular
-   * checkbox, for touch-first contexts (a mobile calendar day view). */
-  variant?: 'compact' | 'card' | 'touch';
+  /** Visual density. 'card' (default, everywhere) gives every row a
+   * course-tinted background, a course-icon badge, and real breathing
+   * room. 'touch' swaps the course-color surface for a top accent bar plus
+   * a larger circular checkbox, for touch-first contexts (a mobile
+   * calendar day view). There is no denser "compact" variant - a uniform
+   * look across the app was chosen over squeezing more rows on screen. */
+  variant?: 'card' | 'touch';
 }
 
 export function TaskRow({
@@ -58,31 +51,15 @@ export function TaskRow({
   type = 'assignment',
   courseCode,
   courseColor,
+  courseIcon,
   completed = false,
   progress,
   priority = 'medium',
   onToggleComplete,
   trailing,
   href,
-  variant = 'compact',
+  variant = 'card',
 }: TaskRowProps) {
-  if (variant === 'card') {
-    return (
-      <CardRow
-        title={title}
-        type={type}
-        courseCode={courseCode}
-        courseColor={courseColor}
-        completed={completed}
-        progress={progress}
-        priority={priority}
-        onToggleComplete={onToggleComplete}
-        trailing={trailing}
-        href={href}
-      />
-    );
-  }
-
   if (variant === 'touch') {
     return (
       <TouchRow
@@ -90,6 +67,7 @@ export function TaskRow({
         type={type}
         courseCode={courseCode}
         courseColor={courseColor}
+        courseIcon={courseIcon}
         completed={completed}
         progress={progress}
         onToggleComplete={onToggleComplete}
@@ -98,89 +76,21 @@ export function TaskRow({
       />
     );
   }
-  const status = getTaskStatus({ completed, progress });
-  const progressPct = clampProgress(progress ?? 0);
-
-  // A bold, course-colored left edge is the row's primary "which class is
-  // this" signal (Direction B), replacing the old small course-colored icon
-  // badge - the type icon below is now plain/muted instead, so it doesn't
-  // compete with the edge for color attention.
-  const rowClass = cn(
-    'flex items-center gap-3 py-2.5 pl-3 border-l-4 first:pt-0 last:pb-0',
-    href && 'rounded-r-lg transition-colors hover:bg-accent',
-  );
-
-  const content = (
-    <>
-      {onToggleComplete && (
-        <input
-          type="checkbox"
-          checked={completed}
-          onChange={onToggleComplete}
-          onClick={(e) => e.stopPropagation()}
-          className="h-4 w-4 rounded border-border accent-primary shrink-0"
-          aria-label={`Mark ${title} complete`}
-        />
-      )}
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground">
-        <svg
-          className="h-4 w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.75}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d={TYPE_ICON_PATH[type]} />
-        </svg>
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          {priority === 'high' && !completed && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
-              title="High priority"
-              aria-label="High priority"
-            />
-          )}
-          <div
-            className={cn(
-              'text-sm font-medium truncate',
-              completed ? 'text-muted-foreground line-through' : 'text-foreground',
-            )}
-          >
-            {title}
-          </div>
-        </div>
-        {courseCode && <div className="text-xs text-muted-foreground">{courseCode}</div>}
-        {status === 'in_progress' && (
-          <div className="mt-1 flex items-center gap-1.5">
-            <ProgressBar percent={progressPct} className="max-w-20" />
-            <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
-              {Math.round(progressPct)}%
-            </span>
-          </div>
-        )}
-      </div>
-      {trailing && (
-        <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
-          {trailing}
-        </div>
-      )}
-    </>
-  );
-
-  if (href) {
-    return (
-      <Link href={href} className={rowClass} style={courseBorderColor(courseColor)}>
-        {content}
-      </Link>
-    );
-  }
 
   return (
-    <div className={rowClass} style={courseBorderColor(courseColor)}>
-      {content}
-    </div>
+    <CardRow
+      title={title}
+      type={type}
+      courseCode={courseCode}
+      courseColor={courseColor}
+      courseIcon={courseIcon}
+      completed={completed}
+      progress={progress}
+      priority={priority}
+      onToggleComplete={onToggleComplete}
+      trailing={trailing}
+      href={href}
+    />
   );
 }
 
@@ -188,11 +98,51 @@ function metaLine(courseCode: string | undefined, type: AssignmentType) {
   return courseCode ? `${courseCode} · ${TYPE_LABEL[type]}` : TYPE_LABEL[type];
 }
 
+/** Shared "in progress" strip: never renders for a task nobody has touched
+ * (status stays 'not_started', not a visible "0%") - only appears once
+ * progress is actually above 0, per the same not_started/in_progress/
+ * completed split used everywhere else (lib/taskStatus.ts). */
+function ProgressStrip({ percent, className }: { percent: number; className?: string }) {
+  return (
+    <div className={cn('mt-1.5 flex items-center gap-2', className)}>
+      <ProgressBar percent={percent} className="max-w-32" />
+      <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
+        {Math.round(percent)}%
+      </span>
+    </div>
+  );
+}
+
+function CourseIconBadge({
+  courseColor,
+  courseIcon,
+  size = 7,
+}: {
+  courseColor: string | undefined;
+  courseIcon: string | undefined;
+  size?: 6 | 7;
+}) {
+  const chip = courseChipTint(courseColor);
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-full border',
+        size === 7 ? 'h-7 w-7' : 'h-6 w-6',
+        chip.className,
+      )}
+      style={chip.style}
+    >
+      <CourseIconGlyph icon={courseIcon} className={size === 7 ? 'h-4 w-4' : 'h-3.5 w-3.5'} />
+    </span>
+  );
+}
+
 function CardRow({
   title,
   type,
   courseCode,
   courseColor,
+  courseIcon,
   completed,
   progress,
   priority,
@@ -202,7 +152,13 @@ function CardRow({
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed' | 'priority'>> &
   Pick<
     TaskRowProps,
-    'courseCode' | 'courseColor' | 'progress' | 'onToggleComplete' | 'trailing' | 'href'
+    | 'courseCode'
+    | 'courseColor'
+    | 'courseIcon'
+    | 'progress'
+    | 'onToggleComplete'
+    | 'trailing'
+    | 'href'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
@@ -223,6 +179,7 @@ function CardRow({
           aria-label={`Mark ${title} complete`}
         />
       )}
+      <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={7} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           {priority === 'high' && !completed && (
@@ -242,14 +199,7 @@ function CardRow({
           </div>
         </div>
         <div className="mt-1 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
-        {status === 'in_progress' && (
-          <div className="mt-1.5 flex items-center gap-2">
-            <ProgressBar percent={progressPct} className="max-w-32" />
-            <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
-              {Math.round(progressPct)}%
-            </span>
-          </div>
-        )}
+        {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
       </div>
       {trailing && (
         <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
@@ -281,6 +231,7 @@ function TouchRow({
   type,
   courseCode,
   courseColor,
+  courseIcon,
   completed,
   progress,
   onToggleComplete,
@@ -289,7 +240,13 @@ function TouchRow({
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed'>> &
   Pick<
     TaskRowProps,
-    'courseCode' | 'courseColor' | 'progress' | 'onToggleComplete' | 'trailing' | 'href'
+    | 'courseCode'
+    | 'courseColor'
+    | 'courseIcon'
+    | 'progress'
+    | 'onToggleComplete'
+    | 'trailing'
+    | 'href'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
@@ -334,6 +291,7 @@ function TouchRow({
             </span>
           </label>
         )}
+        <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={6} />
         <div className="min-w-0 flex-1">
           <div
             className={cn(
@@ -344,14 +302,7 @@ function TouchRow({
             {title}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
-          {status === 'in_progress' && (
-            <div className="mt-1.5 flex items-center gap-2">
-              <ProgressBar percent={progressPct} className="max-w-32" />
-              <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
-                {Math.round(progressPct)}%
-              </span>
-            </div>
-          )}
+          {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
         </div>
         {trailing && (
           <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { courseChipTint, courseSwatch, courseWash } from '@/lib/courseColors';
@@ -15,6 +17,40 @@ const TYPE_LABEL: Record<AssignmentType, string> = {
   reading: 'Reading',
   other: 'Other',
 };
+
+type CheckAnimState = 'idle' | 'checked' | 'unchecked';
+
+/** Time to hold the 'checked' animation state open: long enough for the
+ * pop (480ms), the later of the two staggered ripple rings (80ms delay +
+ * 500ms = 580ms), and the checkmark reveal (70ms delay + 150ms = 220ms) to
+ * all finish before the transient classes are torn down. */
+const CHECK_ANIM_HOLD_MS = 580;
+const UNCHECK_ANIM_HOLD_MS = 100;
+
+/** Tracks the transient completion-animation state for a checkbox:
+ * 'checked' for a moment right after a task is marked done (pop + ripple +
+ * checkmark reveal + row glow), 'unchecked' for a moment right after it's
+ * marked undone (quick checkmark fade, no ripple/glow), 'idle' otherwise.
+ * Skips animating on first mount so a task that's already completed when
+ * the row renders doesn't replay the completion animation. */
+function useCheckAnimState(completed: boolean): CheckAnimState {
+  const [animState, setAnimState] = useState<CheckAnimState>('idle');
+  const prevCompleted = useRef(completed);
+
+  useEffect(() => {
+    if (prevCompleted.current === completed) return;
+    prevCompleted.current = completed;
+    const nextState: CheckAnimState = completed ? 'checked' : 'unchecked';
+    setAnimState(nextState);
+    const timer = setTimeout(
+      () => setAnimState('idle'),
+      completed ? CHECK_ANIM_HOLD_MS : UNCHECK_ANIM_HOLD_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [completed]);
+
+  return animState;
+}
 
 export interface TaskRowProps {
   title: string;
@@ -162,31 +198,83 @@ function CardRow({
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
+  const checkAnim = useCheckAnimState(completed);
   const rowClass = cn(
     'flex items-start gap-3 rounded-xl border border-border/60 p-3',
     href && 'transition-colors hover:border-border',
+    checkAnim === 'checked' && 'animate-task-row-glow',
   );
 
   const content = (
     <>
       {onToggleComplete && (
-        <input
-          type="checkbox"
-          checked={completed}
-          onChange={onToggleComplete}
+        <label
+          className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
           onClick={(e) => e.stopPropagation()}
-          className="mt-0.5 h-4 w-4 shrink-0 rounded border-border accent-primary"
-          aria-label={`Mark ${title} complete`}
-        />
+        >
+          <input
+            type="checkbox"
+            checked={completed}
+            onChange={onToggleComplete}
+            className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label={`Mark ${title} complete`}
+          />
+          {checkAnim === 'checked' && (
+            <>
+              <span
+                aria-hidden="true"
+                className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+              />
+              <span
+                aria-hidden="true"
+                className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+              />
+            </>
+          )}
+          <span
+            className={cn(
+              'flex h-4 w-4 items-center justify-center rounded border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
+              completed && 'border-primary bg-primary',
+              checkAnim === 'checked' && 'animate-task-check-pop',
+            )}
+          >
+            {(completed || checkAnim === 'unchecked') && (
+              <svg
+                className={cn(
+                  'h-2.5 w-2.5 stroke-primary-foreground',
+                  checkAnim === 'checked' && 'animate-task-check-mark-in',
+                  checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                )}
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={4}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </span>
+        </label>
       )}
       <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={7} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           {priority === 'high' && !completed && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
-              title="High priority"
+            <svg
+              className="h-2 w-2 shrink-0"
+              viewBox="0 0 12 12"
+              role="img"
               aria-label="High priority"
+            >
+              <title>High priority</title>
+              <path d="M6 1l5 9H1z" fill="hsl(var(--primary))" />
+            </svg>
+          )}
+          {priority === 'medium' && !completed && (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/70"
+              title="Medium priority"
+              aria-label="Medium priority"
             />
           )}
           <div
@@ -250,9 +338,11 @@ function TouchRow({
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
+  const checkAnim = useCheckAnimState(completed);
   const outerClass = cn(
     'flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-accent/30',
     href && 'transition-colors hover:bg-accent/50',
+    checkAnim === 'checked' && 'animate-task-row-glow',
   );
   const swatch = courseSwatch(courseColor);
 
@@ -262,7 +352,7 @@ function TouchRow({
       <div className="flex items-center gap-3 px-3.5 py-3">
         {onToggleComplete && (
           <label
-            className="relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center"
+            className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
             onClick={(e) => e.stopPropagation()}
           >
             <input
@@ -272,18 +362,36 @@ function TouchRow({
               className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
               aria-label={`Mark ${title} complete`}
             />
+            {checkAnim === 'checked' && (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                />
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                />
+              </>
+            )}
             <span
               className={cn(
                 'flex h-6 w-6 items-center justify-center rounded-full border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
                 completed && 'border-primary bg-primary',
+                checkAnim === 'checked' && 'animate-task-check-pop',
               )}
             >
-              {completed && (
+              {(completed || checkAnim === 'unchecked') && (
                 <svg
-                  className="h-3.5 w-3.5 stroke-primary-foreground"
+                  className={cn(
+                    'h-3.5 w-3.5 stroke-primary-foreground',
+                    checkAnim === 'checked' && 'animate-task-check-mark-in',
+                    checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                  )}
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth={3}
+                  aria-hidden="true"
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                 </svg>

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -261,21 +261,38 @@ function CardRow({
         <div className="flex items-center gap-1.5">
           {priority === 'high' && !completed && (
             <svg
-              className="h-2 w-2 shrink-0"
-              viewBox="0 0 12 12"
+              className="h-3.5 w-3.5 shrink-0"
+              viewBox="0 0 16 16"
               role="img"
               aria-label="High priority"
             >
               <title>High priority</title>
-              <path d="M6 1l5 9H1z" fill="hsl(var(--primary))" />
+              <path d="M8 1.5l7 12.5H1z" fill="hsl(0 84% 60%)" />
+              <rect x="7.25" y="6" width="1.5" height="4" rx="0.75" fill="white" />
+              <circle cx="8" cy="11.5" r="0.9" fill="white" />
             </svg>
           )}
           {priority === 'medium' && !completed && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/70"
-              title="Medium priority"
+            <svg
+              className="h-3.5 w-3.5 shrink-0"
+              viewBox="0 0 16 16"
+              role="img"
               aria-label="Medium priority"
-            />
+            >
+              <title>Medium priority</title>
+              <path d="M8 1.5l7 12.5H1z" fill="hsl(38 92% 50%)" />
+            </svg>
+          )}
+          {priority === 'low' && !completed && (
+            <svg
+              className="h-3 w-3 shrink-0"
+              viewBox="0 0 16 16"
+              role="img"
+              aria-label="Low priority"
+            >
+              <title>Low priority</title>
+              <circle cx="8" cy="8" r="6.5" fill="hsl(142 71% 40%)" />
+            </svg>
           )}
           <div
             className={cn(

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { courseBorderColor } from '@/lib/courseColors';
+import { courseBorderColor, courseSwatch, courseWash } from '@/lib/courseColors';
 import type { AssignmentType, Priority } from '@/types/schedule';
 
 const TYPE_ICON_PATH: Record<AssignmentType, string> = {
@@ -13,6 +13,15 @@ const TYPE_ICON_PATH: Record<AssignmentType, string> = {
   reading:
     'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
   other: 'M5 13l4 4L19 7',
+};
+
+const TYPE_LABEL: Record<AssignmentType, string> = {
+  assignment: 'Assignment',
+  exam: 'Exam',
+  quiz: 'Quiz',
+  project: 'Project',
+  reading: 'Reading',
+  other: 'Other',
 };
 
 export interface TaskRowProps {
@@ -28,6 +37,13 @@ export interface TaskRowProps {
   /** When present, the row navigates to this URL on click (e.g. a task
    * detail page), while the checkbox stays independently clickable. */
   href?: string;
+  /** Visual density. 'compact' (default) is the thin, left-bordered line
+   * built for long lists (Tasks, course detail). 'card' gives the row a
+   * course-tinted background and more breathing room, for short,
+   * high-attention lists (Dashboard, Planner's "Today"). 'touch' swaps the
+   * course-color surface for a top accent bar plus a larger circular
+   * checkbox, for touch-first contexts (a mobile calendar day view). */
+  variant?: 'compact' | 'card' | 'touch';
 }
 
 export function TaskRow({
@@ -40,7 +56,38 @@ export function TaskRow({
   onToggleComplete,
   trailing,
   href,
+  variant = 'compact',
 }: TaskRowProps) {
+  if (variant === 'card') {
+    return (
+      <CardRow
+        title={title}
+        type={type}
+        courseCode={courseCode}
+        courseColor={courseColor}
+        completed={completed}
+        priority={priority}
+        onToggleComplete={onToggleComplete}
+        trailing={trailing}
+        href={href}
+      />
+    );
+  }
+
+  if (variant === 'touch') {
+    return (
+      <TouchRow
+        title={title}
+        type={type}
+        courseCode={courseCode}
+        courseColor={courseColor}
+        completed={completed}
+        onToggleComplete={onToggleComplete}
+        trailing={trailing}
+        href={href}
+      />
+    );
+  }
   // A bold, course-colored left edge is the row's primary "which class is
   // this" signal (Direction B), replacing the old small course-colored icon
   // badge - the type icon below is now plain/muted instead, so it doesn't
@@ -114,4 +161,165 @@ export function TaskRow({
       {content}
     </div>
   );
+}
+
+function metaLine(courseCode: string | undefined, type: AssignmentType) {
+  return courseCode ? `${courseCode} · ${TYPE_LABEL[type]}` : TYPE_LABEL[type];
+}
+
+function CardRow({
+  title,
+  type,
+  courseCode,
+  courseColor,
+  completed,
+  priority,
+  onToggleComplete,
+  trailing,
+  href,
+}: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed' | 'priority'>> &
+  Pick<TaskRowProps, 'courseCode' | 'courseColor' | 'onToggleComplete' | 'trailing' | 'href'>) {
+  const rowClass = cn(
+    'flex items-start gap-3 rounded-xl border border-border/60 p-3',
+    href && 'transition-colors hover:border-border',
+  );
+
+  const content = (
+    <>
+      {onToggleComplete && (
+        <input
+          type="checkbox"
+          checked={completed}
+          onChange={onToggleComplete}
+          onClick={(e) => e.stopPropagation()}
+          className="mt-0.5 h-4 w-4 shrink-0 rounded border-border accent-primary"
+          aria-label={`Mark ${title} complete`}
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          {priority === 'high' && !completed && (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+              title="High priority"
+              aria-label="High priority"
+            />
+          )}
+          <div
+            className={cn(
+              'text-sm font-medium truncate',
+              completed ? 'text-muted-foreground line-through' : 'text-foreground',
+            )}
+          >
+            {title}
+          </div>
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+      </div>
+      {trailing && (
+        <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
+          {trailing}
+        </div>
+      )}
+    </>
+  );
+
+  const style = courseWash(courseColor);
+
+  if (href) {
+    return (
+      <Link href={href} className={rowClass} style={style}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={rowClass} style={style}>
+      {content}
+    </div>
+  );
+}
+
+function TouchRow({
+  title,
+  type,
+  courseCode,
+  courseColor,
+  completed,
+  onToggleComplete,
+  trailing,
+  href,
+}: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed'>> &
+  Pick<TaskRowProps, 'courseCode' | 'courseColor' | 'onToggleComplete' | 'trailing' | 'href'>) {
+  const outerClass = cn(
+    'flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-accent/30',
+    href && 'transition-colors hover:bg-accent/50',
+  );
+  const swatch = courseSwatch(courseColor);
+
+  const content = (
+    <>
+      <div className={cn('h-1 w-full', swatch.className)} style={swatch.style} />
+      <div className="flex items-center gap-3 px-3.5 py-3">
+        {onToggleComplete && (
+          <label
+            className="relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              checked={completed}
+              onChange={onToggleComplete}
+              className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              aria-label={`Mark ${title} complete`}
+            />
+            <span
+              className={cn(
+                'flex h-6 w-6 items-center justify-center rounded-full border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
+                completed && 'border-primary bg-primary',
+              )}
+            >
+              {completed && (
+                <svg
+                  className="h-3.5 w-3.5 stroke-primary-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={3}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </span>
+          </label>
+        )}
+        <div className="min-w-0 flex-1">
+          <div
+            className={cn(
+              'text-sm font-semibold truncate',
+              completed ? 'text-muted-foreground line-through' : 'text-foreground',
+            )}
+          >
+            {title}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+        </div>
+        {trailing && (
+          <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            {trailing}
+          </div>
+        )}
+      </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={outerClass}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={outerClass}>{content}</div>;
 }

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 import { Course, ScheduleItem } from '@/types/schedule';
+import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 
 export interface AppState {
   courses: Course[];
@@ -12,6 +13,12 @@ export interface AppState {
    * 'all' is an explicit user choice to see every term, distinct from "no
    * opinion yet". A specific term string filters to that term. */
   selectedTerm: string | null;
+  /** Account-level settings (lib/firestore/preferences.ts), kept live here
+   * by useFirestoreSync's `users/{uid}` listener - centralizing it means
+   * every view that renders a TaskRow reads the same realtime value
+   * instead of each opening its own Firestore listener. Defaults until the
+   * first snapshot arrives, so nothing needs to null-check this. */
+  preferences: UserPreferences;
   initialized: boolean;
 }
 
@@ -26,13 +33,15 @@ export type AppAction =
   | { type: 'REMOVE_SCHEDULE_ITEM'; payload: string }
   | { type: 'TOGGLE_SCHEDULE_ITEM_COMPLETED'; payload: string }
   | { type: 'SELECT_COURSE'; payload: string | null }
-  | { type: 'SELECT_TERM'; payload: string | null };
+  | { type: 'SELECT_TERM'; payload: string | null }
+  | { type: 'SET_PREFERENCES'; payload: UserPreferences };
 
 export const initialAppState: AppState = {
   courses: [],
   scheduleItems: [],
   selectedCourseId: null,
   selectedTerm: null,
+  preferences: DEFAULT_PREFERENCES,
   initialized: false,
 };
 
@@ -85,6 +94,8 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       return { ...state, selectedCourseId: action.payload };
     case 'SELECT_TERM':
       return { ...state, selectedTerm: action.payload };
+    case 'SET_PREFERENCES':
+      return { ...state, preferences: action.payload };
     default:
       return state;
   }

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -11,6 +11,7 @@ import {
   AppState,
 } from '@/context/AppStateContext';
 import { Course, ScheduleItem } from '@/types/schedule';
+import { DEFAULT_PREFERENCES } from '@/lib/firestore/preferences';
 
 // Helper component that consumes useAppState
 function TestConsumer() {
@@ -156,6 +157,16 @@ describe('AppStateContext Reducer & Selectors', () => {
     expect(state.selectedTerm).toBe('all');
   });
 
+  it('defaults preferences and applies SET_PREFERENCES', () => {
+    expect(initialAppState.preferences).toEqual(DEFAULT_PREFERENCES);
+
+    const next = { ...DEFAULT_PREFERENCES, taskRowVariant: 'touch' as const };
+    const state = appStateReducer(initialAppState, { type: 'SET_PREFERENCES', payload: next });
+    expect(state.preferences.taskRowVariant).toBe('touch');
+    // Untouched fields carry through the whole-object replace.
+    expect(state.preferences.dailyDigest).toBe(DEFAULT_PREFERENCES.dailyDigest);
+  });
+
   it('handles SET_COURSES and SET_SCHEDULE_ITEMS', () => {
     let state = appStateReducer(initialAppState, { type: 'SET_COURSES', payload: [mockCourse] });
     expect(state.courses).toHaveLength(1);
@@ -171,6 +182,7 @@ describe('AppStateContext Reducer & Selectors', () => {
       scheduleItems: [mockItem],
       selectedCourseId: 'c1',
       selectedTerm: null,
+      preferences: DEFAULT_PREFERENCES,
       initialized: true,
     };
 

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -85,12 +85,16 @@ function renderPlanner() {
 }
 
 describe('PlannerView', () => {
-  it('lists all tasks by default, sorted by due date', () => {
+  it('groups by due date by default, with completed items in their own group', () => {
     renderPlanner();
+    // Pending items always render in due-date order regardless of which
+    // date bucket (Overdue/Today/This Week/Later) they land in, and the
+    // Completed bucket always renders last - so this ordering holds no
+    // matter what "today" is when the test runs.
     const titles = screen
       .getAllByText(/^(Recursion HW|Midterm Exam|Finished Reading)$/)
       .map((el) => el.textContent);
-    expect(titles).toEqual(['Finished Reading', 'Midterm Exam', 'Recursion HW']);
+    expect(titles).toEqual(['Midterm Exam', 'Recursion HW', 'Finished Reading']);
   });
 
   it('filters to only pending tasks', () => {
@@ -107,15 +111,34 @@ describe('PlannerView', () => {
     expect(screen.getByText('Midterm Exam')).toBeDefined();
   });
 
-  it('sorts by priority when selected', () => {
+  it('sorts by priority when selected, within a flat list', () => {
     renderPlanner();
-    fireEvent.change(screen.getByDisplayValue('Sort: Due Date'), {
+    fireEvent.change(screen.getByDisplayValue('Group: Due Date'), { target: { value: 'flat' } });
+    fireEvent.change(screen.getByDisplayValue('Then by: Due Date'), {
       target: { value: 'priority' },
     });
     const titles = screen
       .getAllByText(/^(Recursion HW|Midterm Exam|Finished Reading)$/)
       .map((el) => el.textContent);
     expect(titles).toEqual(['Midterm Exam', 'Finished Reading', 'Recursion HW']);
+  });
+
+  it('groups by course and can reorder within a course by status', () => {
+    renderPlanner();
+    fireEvent.change(screen.getByDisplayValue('Group: Due Date'), { target: { value: 'course' } });
+    expect(screen.getByRole('heading', { name: 'CSCI 213' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'MATH 301' })).toBeDefined();
+
+    fireEvent.change(screen.getByDisplayValue('Then by: Due Date'), {
+      target: { value: 'status' },
+    });
+    // CSCI 213 has Recursion HW (pending) and Finished Reading (completed) -
+    // sorting the course group by status should put the pending item first
+    // regardless of due date.
+    const csciTitles = screen
+      .getAllByText(/^(Recursion HW|Finished Reading)$/)
+      .map((el) => el.textContent);
+    expect(csciTitles).toEqual(['Recursion HW', 'Finished Reading']);
   });
 
   it('shows an empty state when no tasks match the filters', () => {

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -53,6 +53,7 @@ const scheduleItems: ScheduleItem[] = [
     dueDate: '2026-09-10T00:00:00.000Z',
     completed: false,
     priority: 'low',
+    progress: 30,
   },
   {
     id: 'i2',
@@ -139,6 +140,17 @@ describe('PlannerView', () => {
       .getAllByText(/^(Recursion HW|Finished Reading)$/)
       .map((el) => el.textContent);
     expect(csciTitles).toEqual(['Recursion HW', 'Finished Reading']);
+  });
+
+  it('groups by status into Overdue/In Progress/Upcoming/Completed', () => {
+    renderPlanner();
+    fireEvent.change(screen.getByDisplayValue('Group: Due Date'), { target: { value: 'status' } });
+    // Recursion HW has progress > 0 and isn't overdue, so it lands in
+    // "In Progress" rather than "Upcoming" - distinct from Midterm Exam,
+    // which has no progress logged.
+    expect(screen.getByRole('heading', { name: 'In Progress' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Upcoming' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Completed' })).toBeDefined();
   });
 
   it('shows an empty state when no tasks match the filters', () => {

--- a/src/lib/__tests__/TaskRow.test.tsx
+++ b/src/lib/__tests__/TaskRow.test.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 import { TaskRow } from '@/components/ui/TaskRow';
 
 describe('TaskRow', () => {
-  it('renders the title and course code', () => {
+  it('renders the title and a course code + type meta line', () => {
     render(<TaskRow title="Recursion HW" courseCode="CSCI 213" />);
     expect(screen.getByText('Recursion HW')).toBeDefined();
-    expect(screen.getByText('CSCI 213')).toBeDefined();
+    // Default type is 'assignment' - the card variant always appends it.
+    expect(screen.getByText('CSCI 213 · Assignment')).toBeDefined();
   });
 
   it('shows a strikethrough style when completed', () => {
@@ -30,9 +31,13 @@ describe('TaskRow', () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('colors the left edge from the course color, not priority', () => {
-    const { container } = render(<TaskRow title="Colored edge" courseColor="bg-blue-500" />);
-    expect((container.firstChild as HTMLElement).style.borderLeftColor).toBe('rgb(59, 130, 246)');
+  it('washes the card background with the course color', () => {
+    const { container } = render(<TaskRow title="Colored card" courseColor="bg-blue-500" />);
+    // courseWash resolves the blue-500 preset to its hex (#3b82f6) with a
+    // faint alpha; jsdom normalizes the 8-digit hex it's given into rgba.
+    expect((container.firstChild as HTMLElement).style.backgroundColor).toBe(
+      'rgba(59, 130, 246, 0.07)',
+    );
   });
 
   it('shows a high-priority indicator only for incomplete high-priority tasks', () => {
@@ -46,5 +51,17 @@ describe('TaskRow', () => {
   it('renders trailing content when provided', () => {
     render(<TaskRow title="With trailing" trailing={<span>Due Sep 1</span>} />);
     expect(screen.getByText('Due Sep 1')).toBeDefined();
+  });
+
+  it('shows the course icon badge, defaulting to the book glyph', () => {
+    const { container } = render(<TaskRow title="Icon default" />);
+    // The default 'book' glyph is a single <path> - no other primitives.
+    expect(container.querySelector('svg rect, svg circle')).toBeNull();
+  });
+
+  it('renders a different glyph when courseIcon is set', () => {
+    const { container } = render(<TaskRow title="Icon set" courseIcon="calculator" />);
+    // The 'calculator' glyph is built from a <rect> plus dot <circle>s.
+    expect(container.querySelector('svg rect')).not.toBeNull();
   });
 });

--- a/src/lib/__tests__/courseColors.test.ts
+++ b/src/lib/__tests__/courseColors.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { pickSuggestedCourseColor, pickNextCourseColor } from '@/lib/courseColors';
+
+describe('pickSuggestedCourseColor', () => {
+  it('uses a valid AI suggestion as-is when nothing else this term has it', () => {
+    expect(pickSuggestedCourseColor([], 'Fall 2026', 'bg-teal-500')).toBe('bg-teal-500');
+  });
+
+  it('falls back to the least-used preset when the suggestion is missing or invalid', () => {
+    expect(pickSuggestedCourseColor([], 'Fall 2026', null)).toBe(pickNextCourseColor([]));
+    expect(pickSuggestedCourseColor([], 'Fall 2026', 'not-a-real-color')).toBe(
+      pickNextCourseColor([]),
+    );
+  });
+
+  it('avoids a color another course this term already uses', () => {
+    const existing = [{ color: 'bg-teal-500', term: 'Fall 2026' }];
+    expect(pickSuggestedCourseColor(existing, 'Fall 2026', 'bg-teal-500')).not.toBe('bg-teal-500');
+  });
+
+  it('keeps the suggestion when the only collision is in a different term', () => {
+    const existing = [{ color: 'bg-teal-500', term: 'Spring 2026' }];
+    expect(pickSuggestedCourseColor(existing, 'Fall 2026', 'bg-teal-500')).toBe('bg-teal-500');
+  });
+
+  it('falls back to comparing against everything when the term is unknown', () => {
+    const existing = [{ color: 'bg-blue-500', term: 'Fall 2026' }];
+    expect(pickSuggestedCourseColor(existing, undefined, 'bg-blue-500')).not.toBe('bg-blue-500');
+  });
+});

--- a/src/lib/__tests__/courseIcons.test.ts
+++ b/src/lib/__tests__/courseIcons.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCourseIcon, pickSuggestedCourseIcon, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
+
+describe('resolveCourseIcon', () => {
+  it('passes through a recognized preset', () => {
+    expect(resolveCourseIcon('flask')).toBe('flask');
+  });
+
+  it('falls back to the default for undefined, unknown, or empty values', () => {
+    expect(resolveCourseIcon(undefined)).toBe(DEFAULT_COURSE_ICON);
+    expect(resolveCourseIcon('not-a-real-icon')).toBe(DEFAULT_COURSE_ICON);
+    expect(resolveCourseIcon('')).toBe(DEFAULT_COURSE_ICON);
+  });
+});
+
+describe('pickSuggestedCourseIcon', () => {
+  it('uses a valid AI suggestion as-is', () => {
+    expect(pickSuggestedCourseIcon('calculator')).toBe('calculator');
+  });
+
+  it('falls back to the default when the suggestion is missing or invalid', () => {
+    expect(pickSuggestedCourseIcon(null)).toBe(DEFAULT_COURSE_ICON);
+    expect(pickSuggestedCourseIcon(undefined)).toBe(DEFAULT_COURSE_ICON);
+    expect(pickSuggestedCourseIcon('not-a-real-icon')).toBe(DEFAULT_COURSE_ICON);
+  });
+});

--- a/src/lib/__tests__/courseIcons.test.ts
+++ b/src/lib/__tests__/courseIcons.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCourseIcon, pickSuggestedCourseIcon, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
+import {
+  resolveCourseIcon,
+  pickSuggestedCourseIcon,
+  DEFAULT_COURSE_ICON,
+  COURSE_ICON_PRESETS,
+} from '@/lib/courseIcons';
 
 describe('resolveCourseIcon', () => {
   it('passes through a recognized preset', () => {
@@ -14,13 +19,29 @@ describe('resolveCourseIcon', () => {
 });
 
 describe('pickSuggestedCourseIcon', () => {
-  it('uses a valid AI suggestion as-is', () => {
-    expect(pickSuggestedCourseIcon('calculator')).toBe('calculator');
+  it('uses a valid AI suggestion as-is when nothing else this term has it', () => {
+    expect(pickSuggestedCourseIcon([], 'Fall 2026', 'calculator')).toBe('calculator');
   });
 
   it('falls back to the default when the suggestion is missing or invalid', () => {
-    expect(pickSuggestedCourseIcon(null)).toBe(DEFAULT_COURSE_ICON);
-    expect(pickSuggestedCourseIcon(undefined)).toBe(DEFAULT_COURSE_ICON);
-    expect(pickSuggestedCourseIcon('not-a-real-icon')).toBe(DEFAULT_COURSE_ICON);
+    expect(pickSuggestedCourseIcon([], 'Fall 2026', null)).toBe(DEFAULT_COURSE_ICON);
+    expect(pickSuggestedCourseIcon([], 'Fall 2026', undefined)).toBe(DEFAULT_COURSE_ICON);
+    expect(pickSuggestedCourseIcon([], 'Fall 2026', 'not-a-real-icon')).toBe(DEFAULT_COURSE_ICON);
+  });
+
+  it('steers away from an icon another course this term already uses, toward a free one', () => {
+    const existing = [{ icon: 'calculator', term: 'Fall 2026' }];
+    const picked = pickSuggestedCourseIcon(existing, 'Fall 2026', 'calculator');
+    expect(picked).not.toBe('calculator');
+  });
+
+  it('keeps the suggestion when the only collision is in a different term', () => {
+    const existing = [{ icon: 'calculator', term: 'Spring 2026' }];
+    expect(pickSuggestedCourseIcon(existing, 'Fall 2026', 'calculator')).toBe('calculator');
+  });
+
+  it('is only a soft preference: keeps the suggestion once every preset is already taken', () => {
+    const existing = COURSE_ICON_PRESETS.map((p) => ({ icon: p.value, term: 'Fall 2026' }));
+    expect(pickSuggestedCourseIcon(existing, 'Fall 2026', 'calculator')).toBe('calculator');
   });
 });

--- a/src/lib/__tests__/courseValidation.test.ts
+++ b/src/lib/__tests__/courseValidation.test.ts
@@ -32,7 +32,12 @@ describe('meetingTimeSchema', () => {
 });
 
 describe('courseFormSchema with meetingTimes', () => {
-  const base = { code: 'CSCI 213', title: 'Computer Science I', color: 'bg-blue-500' };
+  const base = {
+    code: 'CSCI 213',
+    title: 'Computer Science I',
+    color: 'bg-blue-500',
+    icon: 'code',
+  };
 
   it('accepts a course with no meeting times', () => {
     expect(courseFormSchema.safeParse(base).success).toBe(true);

--- a/src/lib/__tests__/taskStatus.test.ts
+++ b/src/lib/__tests__/taskStatus.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { clampProgress, getTaskStatus } from '@/lib/taskStatus';
+
+describe('clampProgress', () => {
+  it('passes through an in-range value', () => {
+    expect(clampProgress(40)).toBe(40);
+  });
+
+  it('clamps above 100 and below 0', () => {
+    expect(clampProgress(150)).toBe(100);
+    expect(clampProgress(-10)).toBe(0);
+  });
+
+  it('treats NaN as 0 rather than propagating it', () => {
+    expect(clampProgress(Number.NaN)).toBe(0);
+  });
+});
+
+describe('getTaskStatus', () => {
+  it('is not_started when neither completed nor progress is set', () => {
+    expect(getTaskStatus({ completed: false })).toBe('not_started');
+    expect(getTaskStatus({ completed: false, progress: 0 })).toBe('not_started');
+  });
+
+  it('is in_progress once progress is above 0 and the task is still open', () => {
+    expect(getTaskStatus({ completed: false, progress: 1 })).toBe('in_progress');
+    expect(getTaskStatus({ completed: false, progress: 99 })).toBe('in_progress');
+  });
+
+  it('is completed whenever `completed` is true, regardless of progress', () => {
+    expect(getTaskStatus({ completed: true, progress: 0 })).toBe('completed');
+    expect(getTaskStatus({ completed: true, progress: 40 })).toBe('completed');
+    expect(getTaskStatus({ completed: true })).toBe('completed');
+  });
+});

--- a/src/lib/__tests__/workload.test.ts
+++ b/src/lib/__tests__/workload.test.ts
@@ -66,6 +66,28 @@ describe('#50 getBaseEffectiveHours', () => {
     const item = makeItem({ estimatedHours: 0 });
     expect(getBaseEffectiveHours(item)).toBe(0);
   });
+
+  it('scales hours down by progress, so a half-finished item counts as half', () => {
+    const item = makeItem({ type: 'assignment', estimatedHours: 10, progress: 50 });
+    expect(getBaseEffectiveHours(item)).toBeCloseTo(5 * ASSIGNMENT_TYPE_WEIGHT.assignment);
+  });
+
+  it('counts a finished-but-not-checked-off item as zero remaining hours', () => {
+    const item = makeItem({ estimatedHours: 10, progress: 100 });
+    expect(getBaseEffectiveHours(item)).toBe(0);
+  });
+
+  it('treats an unset progress the same as 0 (no change from before progress existed)', () => {
+    const item = makeItem({ estimatedHours: 8 });
+    expect(getBaseEffectiveHours(item)).toBeCloseTo(8 * ASSIGNMENT_TYPE_WEIGHT.assignment);
+  });
+
+  it('clamps an out-of-range progress value instead of producing negative or inflated hours', () => {
+    const over = makeItem({ estimatedHours: 10, progress: 150 });
+    const under = makeItem({ estimatedHours: 10, progress: -20 });
+    expect(getBaseEffectiveHours(over)).toBe(0);
+    expect(getBaseEffectiveHours(under)).toBeCloseTo(10 * ASSIGNMENT_TYPE_WEIGHT.assignment);
+  });
 });
 
 describe('#52 applyStressFactor', () => {
@@ -293,6 +315,22 @@ describe('cross-cutting integration', () => {
     const level = getWorkloadLevel(dailyLoad.get(REFERENCE_DATE) ?? 0);
     expect(typeof level).toBe('string');
     expect(['low', 'medium', 'high', 'critical']).toContain(level);
+  });
+
+  it('progress on one item lowers both calculateDailyLoad and recommendStudyStartDate consistently', () => {
+    // Same item, only progress differs - proves the reduction flows through
+    // getBaseEffectiveHours to every consumer, not just one of them.
+    const untouched = makeItem({ dueDate: REFERENCE_DATE, estimatedHours: 4, type: 'assignment' });
+    const halfDone = { ...untouched, progress: 50 };
+
+    const untouchedLoad = calculateDailyLoad([untouched], REFERENCE_DATE).get(REFERENCE_DATE) ?? 0;
+    const halfDoneLoad = calculateDailyLoad([halfDone], REFERENCE_DATE).get(REFERENCE_DATE) ?? 0;
+    expect(halfDoneLoad).toBeCloseTo(untouchedLoad / 2);
+
+    const untouchedRec = recommendStudyStartDate(untouched, REFERENCE_DATE);
+    const halfDoneRec = recommendStudyStartDate(halfDone, REFERENCE_DATE);
+    const sum = (alloc: Record<string, number>) => Object.values(alloc).reduce((a, b) => a + b, 0);
+    expect(sum(halfDoneRec.dailyAllocation)).toBeCloseTo(sum(untouchedRec.dailyAllocation) / 2);
   });
 });
 

--- a/src/lib/ai/syllabusExtractionTool.ts
+++ b/src/lib/ai/syllabusExtractionTool.ts
@@ -1,5 +1,6 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
+import { COURSE_ICON_PRESETS } from '@/lib/courseIcons';
 
 /**
  * Forces Claude's response into our exact schema via tool-calling, rather
@@ -76,6 +77,12 @@ export const SYLLABUS_EXTRACTION_TOOL: Anthropic.Tool = {
             description:
               'A clean, human-readable name for the syllabus file itself, with NO extension, built from the actual course code and term found in the document - e.g. "ECON 201 - Fall 2026 Syllabus" - not the original uploaded file\'s name.',
           },
+          suggestedIcon: {
+            type: ['string', 'null'],
+            enum: [...COURSE_ICON_PRESETS.map((p) => p.value), null],
+            description:
+              'The best-fitting subject icon for this course from the fixed preset list: "book" (reading-heavy/general/humanities with no better fit), "calculator" (math/statistics), "flask" (lab science - biology/chemistry/physics/environmental), "globe" (history/geography/social studies), "chat" (foreign language), "code" (computer science/software engineering), "chart" (business/economics/accounting), "palette" (art/design), "music" (music), "film" (media/theater/film studies), "heart" (health/psychology/nursing), "scale" (law/political science), "bolt" (kinesiology/PE/fitness), "puzzle" (anything else). Pick the closest match rather than defaulting to "book" for every course.',
+          },
         },
       },
       scheduleItems: {
@@ -147,4 +154,5 @@ export const SYLLABUS_EXTRACTION_SYSTEM_PROMPT = `You are an expert academic pla
 8. Flag highStakes: true on items with roughly 15%+ grade weight, or explicit "mandatory"/"required attendance"/"automatic F if missed" language - these deserve a visual warning during review, not the same treatment as a routine reading.
 9. If the term/year is stated anywhere in the document (header, "Spring 2026", a schedule table's date range), use it to resolve every date to a full ISO YYYY-MM-DD - never leave a date ambiguous about the year.
 10. Always propose suggestedColor: pick whichever preset best matches the course's subject by common academic convention (see the tool schema for examples). This is just a starting point the student can change, so a reasonable guess beats leaving it null.
-11. Always propose suggestedFileName: a short, human-readable name built from the real course code and term (e.g. "PSYC 220 - Spring 2026 Syllabus"), not a restatement of the uploaded file's own name.`;
+11. Always propose suggestedFileName: a short, human-readable name built from the real course code and term (e.g. "PSYC 220 - Spring 2026 Syllabus"), not a restatement of the uploaded file's own name.
+12. Always propose suggestedIcon: pick the preset that best matches the course's actual subject (see the tool schema's enum for what each icon represents) - another starting point the student can change, not a final answer.`;

--- a/src/lib/ai/syllabusExtractionTool.ts
+++ b/src/lib/ai/syllabusExtractionTool.ts
@@ -1,4 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk';
+import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
 
 /**
  * Forces Claude's response into our exact schema via tool-calling, rather
@@ -63,6 +64,17 @@ export const SYLLABUS_EXTRACTION_TOOL: Anthropic.Tool = {
             type: ['string', 'null'],
             description:
               'Free-text catch-all for things worth keeping but not worth modeling structurally: footnotes on meeting times (e.g. "sectional days start at noon"), "no comprehensive final exam", grading-dispute windows, etc.',
+          },
+          suggestedColor: {
+            type: ['string', 'null'],
+            enum: [...COURSE_COLOR_PRESETS.map((p) => p.value), null],
+            description:
+              'The best-fitting color for this course from the fixed preset list, using common US academic subject-color conventions where a clear one exists (e.g. math/stats: red or blue; natural sciences - biology, chemistry, physics, environmental science: green; computer science/engineering: indigo or violet; English/literature/writing: purple; history/social studies/political science: orange or amber; economics/business/accounting: amber; foreign languages: teal or cyan; art/music/theater/performance: pink or rose; health/kinesiology/PE/nursing: lime; psychology: teal). For a subject with no strong convention, use judgment - pick whichever available color feels most fitting rather than defaulting to the same one every time.',
+          },
+          suggestedFileName: {
+            type: ['string', 'null'],
+            description:
+              'A clean, human-readable name for the syllabus file itself, with NO extension, built from the actual course code and term found in the document - e.g. "ECON 201 - Fall 2026 Syllabus" - not the original uploaded file\'s name.',
           },
         },
       },
@@ -133,4 +145,6 @@ export const SYLLABUS_EXTRACTION_SYSTEM_PROMPT = `You are an expert academic pla
 6. Look beyond traditional assignments for other calendar-worthy dates: mandatory performances/rehearsals/trips (especially in arts/ensemble courses), registrar deadlines the syllabus itself lists (add/drop, withdrawal-with-refund cutoffs), and holidays/breaks called out in a weekly schedule table. Holidays/breaks go in skipDates (so recurring class meetings can skip them), not scheduleItems.
 7. Extract a general materials list only when the syllabus actually describes required/optional supplies (textbook, calculator, specific paper, dress code, instrument, etc.) - leave it empty if none are mentioned, and don't confuse free/open-source software tools with physical supplies.
 8. Flag highStakes: true on items with roughly 15%+ grade weight, or explicit "mandatory"/"required attendance"/"automatic F if missed" language - these deserve a visual warning during review, not the same treatment as a routine reading.
-9. If the term/year is stated anywhere in the document (header, "Spring 2026", a schedule table's date range), use it to resolve every date to a full ISO YYYY-MM-DD - never leave a date ambiguous about the year.`;
+9. If the term/year is stated anywhere in the document (header, "Spring 2026", a schedule table's date range), use it to resolve every date to a full ISO YYYY-MM-DD - never leave a date ambiguous about the year.
+10. Always propose suggestedColor: pick whichever preset best matches the course's subject by common academic convention (see the tool schema for examples). This is just a starting point the student can change, so a reasonable guess beats leaving it null.
+11. Always propose suggestedFileName: a short, human-readable name built from the real course code and term (e.g. "PSYC 220 - Spring 2026 Syllabus"), not a restatement of the uploaded file's own name.`;

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -136,6 +136,22 @@ export function courseBorderColor(color: string | undefined): CSSProperties {
  * doesn't default to the same blue every other course starts as. Custom
  * hex colors count toward "used" but never get reassigned automatically.
  */
+/** Prefers a subject-matched color suggested by the syllabus extractor
+ * (see `suggestedColor` in types/extraction.ts), but falls back to
+ * `pickNextCourseColor`'s least-used-preset logic when the suggestion is
+ * missing, not a recognized preset, or would collide with a color an
+ * existing course already uses - two courses in the same subject
+ * shouldn't render identically just because they share a convention. */
+export function pickSuggestedCourseColor(
+  existingCourses: Pick<Course, 'color'>[],
+  suggested: string | null | undefined,
+): string {
+  const isValidPreset = !!suggested && COURSE_COLOR_PRESETS.some((p) => p.value === suggested);
+  const alreadyUsed = isValidPreset && existingCourses.some((c) => c.color === suggested);
+  if (isValidPreset && !alreadyUsed) return suggested;
+  return pickNextCourseColor(existingCourses);
+}
+
 export function pickNextCourseColor(existingCourses: Pick<Course, 'color'>[]): string {
   const counts = new Map(COURSE_COLOR_PRESETS.map((p) => [p.value, 0]));
   for (const course of existingCourses) {

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -130,6 +130,21 @@ export function courseBorderColor(color: string | undefined): CSSProperties {
   return { borderLeftColor: resolveCourseHex(color) };
 }
 
+/** Narrows to the courses that share `term`, since a color/icon only needs
+ * to stay distinct from what's already on screen together - a course from
+ * a past semester colliding with this term's palette isn't a real clash.
+ * An unknown/missing term falls back to comparing against everything
+ * (the safer default when we can't tell terms apart); a known term with no
+ * matches yet - the first course added to it - correctly compares against
+ * nothing rather than borrowing an unrelated term's usage. */
+export function scopeToTerm<T extends { term?: string }>(
+  courses: T[],
+  term: string | null | undefined,
+): T[] {
+  if (!term) return courses;
+  return courses.filter((c) => c.term === term);
+}
+
 /**
  * Picks the color least represented among a user's existing courses (ties
  * broken by preset order), so a freshly autofilled or manually added course
@@ -139,17 +154,20 @@ export function courseBorderColor(color: string | undefined): CSSProperties {
 /** Prefers a subject-matched color suggested by the syllabus extractor
  * (see `suggestedColor` in types/extraction.ts), but falls back to
  * `pickNextCourseColor`'s least-used-preset logic when the suggestion is
- * missing, not a recognized preset, or would collide with a color an
- * existing course already uses - two courses in the same subject
- * shouldn't render identically just because they share a convention. */
+ * missing, not a recognized preset, or would collide with a color another
+ * course in the same term already uses - two courses running the same
+ * semester shouldn't render identically just because they share a subject
+ * convention. */
 export function pickSuggestedCourseColor(
-  existingCourses: Pick<Course, 'color'>[],
+  existingCourses: Pick<Course, 'color' | 'term'>[],
+  term: string | null | undefined,
   suggested: string | null | undefined,
 ): string {
+  const pool = scopeToTerm(existingCourses, term);
   const isValidPreset = !!suggested && COURSE_COLOR_PRESETS.some((p) => p.value === suggested);
-  const alreadyUsed = isValidPreset && existingCourses.some((c) => c.color === suggested);
+  const alreadyUsed = isValidPreset && pool.some((c) => c.color === suggested);
   if (isValidPreset && !alreadyUsed) return suggested;
-  return pickNextCourseColor(existingCourses);
+  return pickNextCourseColor(pool);
 }
 
 export function pickNextCourseColor(existingCourses: Pick<Course, 'color'>[]): string {

--- a/src/lib/courseIcons.ts
+++ b/src/lib/courseIcons.ts
@@ -1,3 +1,6 @@
+import type { Course } from '@/types/schedule';
+import { scopeToTerm } from '@/lib/courseColors';
+
 /**
  * A course's icon, separate from its color - color says "which course at a
  * glance across a list," icon says "what kind of subject this is" even
@@ -39,10 +42,45 @@ export function resolveCourseIcon(icon: string | undefined): string {
   return icon && ICON_VALUES.includes(icon) ? icon : DEFAULT_COURSE_ICON;
 }
 
-/** Mirrors pickSuggestedCourseColor's shape, but simpler: unlike color,
- * two same-subject courses sharing an icon is fine (color still tells them
- * apart), so an invalid or missing suggestion just falls back to the
- * default rather than needing a least-used rotation. */
-export function pickSuggestedCourseIcon(suggested: string | null | undefined): string {
-  return suggested && ICON_VALUES.includes(suggested) ? suggested : DEFAULT_COURSE_ICON;
+/** Prefers the syllabus extractor's subject-matched icon suggestion, same
+ * as `pickSuggestedCourseColor`, but the avoidance here is a soft nicety
+ * rather than a hard rule: two same-subject courses sharing an icon is
+ * genuinely fine (color still tells them apart), so this only steers away
+ * from a suggestion that's already in use by another course *this term*
+ * when a less-used icon is readily available - never at the cost of
+ * falling back past the default. */
+export function pickSuggestedCourseIcon(
+  existingCourses: Pick<Course, 'icon' | 'term'>[],
+  term: string | null | undefined,
+  suggested: string | null | undefined,
+): string {
+  const isValid = !!suggested && ICON_VALUES.includes(suggested);
+  if (!isValid) return DEFAULT_COURSE_ICON;
+  const pool = scopeToTerm(existingCourses, term);
+  const alreadyUsed = pool.some((c) => c.icon === suggested);
+  if (!alreadyUsed) return suggested;
+  return pickLeastUsedIcon(pool) ?? suggested;
+}
+
+/** Least-represented preset among `existingCourses`, ties broken by preset
+ * order - only called once a suggested icon is already taken this term, so
+ * a genuine tie (e.g. every preset equally used) just keeps the original
+ * suggestion rather than reshuffling for no benefit. */
+function pickLeastUsedIcon(existingCourses: Pick<Course, 'icon'>[]): string | null {
+  const counts = new Map(ICON_VALUES.map((v) => [v, 0]));
+  for (const course of existingCourses) {
+    if (course.icon && counts.has(course.icon)) {
+      counts.set(course.icon, (counts.get(course.icon) ?? 0) + 1);
+    }
+  }
+  let best: string | null = null;
+  let bestCount = Infinity;
+  for (const value of ICON_VALUES) {
+    const count = counts.get(value) ?? 0;
+    if (count < bestCount) {
+      best = value;
+      bestCount = count;
+    }
+  }
+  return bestCount === 0 ? best : null;
 }

--- a/src/lib/courseIcons.ts
+++ b/src/lib/courseIcons.ts
@@ -1,0 +1,48 @@
+/**
+ * A course's icon, separate from its color - color says "which course at a
+ * glance across a list," icon says "what kind of subject this is" even
+ * before you've learned to associate the color. Kept as a small fixed
+ * preset list (like COURSE_COLOR_PRESETS) rather than free-form upload/
+ * emoji, so every course row can render it as a plain stroked SVG glyph
+ * instead of juggling image assets.
+ */
+export interface CourseIconPreset {
+  value: string;
+  label: string;
+}
+
+export const COURSE_ICON_PRESETS: CourseIconPreset[] = [
+  { value: 'book', label: 'Reading/General' },
+  { value: 'calculator', label: 'Math' },
+  { value: 'flask', label: 'Science' },
+  { value: 'globe', label: 'History/Geography' },
+  { value: 'chat', label: 'Language' },
+  { value: 'code', label: 'Computer Science' },
+  { value: 'chart', label: 'Business/Economics' },
+  { value: 'palette', label: 'Art/Design' },
+  { value: 'music', label: 'Music' },
+  { value: 'film', label: 'Media/Theater' },
+  { value: 'heart', label: 'Health/Psychology' },
+  { value: 'scale', label: 'Law/Political Science' },
+  { value: 'bolt', label: 'Fitness/Kinesiology' },
+  { value: 'puzzle', label: 'Other' },
+];
+
+export const DEFAULT_COURSE_ICON = 'book';
+
+const ICON_VALUES = COURSE_ICON_PRESETS.map((p) => p.value);
+
+/** Every reader of `Course.icon` goes through this rather than trusting the
+ * stored string directly, so a missing/renamed/hand-edited value degrades
+ * to the default glyph instead of rendering nothing. */
+export function resolveCourseIcon(icon: string | undefined): string {
+  return icon && ICON_VALUES.includes(icon) ? icon : DEFAULT_COURSE_ICON;
+}
+
+/** Mirrors pickSuggestedCourseColor's shape, but simpler: unlike color,
+ * two same-subject courses sharing an icon is fine (color still tells them
+ * apart), so an invalid or missing suggestion just falls back to the
+ * default rather than needing a least-used rotation. */
+export function pickSuggestedCourseIcon(suggested: string | null | undefined): string {
+  return suggested && ICON_VALUES.includes(suggested) ? suggested : DEFAULT_COURSE_ICON;
+}

--- a/src/lib/firestore/preferences.ts
+++ b/src/lib/firestore/preferences.ts
@@ -8,12 +8,20 @@ export interface UserPreferences {
   dailyDigest: boolean;
   deadlineReminders: boolean;
   weeklyRecap: boolean;
+  /** Which TaskRow visual density the student wants used everywhere the
+   * app renders a task - 'card' (tinted background, denser info) or
+   * 'touch' (top accent bar, large circular checkbox, built for tapping
+   * on a phone). Set from Profile; synced the same as every other
+   * preference here, so it's realtime and follows the account across
+   * devices rather than being a per-browser setting. */
+  taskRowVariant: 'card' | 'touch';
 }
 
 export const DEFAULT_PREFERENCES: UserPreferences = {
   dailyDigest: true,
   deadlineReminders: true,
   weeklyRecap: false,
+  taskRowVariant: 'card',
 };
 
 function requireDb() {

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import { collection, doc, onSnapshot } from 'firebase/firestore';
 import { db } from '@/lib/firebase/client';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
+import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 import type { Course, ScheduleItem } from '@/types/schedule';
 
 /**
@@ -31,10 +32,19 @@ export function useFirestoreSync() {
         });
       },
     );
+    // Same doc ProfileView writes to via updateUserPreferences - kept here
+    // instead of a separate listener per consumer, so a change (from this
+    // device or another) reaches every view that reads state.preferences
+    // through the one realtime subscription.
+    const unsubPreferences = onSnapshot(doc(db, 'users', user.uid), (snapshot) => {
+      const stored = snapshot.data()?.preferences as Partial<UserPreferences> | undefined;
+      dispatch({ type: 'SET_PREFERENCES', payload: { ...DEFAULT_PREFERENCES, ...stored } });
+    });
 
     return () => {
       unsubCourses();
       unsubItems();
+      unsubPreferences();
     };
   }, [user, dispatch]);
 }

--- a/src/lib/taskStatus.ts
+++ b/src/lib/taskStatus.ts
@@ -1,0 +1,28 @@
+import type { ScheduleItem } from '@/types/schedule';
+
+/**
+ * Derived task status. `completed` is always authoritative - a task can be
+ * completed with `progress` at any value (e.g. reopening a done task falls
+ * back to whatever progress it last reported, rather than snapping to 0).
+ */
+export type TaskStatus = 'not_started' | 'in_progress' | 'completed';
+
+/** Defensive against a hand-edited or stale Firestore doc with an
+ * out-of-range value - every reader of `progress` should go through this
+ * rather than trusting the stored number directly. */
+export function clampProgress(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+}
+
+export function getTaskStatus(item: Pick<ScheduleItem, 'completed' | 'progress'>): TaskStatus {
+  if (item.completed) return 'completed';
+  if (clampProgress(item.progress ?? 0) > 0) return 'in_progress';
+  return 'not_started';
+}
+
+export const TASK_STATUS_LABEL: Record<TaskStatus, string> = {
+  not_started: 'Not Started',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+};

--- a/src/lib/validation/course.ts
+++ b/src/lib/validation/course.ts
@@ -24,6 +24,7 @@ export const courseFormSchema = z.object({
   instructor: z.string().trim().max(100, 'Keep it under 100 characters').optional(),
   term: z.string().trim().max(50, 'Keep it under 50 characters').optional(),
   color: z.string().min(1),
+  icon: z.string().min(1),
   modality: z.union([z.literal('in-person'), z.literal('online'), z.literal('hybrid')]).optional(),
   meetingTimes: z.array(meetingTimeSchema).optional(),
 });

--- a/src/lib/validation/scheduleItem.ts
+++ b/src/lib/validation/scheduleItem.ts
@@ -11,6 +11,13 @@ export const scheduleItemFormSchema = z.object({
     .refine((v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0), 'Enter a positive number'),
   priority: z.enum(['low', 'medium', 'high']),
   notes: z.string().max(500, 'Keep it under 500 characters').optional(),
+  progress: z
+    .string()
+    .optional()
+    .refine(
+      (v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0 && Number(v) <= 100),
+      'Enter 0-100',
+    ),
 });
 
 export type ScheduleItemFormValues = z.infer<typeof scheduleItemFormSchema>;

--- a/src/lib/workload/dailyLoad.ts
+++ b/src/lib/workload/dailyLoad.ts
@@ -1,4 +1,5 @@
 import type { ScheduleItem, WorkloadLevel } from '@/types/schedule';
+import { clampProgress } from '@/lib/taskStatus';
 import {
   ASSIGNMENT_TYPE_WEIGHT,
   DEFAULT_ESTIMATED_HOURS,
@@ -31,10 +32,20 @@ export interface WorkloadOptions {
  * un-estimated item as zero load. A true 0-hour item (estimatedHours: 0) is
  * respected as zero, since that's an explicit user statement, not an absence
  * of data.
+ *
+ * The result is further scaled by how much of the item is *not yet* done
+ * (`1 - progress/100`), so a half-finished project counts as half its
+ * estimate instead of its full estimate right up until it's checked
+ * complete - this is the single choke point both `calculateDailyLoad` (today
+ * forward) and `recommendStudyStartDate` (backward from the due date) read
+ * through, so progress-aware remaining effort is consistent everywhere the
+ * workload engine is used. An item with no `progress` set behaves exactly as
+ * before (fraction of 1, no change).
  */
 export function getBaseEffectiveHours(item: ScheduleItem): number {
   const rawHours = item.estimatedHours ?? DEFAULT_ESTIMATED_HOURS[item.type];
-  return rawHours * ASSIGNMENT_TYPE_WEIGHT[item.type];
+  const remainingFraction = 1 - clampProgress(item.progress ?? 0) / 100;
+  return rawHours * ASSIGNMENT_TYPE_WEIGHT[item.type] * remainingFraction;
 }
 
 /**

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
+import { COURSE_ICON_PRESETS } from '@/lib/courseIcons';
 
 const courseColorValues = COURSE_COLOR_PRESETS.map((p) => p.value) as [string, ...string[]];
+const courseIconValues = COURSE_ICON_PRESETS.map((p) => p.value) as [string, ...string[]];
 
 /**
  * Schema for what Claude extracts from a syllabus PDF (Epic 6). Shared
@@ -82,6 +84,10 @@ export const extractedCourseSchema = z.object({
    * the source file happened to be named, e.g. "ECON 201 - Fall 2026
    * Syllabus" instead of "scan0042.pdf". */
   suggestedFileName: z.string().min(1).max(80).nullable().optional(),
+  /** One of COURSE_ICON_PRESETS (lib/courseIcons.ts) that Claude judges
+   * fits the subject, e.g. a flask for a lab science. Same "suggestion,
+   * not mandate" treatment as suggestedColor. */
+  suggestedIcon: z.enum(courseIconValues).nullable().optional(),
 });
 
 export const syllabusExtractionSchema = z.object({

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod';
+import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
+
+const courseColorValues = COURSE_COLOR_PRESETS.map((p) => p.value) as [string, ...string[]];
 
 /**
  * Schema for what Claude extracts from a syllabus PDF (Epic 6). Shared
@@ -67,6 +70,18 @@ export const extractedCourseSchema = z.object({
    * structurally: footnotes on meeting times, "no comprehensive final",
    * grading-dispute windows, etc. */
   notes: z.string().max(1000).nullable().optional(),
+  /** A course-color preset (one of COURSE_COLOR_PRESETS) that Claude judges
+   * to fit the subject's common academic color convention, e.g. green for
+   * a natural science, red/blue for math - a nicer starting point than
+   * round-robin assignment. Still just a suggestion: the review screen
+   * lets the user override it, and it's ignored if it collides with a
+   * color an existing course already uses. */
+  suggestedColor: z.enum(courseColorValues).nullable().optional(),
+  /** A clean, human-readable file name (no extension) for the uploaded
+   * syllabus, built from the actual course code/term rather than whatever
+   * the source file happened to be named, e.g. "ECON 201 - Fall 2026
+   * Syllabus" instead of "scan0042.pdf". */
+  suggestedFileName: z.string().min(1).max(80).nullable().optional(),
 });
 
 export const syllabusExtractionSchema = z.object({

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -33,6 +33,10 @@ export interface Course {
   instructor?: string;
   /** HEX or Tailwind class for color coding this course in UI elements */
   color?: string;
+  /** One of COURSE_ICON_PRESETS (lib/courseIcons.ts) - a subject glyph
+   * shown alongside color, e.g. a flask for a science course. Missing or
+   * unrecognized values resolve to the default via resolveCourseIcon(). */
+  icon?: string;
   /** The academic term, e.g., 'Fall 2026' */
   term?: string;
   /** Free-text notes about the course */

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -88,8 +88,17 @@ export interface ScheduleItem {
   dueDate: string;
   /** Estimated hours required to complete this task */
   estimatedHours?: number;
-  /** Completion status of the task */
+  /** Completion status of the task - the sole authoritative "done" signal.
+   * `progress` below is a separate, softer measure and never overrides this. */
   completed: boolean;
+  /** Self-reported completion progress, 0-100. Undefined or 0 means not
+   * started; a value above 0 (while `completed` is still false) means in
+   * progress. Feeds the workload engine's remaining-hours estimate (see
+   * getBaseEffectiveHours in lib/workload/dailyLoad.ts) so a half-finished
+   * project counts as half its estimated hours instead of its full estimate
+   * right up until the moment it's checked done. See lib/taskStatus.ts for
+   * the derived not_started/in_progress/completed status every surface uses. */
+  progress?: number;
   /** User-assigned priority */
   priority?: Priority;
   /** Free-text notes */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,9 @@ const config: Config = {
         // (globals.css) so the same class works in light and dark.
         card: 'var(--card-shadow)',
         'card-hover': 'var(--card-shadow-hover)',
+        // Modal v1: a distinct, deeper elevation tier for true modal-overlay
+        // surfaces (dialogs, sheets), theme-aware via --modal-shadow.
+        modal: 'var(--modal-shadow)',
       },
     },
   },


### PR DESCRIPTION
## Summary
Everything from the wireframe design-spec review, implemented as real code and merged in dependency order:

- Reduced-motion support + a dark-mode modal elevation tier (#151)
- Brand-gradient extraction spinner + staggered syllabus review reveal (#152)
- Dramatic task-completion animation + 44px touch targets (#155)
- Mobile hamburger drawer replaced with a 5-tab bottom bar (#153)
- Dashboard hierarchy: Tasks as a real primary card, Course Load demoted to secondary (#154)
- Progress-slider tick marks, workload-color ramp, tactile thumb (#156)
- Priority indicator redesign: colored icon (red exclamation-triangle / amber triangle / green circle) (#157)

Every change was verified with real before/after screenshots (throwaway Playwright harnesses against the actual components, not mockups) before this merge — reviewed and approved.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated `workload.test.ts` errors present on `main` already)
- [x] `npm run build` — succeeds with zero env vars set
- [x] `npm test` — 215/215 passing
- [x] Real pointer-drag test on the progress slider (not just programmatic `.fill()`)
- [x] Real before/after screenshots reviewed for all 7 changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_