### PR TITLE
Courses: urgency badges, all-terms default, honest progress ring, always-visible AI summary teaser, stakes badges (CO-1..5, VA-4)

### DIFF
--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -42,10 +42,8 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
     .slice()
     .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
 
-  if (!latestSyllabus) return null;
-
   const handleGenerate = async () => {
-    if (!user) return;
+    if (!user || !latestSyllabus) return;
     setGenerating(true);
     setError(null);
     try {
@@ -86,7 +84,42 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   // A summary generated from a since-deleted/replaced file is still shown -
   // it's better to have slightly stale info clearly labeled with its source
   // than to silently discard a real Anthropic result.
-  const isStale = summary && summary.sourceFileName !== latestSyllabus.fileName;
+  const isStale = !!summary && !!latestSyllabus && summary.sourceFileName !== latestSyllabus.fileName;
+
+  // CO-4: this card used to return null with no syllabus on file, so a fresh
+  // course page showed nothing between the dropzone and Tasks - zero
+  // indication that "read your syllabus and flag what to watch for" (the
+  // app's namesake feature) exists at all. A locked/teaser state - visually
+  // distinct (dashed, muted) from both the populated and the
+  // ready-to-generate states below - reads as "not yet" instead of
+  // "broken/missing".
+  if (!latestSyllabus) {
+    return (
+      <Card className="rounded-2xl border-dashed p-6 opacity-90">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z"
+              />
+            </svg>
+          </span>
+          <h2 className="text-base font-semibold text-muted-foreground">AI Summary</h2>
+        </div>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Upload a syllabus above to get an AI summary and a watch-out-for list.
+        </p>
+      </Card>
+    );
+  }
 
   return (
     <Card className="rounded-2xl p-6 space-y-4">

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -33,6 +33,12 @@ import type { ScheduleItem } from '@/types/schedule';
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
+/** Below this many logged tasks, `progressPct` is too small a sample to read
+ * as a meaningful measure of how the class is going - a single seeded task
+ * marked done would otherwise render a triumphant full ring (CO-3). Below
+ * the threshold a muted outline stands in for the gradient ring. */
+const RING_MIN_TASK_COUNT = 3;
+
 export function CourseDetailView({ courseId }: { courseId: string }) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
@@ -189,9 +195,29 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                 </div>
               </div>
               {items.length > 0 && (
-                <ProgressRing percent={progressPct} size={56} strokeWidth={6}>
-                  <span className="text-xs font-bold text-foreground">{progressPct}%</span>
-                </ProgressRing>
+                <div className="flex shrink-0 flex-col items-center gap-1">
+                  {items.length < RING_MIN_TASK_COUNT ? (
+                    // Too few tracked tasks for a percentage to mean anything -
+                    // a muted dashed outline stands in for the bold gradient
+                    // arc so this doesn't read as a confident grade proxy.
+                    <div
+                      className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-dashed border-muted-foreground/30"
+                      title="Not enough tracked tasks yet for a meaningful progress ring"
+                    >
+                      <span className="text-[11px] font-semibold text-muted-foreground">
+                        {completedCount}/{items.length}
+                      </span>
+                    </div>
+                  ) : (
+                    <ProgressRing percent={progressPct} size={56} strokeWidth={6}>
+                      <span className="text-xs font-bold text-foreground">{progressPct}%</span>
+                    </ProgressRing>
+                  )}
+                  <span className="max-w-[88px] text-center text-[10px] leading-tight text-muted-foreground">
+                    {completedCount} of {items.length} tracked task{items.length === 1 ? '' : 's'}{' '}
+                    done
+                  </span>
+                </div>
               )}
             </div>
 
@@ -340,6 +366,18 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                     trailing={
                       <>
+                        {/* Stakes badge (CO-5) - a 25%-of-grade exam and a
+                            zero-weight attendance check otherwise render as
+                            visual near-twins in this list. Only items with a
+                            real grade weight get the badge, so it stays a
+                            signal rather than noise on every row. Reuses
+                            TaskRow's existing `trailing` slot; TaskRow itself
+                            is untouched. */}
+                        {item.gradeWeight != null && item.gradeWeight > 0 && (
+                          <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400">
+                            {item.gradeWeight}% grade
+                          </span>
+                        )}
                         {overdue && (
                           <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
                             Overdue

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
-import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
+import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
@@ -30,13 +30,14 @@ export function CoursesListView() {
   const { courses, scheduleItems } = state;
 
   const [search, setSearch] = useState('');
-  // Seeded from the global term switcher (#101) so this page opens already
-  // scoped to whatever term the rest of the app is showing, while staying a
-  // fully independent local filter the user can change without affecting
-  // the global selection.
-  const [termFilter, setTermFilter] = useState(
-    () => resolveActiveTerm(state.selectedTerm, state.courses) ?? 'all',
-  );
+  // Defaults to "All Terms" rather than the global term switcher's active
+  // term (#101) - this page is where a student comes to find a specific
+  // course, including one from a past term, and a silently-narrowed default
+  // used to make older courses disappear with no indication a filter was
+  // hiding them (CO-2). Users can still narrow explicitly via the select
+  // below; each card is term-badged so identity stays clear once several
+  // terms are shown together.
+  const [termFilter, setTermFilter] = useState<string>('all');
   const [sortMode, setSortMode] = useState<SortMode>('code');
   const [addCourseOpen, setAddCourseOpen] = useState(false);
   const [autofillOpen, setAutofillOpen] = useState(false);
@@ -98,7 +99,9 @@ export function CoursesListView() {
         <div className="flex items-center justify-between gap-4">
           <div>
             <h1 className="text-2xl font-bold text-foreground tracking-tight">Courses</h1>
-            <p className="text-sm text-muted-foreground mt-1">Every course you&apos;re tracking.</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              See what needs attention across every class.
+            </p>
           </div>
           <div className="flex items-center gap-2">
             <CardActionButton onClick={() => setAutofillOpen(true)}>
@@ -191,6 +194,14 @@ export function CoursesListView() {
               const completed = items.filter((i) => i.completed).length;
               const pct = items.length ? Math.round((completed / items.length) * 100) : 0;
               const meetingDays = meetingDaysLabel(course.meetingTimes);
+              // Same "overdue" definition CourseDetailView already uses for
+              // its per-task badge (CO-1) - surfaced here too so the list a
+              // student opens to decide what to worry about actually answers
+              // that, instead of only a generic completion percentage.
+              const now = new Date();
+              const overdueCount = items.filter(
+                (i) => !i.completed && new Date(i.dueDate) < now,
+              ).length;
 
               return (
                 <Link key={course.id} href={`/courses/${course.id}`} className="block">
@@ -220,24 +231,40 @@ export function CoursesListView() {
                         </div>
                       </div>
 
-                      {(meetingDays || course.modality) && (
-                        <div className="mb-3 flex flex-wrap gap-1.5">
-                          {meetingDays && (
-                            <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                              {meetingDays}
-                            </span>
+                      <div className="mb-3 flex flex-wrap items-center gap-1.5">
+                        {/* Term badge lives on every card (not just the bottom-line
+                            caption it replaces) so a course keeps a clear identity
+                            even once the list defaults to showing every term at
+                            once (CO-2). */}
+                        <span
+                          className={cn(
+                            'rounded-full px-2 py-0.5 text-[10px] font-medium',
+                            course.term
+                              ? 'bg-accent text-muted-foreground'
+                              : 'bg-accent/60 italic text-muted-foreground/70',
                           )}
-                          {course.modality && (
-                            <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium capitalize text-muted-foreground">
-                              {course.modality}
-                            </span>
-                          )}
-                        </div>
-                      )}
+                        >
+                          {course.term || 'No term set'}
+                        </span>
+                        {meetingDays && (
+                          <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                            {meetingDays}
+                          </span>
+                        )}
+                        {course.modality && (
+                          <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium capitalize text-muted-foreground">
+                            {course.modality}
+                          </span>
+                        )}
+                        {overdueCount > 0 && (
+                          <span className="ml-auto rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                            {overdueCount} overdue
+                          </span>
+                        )}
+                      </div>
 
                       <div className="mt-auto space-y-1.5">
-                        <div className="flex items-center justify-between text-xs text-muted-foreground">
-                          <span>{course.term || 'No term set'}</span>
+                        <div className="flex items-center justify-end text-xs text-muted-foreground">
                           <span>
                             {items.length > 0
                               ? `${pct}% · ${items.length} task${items.length === 1 ? '' : 's'}`


### PR DESCRIPTION
Courses slice (list + detail) from the UX-audit backlog: CO-1 through CO-5, plus this slice's portion of VA-4. Scope: `CoursesListView.tsx`, `CourseDetailView.tsx`, `CourseAiSummaryCard.tsx` only — `TaskRow.tsx` is untouched, reusing its existing `trailing` prop for CO-5.

## CO-1 — No urgency signal on the course list
**What changed:** Each course card now computes an overdue-task count (same `!completed && dueDate < now` check `CourseDetailView` already used) and shows a small "N overdue" chip when it's non-zero.
**Why:** This is the page a student opens to decide what to worry about. It used to answer that worse than the Dashboard did — a completion percentage doesn't say anything is late. The chip surfaces exactly the signal that was one click away and missing here.

## CO-2 — Courses silently disappear when the term filter defaults away from them
**What changed:** The term filter now defaults to "All Terms" instead of the inferred active term. Every card is now term-badged (including a "No term set" badge when absent), replacing the old bottom-line term caption, so a course's identity stays clear when several terms are shown together.
**Why:** A student referencing an old syllabus previously had to guess a filter was hiding it — the page just showed fewer cards with no explanation. Now nothing is hidden by default, and users narrow down explicitly.

## CO-3 — The progress ring measures task-checking, not how the class is going
**What changed:** (a) Subtext under the ring now reads "X of Y tracked tasks done." (b) Below 3 logged tasks, the bold gradient ring is replaced with a muted dashed outline showing a plain `completed/total` fraction instead of a percentage arc.
**Why:** A past-term course with one seeded, completed task showed a triumphant 100% ring — an artifact of how little was tracked, not an assessment of standing in the class. The relabel and muted treatment below a small sample size keep the ring from reading as a grade proxy it was never designed to be.

## CO-4 — The AI Summary card is invisible until a syllabus is uploaded
**What changed:** `CourseAiSummaryCard` no longer returns `null` when there's no syllabus yet. It now always renders, with a dashed/muted teaser state: "Upload a syllabus above to get an AI summary and a watch-out-for list."
**Why:** For a product named Syllabus Sense, "read your syllabus and flag what to watch for" is the pitch — and a new user looking at a fresh course page had zero indication the feature exists. The teaser makes it discoverable as "not yet," not "missing."

## CO-5 — High-stakes tasks look identical to trivial ones in the course hub
**What changed:** Task rows in `CourseDetailView`'s Tasks card now pass a small amber "N% grade" pill via TaskRow's existing `trailing` prop, for any item with a `gradeWeight > 0`. Zero/unset-weight items (e.g. attendance) get no badge, so the badge stays a signal rather than noise.
**Why:** A 25%-of-grade Midterm Exam and a zero-weight "Recitation Attendance" rendered as visual near-twins. The course hub is supposed to say what matters in this specific class — the stakes badge does that at a glance, without touching `TaskRow.tsx` itself.

## VA-4 (Courses portion) — Generic, flat subhead
**What changed:** Courses' subhead now reads "See what needs attention across every class." instead of "Every course you're tracking."
**Why:** The old copy was placeholder-grade next to the Dashboard's punchier AI-brand voice. The new line is benefit-forward and references the urgency/overdue-triage work this page now actually does (CO-1), instead of restating what the page obviously is.

## Screenshots
Before/after pairs captured with a throwaway harness (`AuthContext` temporarily exported, `useSyllabi` temporarily given a preview-only override, a `preview-harness` route seeding `AppStateProvider` with 4 courses across 2 terms) — all reverted; the final diff touches only the 3 files above. "Before" shots are from the base commit (`0006976`) in a separate worktree; "after" from this branch.

| Finding | Before | After |
|---|---|---|
| CO-1 (overdue chip) | list view, no urgency signal | "1 overdue" chip on CS 201 |
| CO-2 (all-terms default) | Spring 2026 course (HIST 110) hidden by default | all 4 courses shown, term-badged |
| CO-3 (honest ring) | MATH 150 shows bold 100% from 1 task | muted "1/1" outline + "1 of 1 tracked task done" |
| CO-4 (AI summary teaser) | nothing between Syllabus and Tasks | dashed "Upload a syllabus above..." teaser |
| CO-5 (stakes badges) | Midterm Exam (25%) and Recitation Attendance look alike | grade-weight pills on weighted tasks only |
| VA-4 (subhead) | "Every course you're tracking." | "See what needs attention across every class." |

## Verification
- `npm run lint` — clean
- `npx tsc --noEmit` — clean (only the 2 known pre-existing `workload.test.ts` errors, unrelated to this change)
- `npm run build` (zero env vars) — clean
- `npm test` — 215/215 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_