### PR TITLE
Syllabus flow: recoverable errors, mobile-usable review, surface hidden extraction data, honest copy, safe re-run (SY-1..5, VA-3, MO-5)

### DIFF
--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -56,6 +56,33 @@ interface DraftItem extends ExtractedScheduleItem {
   approved: boolean;
 }
 
+/** Classifies a caught extraction error into a user-facing bucket so the UI
+ * never surfaces a raw fetch/JS error message (e.g. the literal string
+ * "Failed to fetch") to the student. `fetch()` itself rejects with a
+ * TypeError on a genuine network failure (offline, DNS, CORS, connection
+ * reset) across browsers - that's the one case we can reliably tell apart
+ * from a server-returned/parse failure, which covers everything else. */
+function classifyExtractionError(err: unknown): 'network' | 'auth' | 'parsing' {
+  if (err instanceof Error && err.message === 'You must be signed in.') return 'auth';
+  if (err instanceof TypeError) return 'network';
+  return 'parsing';
+}
+
+const EXTRACTION_ERROR_COPY: Record<ReturnType<typeof classifyExtractionError>, string> = {
+  network: "Couldn't reach the server — check your connection and try again.",
+  auth: 'You must be signed in to use Syllabus Autofill.',
+  parsing: "Couldn't read that file — try a different PDF or Word doc.",
+};
+
+/** Strips the synthetic per-item `key` (React list identity only, never
+ * part of the extracted data) before a draft is snapshotted/compared for
+ * the SY-5 dirty check. */
+function omitDraftKey(item: DraftItem): Omit<DraftItem, 'key'> {
+  const rest: Partial<DraftItem> = { ...item };
+  delete rest.key;
+  return rest as Omit<DraftItem, 'key'>;
+}
+
 function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -83,7 +110,14 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [rerunCount, setRerunCount] = useState(0);
+  const [showRerunConfirm, setShowRerunConfirm] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  /** Snapshot (as a JSON string, for a cheap deep-equality check) of the
+   * draft exactly as Claude returned it, taken right after the most recent
+   * successful extraction. Compared against the live draft before a rerun
+   * so a student who has already hand-corrected titles/dates/approvals
+   * gets a confirmation instead of losing that work silently (SY-5). */
+  const initialDraftRef = useRef<string | null>(null);
 
   const [course, setCourse] = useState<{
     code: string;
@@ -114,6 +148,8 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setUnresolved([]);
     setFileName('');
     setRerunCount(0);
+    setShowRerunConfirm(false);
+    initialDraftRef.current = null;
   };
 
   const handleClose = () => {
@@ -145,7 +181,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       if (!res.ok) throw new Error(data.error ?? 'Extraction failed.');
 
       const result: SyllabusExtractionResult = data.result;
-      setCourse({
+      const nextCourse = {
         code: result.course.code,
         title: result.course.title,
         instructor: result.course.instructor ?? '',
@@ -175,15 +211,17 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         materials: result.course.materials,
         skipDates: result.course.skipDates,
         notes: result.course.notes ?? '',
-      });
-      setItems(
-        result.scheduleItems.map((item, i) => ({
-          ...item,
-          key: `${i}-${item.title}`,
-          approved: item.dueDate !== null,
-        })),
-      );
-      setUnresolved(result.unresolved);
+      };
+      const nextItems: DraftItem[] = result.scheduleItems.map((item, i) => ({
+        ...item,
+        key: `${i}-${item.title}`,
+        approved: item.dueDate !== null,
+      }));
+      const nextUnresolved = result.unresolved;
+
+      setCourse(nextCourse);
+      setItems(nextItems);
+      setUnresolved(nextUnresolved);
       setFileName(
         dedupeSuggestedFileName(
           state.courses,
@@ -192,9 +230,19 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
           result.course.suggestedFileName,
         ),
       );
+      // Baseline for the SY-5 "did the student already edit this?" check -
+      // taken from the exact objects just written to state, minus the
+      // synthetic per-item `key` used only for React list identity.
+      initialDraftRef.current = JSON.stringify({
+        course: nextCourse,
+        items: nextItems.map(omitDraftKey),
+        unresolved: nextUnresolved,
+      });
       setStep('review');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Extraction failed. Please try again.');
+      // Never surface the raw fetch/JS error (e.g. "Failed to fetch") to
+      // the student - map it to typed, actionable copy instead (SY-1).
+      setError(EXTRACTION_ERROR_COPY[classifyExtractionError(err)]);
       setStep(course ? 'review' : 'upload');
     }
   };
@@ -209,14 +257,50 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     await runExtraction(selected);
   };
 
+  /** True once the live draft has diverged from the extraction it started
+   * from - a hand-edited title/date/approval, a rejected item, an added
+   * material, etc. Deliberately a simple stringified-snapshot comparison
+   * (SY-5 only asks for "simple," not sophisticated) rather than a field-
+   * by-field diff. */
+  const isDraftDirty = () => {
+    if (!initialDraftRef.current) return false;
+    const current = JSON.stringify({
+      course,
+      items: items.map(omitDraftKey),
+      unresolved,
+    });
+    return current !== initialDraftRef.current;
+  };
+
   /** "Reject and send it back to the AI": discards the current draft and
    * re-runs extraction on the same uploaded file. A fresh pass can land
    * differently since the model isn't deterministic, and it's cheaper than
-   * asking the student to re-upload. */
+   * asking the student to re-upload. Guarded behind a confirmation when the
+   * student has already hand-corrected the draft, so one click can't
+   * silently erase several minutes of careful review (SY-5). */
   const handleRerun = async () => {
+    if (!file) return;
+    if (isDraftDirty()) {
+      setShowRerunConfirm(true);
+      return;
+    }
+    setRerunCount((n) => n + 1);
+    await runExtraction(file);
+  };
+
+  const confirmRerun = async () => {
+    setShowRerunConfirm(false);
     if (!file) return;
     setRerunCount((n) => n + 1);
     await runExtraction(file);
+  };
+
+  /** Clears the failed pick and reopens the file browser, for the "Choose a
+   * different file" affordance on the post-failure error view (SY-1). */
+  const chooseDifferentFile = () => {
+    setError(null);
+    setFile(null);
+    inputRef.current?.click();
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -265,6 +349,13 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
   };
 
   const approvedCount = items.filter((i) => i.approved).length;
+  // Counts for the VA-3 post-extraction summary chip: high-stakes uses the
+  // same `highStakes` flag the per-item badge already renders below, and
+  // "needs confirmation" uses the same dateConfidence values the per-item
+  // badges already flag ("approximate" / "unknown") - no new concept, just
+  // surfacing what the review list already tracks per item as a headline.
+  const highStakesCount = items.filter((i) => i.highStakes).length;
+  const needsConfirmationCount = items.filter((i) => i.dateConfidence !== 'exact').length;
 
   const handleConfirm = async () => {
     if (!course || !user) return;
@@ -376,8 +467,9 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
               Let Claude read it, you decide what sticks
             </h2>
             <p className="mt-1.5 max-w-xl text-sm text-white/80">
-              Upload a syllabus, review every field and assignment Claude drafted, and approve only
-              what you want on your calendar.
+              Grade weights, high-stakes deadlines, and easy-to-miss dates get buried in a long
+              PDF &mdash; Claude pulls them out so nothing slips by, and you approve every one
+              before it hits your calendar.
             </p>
             <div className="mt-5">
               <StepIndicator step={step} />
@@ -385,7 +477,10 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
           </div>
 
           <CardContent className="space-y-5 p-6 sm:p-8">
-            {error && (
+            {/* The post-failure retry view below (SY-1) already shows this
+                same message inline with the retained file, so the generic
+                banner is suppressed there to avoid saying it twice. */}
+            {error && !(step === 'upload' && file) && (
               <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3.5 py-2.5 text-sm text-destructive">
                 <svg
                   className="mt-0.5 h-4 w-4 shrink-0"
@@ -404,23 +499,13 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
               </div>
             )}
 
-            {step === 'upload' && (
-              <div
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setDragActive(true);
-                }}
-                onDragLeave={() => setDragActive(false)}
-                onDrop={handleDrop}
-                onClick={() => inputRef.current?.click()}
-                role="button"
-                tabIndex={0}
-                className={cn(
-                  'flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed px-4 py-16 text-center cursor-pointer transition-colors',
-                  dragActive ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/60',
-                )}
-              >
-                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            {step === 'upload' && file && error ? (
+              // SY-1: a failed extraction lands back here, but with the
+              // originally-picked file retained and named - never the bare
+              // "drop a file" prompt again, which read as if nothing had
+              // been chosen at all.
+              <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-destructive/30 bg-destructive/5 px-4 py-16 text-center">
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-destructive/10 text-destructive">
                   <svg
                     className="h-6 w-6"
                     fill="none"
@@ -431,14 +516,30 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
-                      d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M12 12v9m0-9l-3 3m3-3l3 3"
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
                     />
                   </svg>
                 </span>
-                <span className="text-sm font-semibold text-foreground">
-                  Drop a syllabus PDF or Word doc here, or click to browse
+                <span className="max-w-xs truncate text-sm font-semibold text-foreground">
+                  {file.name}
                 </span>
-                <span className="text-xs text-muted-foreground">PDF or .docx, up to 10MB</span>
+                <span className="text-xs text-destructive">{error}</span>
+                <div className="mt-3 flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => runExtraction(file)}
+                    className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90"
+                  >
+                    Try again
+                  </button>
+                  <button
+                    type="button"
+                    onClick={chooseDifferentFile}
+                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                  >
+                    Choose a different file
+                  </button>
+                </div>
                 <input
                   ref={inputRef}
                   type="file"
@@ -451,6 +552,63 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   }}
                 />
               </div>
+            ) : (
+              step === 'upload' && (
+                <div
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragActive(true);
+                  }}
+                  onDragLeave={() => setDragActive(false)}
+                  onDrop={handleDrop}
+                  onClick={() => inputRef.current?.click()}
+                  role="button"
+                  tabIndex={0}
+                  className={cn(
+                    'flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed px-4 py-16 text-center cursor-pointer transition-colors',
+                    dragActive
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:bg-accent/60',
+                  )}
+                >
+                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    <svg
+                      className="h-6 w-6"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.75}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M12 12v9m0-9l-3 3m3-3l3 3"
+                      />
+                    </svg>
+                  </span>
+                  {/* MO-5: dragging onto a browser tab isn't possible on a
+                      touch device, so the universally-applicable tap action
+                      leads, with drag demoted to secondary desktop-only copy. */}
+                  <span className="text-sm font-semibold text-foreground">
+                    Tap to choose a file
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    or drag a syllabus PDF or Word doc here
+                  </span>
+                  <span className="text-xs text-muted-foreground">PDF or .docx, up to 10MB</span>
+                  <input
+                    ref={inputRef}
+                    type="file"
+                    accept="application/pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    className="hidden"
+                    onChange={(e) => {
+                      const selected = e.target.files?.[0];
+                      if (selected) handleFile(selected);
+                      e.target.value = '';
+                    }}
+                  />
+                </div>
+              )
             )}
 
             {step === 'extracting' && (
@@ -463,7 +621,8 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     {rerunCount > 0 ? 'Giving it another pass...' : 'Reading your syllabus...'}
                   </p>
                   <p className="mt-0.5 text-xs text-muted-foreground">
-                    Finding the course details, every assignment, and a color and icon that fit.
+                    Pulling out grade weights, high-stakes items, and registrar deadlines &mdash;
+                    not just a list of assignments.
                   </p>
                 </div>
               </div>
@@ -471,6 +630,29 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
 
             {(step === 'review' || step === 'saving') && course && (
               <div className="space-y-6">
+                {/* VA-3: names what was actually protected against, right
+                    where the student lands after extraction completes. */}
+                {items.length > 0 && (
+                  <div
+                    className="review-reveal flex flex-wrap items-center gap-1.5 text-xs font-semibold"
+                    style={{ animationDelay: '0ms' }}
+                  >
+                    <span className="rounded-full bg-primary/10 px-2.5 py-1 text-primary">
+                      Found {items.length} item{items.length === 1 ? '' : 's'}
+                    </span>
+                    {highStakesCount > 0 && (
+                      <span className="rounded-full bg-load-critical/10 px-2.5 py-1 text-load-critical">
+                        {highStakesCount} high-stakes
+                      </span>
+                    )}
+                    {needsConfirmationCount > 0 && (
+                      <span className="rounded-full bg-load-medium/10 px-2.5 py-1 text-load-medium">
+                        {needsConfirmationCount} date{needsConfirmationCount === 1 ? '' : 's'}{' '}
+                        {needsConfirmationCount === 1 ? 'needs' : 'need'} confirmation
+                      </span>
+                    )}
+                  </div>
+                )}
                 <section
                   className="review-reveal space-y-4 rounded-2xl border border-border bg-accent/30 p-4 sm:p-5"
                   style={{ animationDelay: '0ms' }}
@@ -707,13 +889,77 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   </section>
                 )}
 
+                {/* SY-3: course.notes and course.skipDates were parsed and
+                    saved to Firestore on confirm but never shown anywhere in
+                    this review UI - a lost "it actually read this" moment.
+                    Read-only per the finding's minimum bar, with notes as a
+                    light editable bonus since it reuses the existing
+                    TextField-style pattern already used above. */}
+                {(course.notes || course.skipDates.length > 0) && (
+                  <section
+                    className="review-reveal space-y-2.5 rounded-xl border border-primary/20 bg-primary/5 p-3 sm:p-4"
+                    style={{ animationDelay: '150ms' }}
+                  >
+                    <h3 className="flex items-center gap-1.5 text-xs font-semibold text-primary">
+                      <svg
+                        className="h-3.5 w-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+                        />
+                      </svg>
+                      Claude also caught
+                    </h3>
+                    {course.notes && (
+                      <div className="space-y-1">
+                        <label
+                          htmlFor="autofill-course-notes"
+                          className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                        >
+                          Fine print
+                        </label>
+                        <textarea
+                          id="autofill-course-notes"
+                          value={course.notes}
+                          onChange={(e) => setCourse((c) => c && { ...c, notes: e.target.value })}
+                          rows={2}
+                          className="w-full resize-none rounded-lg border border-border bg-card px-3 py-1.5 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                      </div>
+                    )}
+                    {course.skipDates.length > 0 && (
+                      <div className="space-y-1">
+                        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          No class on
+                        </span>
+                        <div className="flex flex-wrap gap-1.5">
+                          {course.skipDates.map((d) => (
+                            <span
+                              key={d}
+                              className="rounded-full border border-primary/30 bg-card px-2 py-0.5 text-xs font-medium text-foreground"
+                            >
+                              {formatIsoDate(d)}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </section>
+                )}
+
                 <section className="space-y-3">
                   <div
                     className="review-reveal flex flex-wrap items-center justify-between gap-2"
                     style={{ animationDelay: '180ms' }}
                   >
                     <h3 className="text-sm font-semibold text-foreground">
-                      Assignments
+                      What Claude found
                       <span className="ml-1.5 font-normal text-muted-foreground">
                         {approvedCount} of {items.length} approved
                       </span>
@@ -780,65 +1026,84 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                           )}
                           style={{ animationDelay: `${Math.min(220 + i * 40, 580)}ms` }}
                         >
-                          <div className="flex flex-wrap items-center gap-2">
-                            <div className="flex shrink-0 overflow-hidden rounded-full border border-border">
-                              <button
-                                type="button"
-                                onClick={() => updateItem(it.key, { approved: true })}
-                                disabled={!it.dueDate}
-                                className={cn(
-                                  'px-2.5 py-1 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40',
-                                  it.approved
-                                    ? 'bg-primary text-primary-foreground'
-                                    : 'bg-card text-muted-foreground hover:bg-accent',
-                                )}
-                              >
-                                Approve
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => updateItem(it.key, { approved: false })}
-                                className={cn(
-                                  'border-l border-border px-2.5 py-1 font-semibold transition-colors',
-                                  !it.approved
-                                    ? 'bg-destructive/10 text-destructive'
-                                    : 'bg-card text-muted-foreground hover:bg-accent',
-                                )}
-                              >
-                                Reject
-                              </button>
-                            </div>
+                          {/* SY-2: below `sm` this becomes two stacked rows -
+                              the title gets its own full-width line instead
+                              of losing the space race to the toggle/type/
+                              date controls in one unwrapping row. At `sm`
+                              and up, the inner wrapper collapses via
+                              `sm:contents` so its children rejoin the outer
+                              flex row and the original single-row desktop
+                              layout (and order) is unchanged. */}
+                          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
                             <input
                               value={it.title}
                               onChange={(e) => updateItem(it.key, { title: e.target.value })}
-                              className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 font-medium text-foreground"
+                              className="w-full min-w-0 rounded-md border border-border bg-background px-2 py-1 font-medium text-foreground sm:order-2 sm:flex-1"
                             />
-                            <select
-                              value={it.type}
-                              onChange={(e) =>
-                                updateItem(it.key, { type: e.target.value as AssignmentType })
-                              }
-                              className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground"
-                            >
-                              {Object.entries(TYPE_LABELS).map(([value, label]) => (
-                                <option key={value} value={value}>
-                                  {label}
-                                </option>
-                              ))}
-                            </select>
-                            <input
-                              type="date"
-                              value={it.dueDate ?? ''}
-                              onChange={(e) =>
-                                updateItem(it.key, {
-                                  dueDate: e.target.value || null,
-                                  approved: e.target.value ? it.approved : false,
-                                })
-                              }
-                              className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground"
-                            />
+                            <div className="flex flex-wrap items-center gap-2 sm:contents">
+                              <div className="flex shrink-0 overflow-hidden rounded-full border border-border sm:order-1">
+                                <button
+                                  type="button"
+                                  onClick={() => updateItem(it.key, { approved: true })}
+                                  disabled={!it.dueDate}
+                                  className={cn(
+                                    'px-2.5 py-1 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40',
+                                    it.approved
+                                      ? 'bg-primary text-primary-foreground'
+                                      : 'bg-card text-muted-foreground hover:bg-accent',
+                                  )}
+                                >
+                                  Approve
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => updateItem(it.key, { approved: false })}
+                                  className={cn(
+                                    'border-l border-border px-2.5 py-1 font-semibold transition-colors',
+                                    !it.approved
+                                      ? 'bg-destructive/10 text-destructive'
+                                      : 'bg-card text-muted-foreground hover:bg-accent',
+                                  )}
+                                >
+                                  Reject
+                                </button>
+                              </div>
+                              <select
+                                value={it.type}
+                                onChange={(e) =>
+                                  updateItem(it.key, { type: e.target.value as AssignmentType })
+                                }
+                                className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground sm:order-3"
+                              >
+                                {Object.entries(TYPE_LABELS).map(([value, label]) => (
+                                  <option key={value} value={value}>
+                                    {label}
+                                  </option>
+                                ))}
+                              </select>
+                              <input
+                                type="date"
+                                value={it.dueDate ?? ''}
+                                onChange={(e) =>
+                                  updateItem(it.key, {
+                                    dueDate: e.target.value || null,
+                                    approved: e.target.value ? it.approved : false,
+                                  })
+                                }
+                                className="rounded-md border border-border bg-background px-1.5 py-1 text-foreground sm:order-4"
+                              />
+                            </div>
                           </div>
-                          <div className="mt-2 flex flex-wrap items-center gap-1.5 pl-[4.5rem]">
+                          <div className="mt-2 flex flex-wrap items-center gap-1.5 sm:pl-[4.5rem]">
+                            {/* SY-4c: non-assignment calendar items (registrar
+                                deadlines, mandatory dates, etc.) render inside
+                                this same list - a small distinct badge keeps
+                                them from reading as just another assignment. */}
+                            {it.type === 'other' && (
+                              <span className="rounded-full border border-border bg-accent px-2 py-0.5 font-semibold text-foreground">
+                                Key date
+                              </span>
+                            )}
                             {it.dateConfidence === 'approximate' && (
                               <span className="rounded-full bg-load-medium/10 px-2 py-0.5 font-semibold text-load-medium">
                                 ~ approximate date, please confirm
@@ -909,6 +1174,44 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
           )}
         </Card>
       </div>
+
+      {/* SY-5: rerun would otherwise silently overwrite hand-corrected
+          titles/dates/approvals with zero confirmation - this only appears
+          when handleRerun's dirty check found a real difference from the
+          original extraction. */}
+      {showRerunConfirm && (
+        <div
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 px-4"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="rerun-confirm-title"
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-card p-5 shadow-modal">
+            <h3 id="rerun-confirm-title" className="text-sm font-semibold text-foreground">
+              Discard your edits?
+            </h3>
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              Re-running will discard your edits &mdash; continue?
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowRerunConfirm(false)}
+                className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmRerun}
+                className="rounded-lg bg-destructive text-destructive-foreground text-xs font-semibold px-3 py-1.5 transition-opacity hover:opacity-90"
+              >
+                Discard &amp; re-run
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -976,6 +1279,21 @@ function dedupeSuggestedFileName(
   if (!suggested || !code) return suggested ?? '';
   const collisions = existingCourses.filter((c) => c.term === term && c.code === code).length;
   return collisions > 0 ? `${suggested} (${collisions + 1})` : suggested;
+}
+
+/** Formats an ISO YYYY-MM-DD skipDate as a short human date (e.g. "Mar 9,
+ * 2026") for the SY-3 "Claude also caught" callout, without pulling in a
+ * date library for one label. Parsed as UTC noon rather than midnight so a
+ * negative-offset timezone can't roll the displayed date back a day. */
+function formatIsoDate(iso: string): string {
+  const parsed = new Date(`${iso}T12:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 function extensionOf(name: string | undefined): string {


### PR DESCRIPTION
## Scope

This PR is the Syllabus AI-autofill slice of the UX-audit backlog. All changes are contained in `src/components/syllabus/SyllabusAutofillModal.tsx` (no changes were needed in `syllabusExtractionTool.ts` — the extraction schema already captured everything these findings needed, it just wasn't rendered).

---

### SY-1 — Errors lose your progress and speak like a stack trace

**What changed:** The selected `File` is now retained through a failed extraction. On failure, the upload step renders a dedicated error/retry view (the file name, a typed message, "Try again" using the same file, and "Choose a different file") instead of falling back to the bare empty dropzone. Raw fetch/JS errors are classified into `network` / `auth` / `parsing` buckets and mapped to fixed, user-facing copy — the literal string `"Failed to fetch"` (or any other raw error message) is never shown to the user.

**Why:** The exact failure modes a syllabus upload is prone to (network blip, corrupted PDF) were dumping the user into a raw error and forcing a full re-pick with zero indication a file had ever been chosen — reads as broken software at the worst possible moment (right after they trusted us with their file).

### SY-2 — The review UI is unusable on mobile for its own core task

**What changed:** Below the `sm` breakpoint, each assignment row now stacks: the title gets its own full-width line, and the approve/reject toggle, type dropdown, and date input move to a line below. Above `sm`, the original single-row layout and order are unchanged (`sm:contents` collapses the mobile wrapper back into the row).

**Why:** At 375px, a realistic title like "Essay 1: Personal Narrative and Reflection" was rendering as roughly one visible character — on a phone, the majority device, a student literally couldn't read what they were approving in a flow whose entire value proposition is "you decide what sticks."

### SY-3 — Claude's best "wow" data is captured but never shown

**What changed:** Added a read-only "Claude also caught" callout that surfaces `course.notes` (e.g. "Late essays lose one letter grade per day") and `course.skipDates` (resolved holiday/break dates) when present. As a low-effort bonus, `notes` is actually editable (reuses the existing text-field pattern); `skipDates` renders as a read-only chip list per the finding's stated minimum bar.

**Why:** These fields were parsed by Claude and written straight to Firestore on confirm, but no input/textarea/list anywhere in the review UI ever rendered them. That's exactly the fine-print detail that makes a student think "it actually read this" — instead it was saved invisibly, a lost selling moment and a quiet trust problem.

### SY-4 — Copy and structure undersell what's actually being extracted

**What changed:** (a) The section heading changed from "Assignments" to "What Claude found". (b) The loading-phase copy now names the higher-value extraction targets ("Pulling out grade weights, high-stakes items, and registrar deadlines — not just a list of assignments") instead of "Finding the course details, every assignment, and a color and icon that fit." (c) Non-assignment items (`type: 'other'`) get a small "Key date" badge instead of rendering identically to a routine assignment.

**Why:** The product's real differentiator — grade weights, high-stakes flags, buried non-assignment deadlines like registrar cutoffs — was never narrated back anywhere, so even a genuinely impressive extraction read as "it filled out a form."

### SY-5 — "Re-run AI" silently discards manual edits

**What changed:** A JSON-snapshot of the draft is captured right after a successful extraction. Before rerunning, the draft is compared against that snapshot; if it has diverged (edited title/date/type, a rejected item, an added material, etc.) a confirmation dialog ("Re-running will discard your edits — continue?") appears instead of rerunning immediately. An untouched draft still reruns with zero extra friction.

**Why:** "Not right? Re-run AI" is meant to fix one wrong field, but was unconditionally overwriting course/items/unresolved with zero confirmation — capable of erasing several minutes of careful review in one click, punishing exactly the users who engaged most.

### VA-3 — Syllabus Autofill undersells what it actually catches

**What changed:** The modal subhead now names what's actually being protected against ("Grade weights, high-stakes deadlines, and easy-to-miss dates get buried in a long PDF — Claude pulls them out so nothing slips by...") instead of generic "review what Claude drafted" language. A summary chip now appears after extraction completes ("Found N items · K high-stakes · M dates need confirmation"), computed from the real `highStakes` flags and `dateConfidence` values already tracked per item.

**Why:** The old copy could describe any app. The real value is protecting the student from missing something grade-critical buried in a 12-page PDF, and that pitch was never actually made.

### MO-5 — Drag-copy CTA wording on touch devices

**What changed:** The dropzone now leads with "Tap to choose a file" (bold, primary), with "or drag a syllabus PDF or Word doc here" demoted to secondary copy below it.

**Why:** The old copy led with bolded "Drop a syllabus PDF... here" even though dragging a file onto a browser tab isn't possible on a touchscreen — on an app that's explicitly phone-first, that asks phone users to parse an instruction that doesn't apply to them before finding the actual tap target.

---

## Screenshots

Before/after pairs for all 7 findings were captured with a throwaway Playwright harness (mounted the real modal with a seeded `AppStateProvider` + faked `AuthContext`, intercepted `window.fetch` for the extraction endpoint, drove the real DOM via `setInputFiles`) against this branch and a second worktree at the base commit. The harness was fully removed before commit — `git status` is clean except this one file. Screenshots are attached to this PR description in the team's review doc / shared with the reviewer separately (see session notes) since they're saved to the sandbox's local scratchpad, not the repo.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean except the 2 known pre-existing `workload.test.ts` errors
- `npm run build` — succeeds with zero env vars, 17 routes (unchanged from base)
- `npm test` — 25 test files / 215 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_