### PR TITLE
Calendar: split due-vs-prep heat-tint, honor the legend, mobile chip clarity, term-wide busy alert, priority-sorted chips (CA-1..5, VA-4)

### DIFF
--- a/src/app/(app)/calendar/page.tsx
+++ b/src/app/(app)/calendar/page.tsx
@@ -11,7 +11,9 @@ export default function CalendarPage() {
     <div className="max-w-4xl space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-foreground tracking-tight">Calendar</h1>
-        <p className="text-sm text-muted-foreground mt-1">Click a day to see what&apos;s due.</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          See your workload build before it hits — not just what&apos;s due.
+        </p>
       </div>
       <MonthCalendar />
     </div>

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -15,6 +15,7 @@ import {
   getWeekDays,
   groupItemsByDay,
   isSameDay,
+  sortItemsByUrgency,
   toDayKey,
   startOfDay,
 } from '@/lib/calendar/dates';
@@ -29,6 +30,7 @@ import {
   getWorkloadLevel,
   WORKLOAD_LEVEL_LABELS,
   WORKLOAD_CHIP_CLASS,
+  WORKLOAD_PREP_INDICATOR_CLASS,
   WORKLOAD_SWATCH_CLASS,
   WORKLOAD_TEXT_CLASS,
   WORKLOAD_TINT_CLASS,
@@ -37,7 +39,7 @@ import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
 import { useModalA11y } from '@/hooks/useModalA11y';
-import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
+import type { AssignmentType, Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
 
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const monthLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
@@ -127,6 +129,26 @@ function WorkloadGaugeIcon({ level, className }: { level: WorkloadLevel; classNa
   );
 }
 
+/** Small triangular alert glyph for the CA-4 "busiest stretch" callout -
+ * distinct from the workload gauge (which encodes a *level*) since this
+ * icon just needs to say "heads up", not grade a severity. */
+function AlertIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      <path d="M12 9v4M12 17h.01" />
+    </svg>
+  );
+}
+
 function FilterIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -152,10 +174,39 @@ function formatWeekRangeLabel(weekDays: Date[]): string {
   return `${startLabel} – ${endLabel}, ${end.getFullYear()}`;
 }
 
+/** Compact "Sep 3 – 9" style range for the CA-4 busiest-stretch banner - no
+ * year, since it's a single inline banner line rather than a page heading. */
+function formatStretchRangeLabel(start: Date, end: Date): string {
+  const sameMonth = start.getMonth() === end.getMonth();
+  const startLabel = weekLabelFormatter.format(start);
+  const endLabel = sameMonth ? String(end.getDate()) : weekLabelFormatter.format(end);
+  return `${startLabel} – ${endLabel}`;
+}
+
 const MAX_VISIBLE_CHIPS = 2;
 const AGENDA_WINDOW_DAYS = 30;
+// #CA-4: width of the rolling window scanned for the term's busiest
+// upcoming stretch - a week-long lens, since a single busy day is already
+// covered by the per-month "Busiest" callout and a whole month is too
+// coarse to act on.
+const BUSY_STRETCH_WINDOW_DAYS = 7;
 
 const LEGEND_LEVELS: WorkloadLevel[] = ['low', 'medium', 'high', 'critical'];
+
+// #CA-3: on mobile-width chips there's only room for a handful of
+// characters before truncation, so a shared title prefix ("Final...")
+// collapses several different items to the same illegible fragment. Leading
+// with the item's type instead keeps mobile chips distinguishable even
+// fully truncated. Short and uppercase so it reads as a tag, not a
+// truncated word.
+const TYPE_MOBILE_LABEL: Record<AssignmentType, string> = {
+  assignment: 'ASSIGN',
+  exam: 'EXAM',
+  quiz: 'QUIZ',
+  project: 'PROJECT',
+  reading: 'READING',
+  other: 'OTHER',
+};
 
 type ViewMode = 'month' | 'week' | 'agenda';
 
@@ -253,6 +304,38 @@ export function MonthCalendar() {
     }
     return { pendingCount, totalHours, busiestDay };
   }, [grid, viewMonth, itemsByDay, dailyLoad]);
+
+  // #CA-4: the term's genuinely busiest upcoming stretch, scanned across the
+  // *entire* known dataset (dailyLoad already spans every course's items,
+  // not just the visible month) rather than monthStats above, which is
+  // deliberately scoped to whichever month is currently in view. A student
+  // paging through August has no way to discover November is brutal without
+  // this - that's the whole point of a workload-aware calendar over a plain
+  // one. Slides a BUSY_STRETCH_WINDOW_DAYS window starting from today (never
+  // the past - "upcoming") across every day that carries any load, and keeps
+  // whichever window sums the most effective hours.
+  const busiestStretch = useMemo(() => {
+    let maxDate: Date | null = null;
+    for (const key of Array.from(dailyLoad.keys())) {
+      if ((dailyLoad.get(key) ?? 0) <= 0) continue;
+      const [y, m, d] = key.split('-').map(Number);
+      const day = new Date(y, m - 1, d);
+      if (!maxDate || day > maxDate) maxDate = day;
+    }
+    if (!maxDate || maxDate < today) return null;
+
+    let best: { start: Date; end: Date; hours: number } | null = null;
+    for (let cursor = today; cursor <= maxDate; cursor = addDays(cursor, 1)) {
+      let sum = 0;
+      for (let i = 0; i < BUSY_STRETCH_WINDOW_DAYS; i++) {
+        sum += dailyLoad.get(toDayKey(addDays(cursor, i))) ?? 0;
+      }
+      if (!best || sum > best.hours) {
+        best = { start: cursor, end: addDays(cursor, BUSY_STRETCH_WINDOW_DAYS - 1), hours: sum };
+      }
+    }
+    return best && best.hours > 0 ? best : null;
+  }, [dailyLoad, today]);
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
@@ -374,6 +457,23 @@ export function MonthCalendar() {
             )}
           </div>
         </div>
+
+        {/* #CA-4: term-wide proactive heads-up, shown no matter which month/
+            week is currently in view - the whole point is surfacing a busy
+            stretch the student hasn't paged forward to see yet. */}
+        {busiestStretch && (
+          <button
+            onClick={() => selectDay(busiestStretch.start)}
+            className="mb-3 flex w-full items-center gap-2 rounded-xl border border-load-high/30 bg-load-high/10 px-3 py-2 text-left text-xs font-semibold text-foreground transition-colors hover:bg-load-high/15 sm:text-sm"
+          >
+            <AlertIcon className="h-4 w-4 shrink-0 text-load-high" />
+            <span>
+              Heads up: your busiest stretch this term is{' '}
+              {formatStretchRangeLabel(busiestStretch.start, busiestStretch.end)} (
+              {busiestStretch.hours.toFixed(1)}h)
+            </span>
+          </button>
+        )}
 
         {state.courses.length > 0 && (
           <>
@@ -584,8 +684,18 @@ export function MonthCalendar() {
                 const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
                 const hours = dailyLoad.get(toDayKey(day)) ?? 0;
                 const heatLevel = getWorkloadLevel(hours);
-                const visibleChips = dayItems.slice(0, MAX_VISIBLE_CHIPS);
-                const hiddenCount = dayItems.length - visibleChips.length;
+                // #CA-1: only a day something is literally due/scheduled on
+                // gets the full "due here" tint. A day that merely picked up
+                // some of an item's spread-out prep-time load (from
+                // calculateDailyLoad distributing hours across the days
+                // leading up to a *different* day's due date) gets the
+                // quieter WORKLOAD_PREP_INDICATOR_CLASS treatment instead -
+                // otherwise the heatmap shades empty days and a student who
+                // clicks one expecting to see why stops trusting it.
+                const dueHere = dayItems.length > 0 || dayMeetings.length > 0;
+                const sortedItems = sortItemsByUrgency(dayItems, today);
+                const visibleChips = sortedItems.slice(0, MAX_VISIBLE_CHIPS);
+                const hiddenCount = sortedItems.length - visibleChips.length;
 
                 return (
                   <button
@@ -595,7 +705,11 @@ export function MonthCalendar() {
                       'min-h-[4rem] rounded-lg p-1 flex flex-col items-start gap-0.5 text-left transition-colors sm:min-h-[6.5rem] sm:rounded-xl sm:p-1.5 sm:gap-1',
                       inCurrentMonth ? 'hover:bg-accent' : 'opacity-40 hover:bg-accent/50',
                       isSelected && 'ring-2 ring-primary',
-                      !isSelected && inCurrentMonth && WORKLOAD_TINT_CLASS[heatLevel],
+                      !isSelected &&
+                        inCurrentMonth &&
+                        (dueHere
+                          ? WORKLOAD_TINT_CLASS[heatLevel]
+                          : WORKLOAD_PREP_INDICATOR_CLASS[heatLevel]),
                     )}
                   >
                     <span
@@ -615,12 +729,14 @@ export function MonthCalendar() {
                           <span
                             key={`${m.course.id}-${i}`}
                             className={cn(
-                              'h-1.5 w-1.5 rounded-[2px]',
+                              'flex h-3 w-3 shrink-0 items-center justify-center rounded-[3px] text-white',
                               courseSwatch(m.course.color).className,
                             )}
                             style={courseSwatch(m.course.color).style}
                             title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}`}
-                          />
+                          >
+                            <GraduationCapIcon className="h-2 w-2" />
+                          </span>
                         ))}
                       </div>
                     )}
@@ -630,14 +746,29 @@ export function MonthCalendar() {
                         <span
                           key={item.id}
                           className={cn(
-                            'block w-full truncate rounded px-1 py-0.5 text-[9px] font-medium leading-tight text-white',
+                            'flex w-full min-w-0 items-center gap-0.5 overflow-hidden rounded px-1 py-0.5 text-[9px] font-medium leading-tight text-white',
                             courseSwatch(courseOf(item)?.color).className,
                             item.completed && 'opacity-40 line-through',
                           )}
                           style={courseSwatch(courseOf(item)?.color).style}
                           title={item.title}
                         >
-                          {item.title}
+                          {/* Hidden below sm: at mobile chip widths every
+                              pixel goes to the type label (CA-3) - the icon
+                              still fulfills the legend's promise (CA-2) at
+                              sm+, where there's room for both. */}
+                          <FlagIcon className="hidden h-2 w-2 shrink-0 sm:block" />
+                          {/* #CA-3: mobile-width chips only fit a handful of
+                              characters, so several similarly-titled items
+                              ("Final Exam"/"Final Project"/...) all truncate
+                              to the same illegible "Fina…". Leading with the
+                              type keeps them distinguishable; the full title
+                              is still shown at sm+ and always in the
+                              day-detail panel below. */}
+                          <span className="min-w-0 truncate sm:hidden">
+                            {TYPE_MOBILE_LABEL[item.type]}
+                          </span>
+                          <span className="hidden min-w-0 truncate sm:inline">{item.title}</span>
                         </span>
                       ))}
                       {hiddenCount > 0 && (

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { isSameDay, toDayKey } from '@/lib/calendar/dates';
+import { isSameDay, sortItemsByUrgency, toDayKey } from '@/lib/calendar/dates';
 import {
   formatTimeLabel,
   timeToFractionalHours,
@@ -10,7 +10,19 @@ import {
 import { cn } from '@/lib/utils';
 import { getWorkloadLevel } from '@/lib/workload';
 import { courseSwatch } from '@/lib/courseColors';
-import type { Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
+import type { AssignmentType, Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
+
+// #CA-3: same short, uppercase, mobile-lead labels MonthCalendar uses for
+// its day-cell chips - kept in sync so a truncated item reads the same way
+// in both views instead of picking a different abbreviation per screen.
+const TYPE_MOBILE_LABEL: Record<AssignmentType, string> = {
+  assignment: 'ASSIGN',
+  exam: 'EXAM',
+  quiz: 'QUIZ',
+  project: 'PROJECT',
+  reading: 'READING',
+  other: 'OTHER',
+};
 
 // Full 24-hour day, like Google Calendar/Outlook - a hardcoded 7am-9pm window
 // would silently hide any class or task that lands outside "typical" hours
@@ -32,6 +44,18 @@ const HEAT_TINT_CLASS: Record<WorkloadLevel, string> = {
   medium: 'bg-load-medium/5',
   high: 'bg-load-high/5',
   critical: 'bg-load-critical/10',
+};
+
+// #CA-1: mirrors MonthCalendar's due-here/prep-window split - a day column
+// only gets the full background wash when something is literally due or in
+// session that day. A day that only absorbed some of a *different* day's
+// spread-out prep-time load gets a slim top border instead, so the two
+// signals stay visually distinct here too.
+const PREP_INDICATOR_CLASS: Record<WorkloadLevel, string> = {
+  low: '',
+  medium: 'border-t-2 border-load-medium/50',
+  high: 'border-t-2 border-load-high/60',
+  critical: 'border-t-2 border-load-critical/70',
 };
 
 export interface WeekViewProps {
@@ -128,6 +152,7 @@ export function WeekView({
 
             {weekDays.map((day) => {
               const meetings = meetingsFor(day);
+              const dueHere = meetings.length > 0 || itemsFor(day).length > 0;
               const hours = dailyLoad.get(toDayKey(day)) ?? 0;
               const heatLevel = getWorkloadLevel(hours);
               const isSelected = selectedDay !== null && isSameDay(day, selectedDay);
@@ -138,7 +163,11 @@ export function WeekView({
                   style={{ height: GRID_HEIGHT }}
                   className={cn(
                     'relative border-l border-border',
-                    isSelected ? 'bg-primary/5' : HEAT_TINT_CLASS[heatLevel],
+                    isSelected
+                      ? 'bg-primary/5'
+                      : dueHere
+                        ? HEAT_TINT_CLASS[heatLevel]
+                        : PREP_INDICATOR_CLASS[heatLevel],
                   )}
                 >
                   {HOUR_LABELS.map((hour) => (
@@ -166,7 +195,21 @@ export function WeekView({
                         style={{ top, height, ...swatch.style }}
                         title={`${m.course.code} · ${formatTimeLabel(m.meeting.startTime)}–${formatTimeLabel(m.meeting.endTime)}`}
                       >
-                        <div className="truncate font-semibold">{m.course.code}</div>
+                        <div className="flex items-center gap-0.5 truncate font-semibold">
+                          <svg
+                            className="h-2.5 w-2.5 shrink-0"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <path d="M22 10L12 5 2 10l10 5 10-5z" />
+                            <path d="M6 12v5c0 1.5 2.7 3 6 3s6-1.5 6-3v-5" />
+                          </svg>
+                          <span className="truncate">{m.course.code}</span>
+                        </div>
                         {height > 32 && (
                           <div className="truncate opacity-90">
                             {formatTimeLabel(m.meeting.startTime)}
@@ -184,7 +227,10 @@ export function WeekView({
         <div className="mt-2 grid grid-cols-[3rem_repeat(7,1fr)] gap-1 border-t border-border px-0.5 pt-2">
           <div />
           {weekDays.map((day) => {
-            const items = itemsFor(day);
+            // #CA-5: same priority/urgency-first ordering as the month grid,
+            // so this column's 3-chip preview surfaces the important items
+            // rather than whichever were inserted first.
+            const items = sortItemsByUrgency(itemsFor(day), today);
             return (
               <div key={day.toISOString()} className="space-y-0.5">
                 {items.slice(0, 3).map((item) => (
@@ -192,12 +238,29 @@ export function WeekView({
                     key={item.id}
                     title={item.title}
                     className={cn(
-                      'block truncate rounded px-1 py-0.5 text-[9px] font-medium text-white',
+                      'flex items-center gap-0.5 truncate rounded px-1 py-0.5 text-[9px] font-medium text-white',
                       courseOf(item)?.color || 'bg-primary',
                       item.completed && 'opacity-40 line-through',
                     )}
                   >
-                    {item.title}
+                    <svg
+                      className="hidden h-2 w-2 shrink-0 sm:block"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M4 3v18M4 4h11l-2 4 2 4H4" />
+                    </svg>
+                    {/* #CA-3: mobile leads with the short, uppercase type
+                        instead of the title so similarly-named items stay
+                        distinguishable once truncated. */}
+                    <span className="min-w-0 truncate sm:hidden">
+                      {TYPE_MOBILE_LABEL[item.type]}
+                    </span>
+                    <span className="hidden min-w-0 truncate sm:inline">{item.title}</span>
                   </span>
                 ))}
                 {items.length > 3 && (

--- a/src/lib/calendar/dates.ts
+++ b/src/lib/calendar/dates.ts
@@ -1,4 +1,4 @@
-import type { ScheduleItem } from '@/types/schedule';
+import type { Priority, ScheduleItem } from '@/types/schedule';
 
 /**
  * Local-time calendar day key (YYYY-MM-DD).
@@ -50,6 +50,34 @@ export function getMonthGrid(month: Date): Date[] {
 export function getWeekDays(date: Date): Date[] {
   const weekStart = addDays(startOfDay(date), -date.getDay());
   return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+}
+
+// #CA-5: same high/medium/low ranking PlannerView's "Sort by: Priority"
+// already uses (see PRIORITY_RANK in components/schedule/PlannerView.tsx) -
+// duplicated here rather than imported since that file's constant isn't
+// exported and pulling a page-level component into a shared lib module
+// would be a layering inversion.
+const PRIORITY_RANK: Record<Priority, number> = { high: 0, medium: 1, low: 2 };
+
+/**
+ * Orders a day's schedule items by at-a-glance urgency - high priority
+ * first, then overdue items, then soonest due - so callers that can only
+ * show a couple of items (a calendar cell's chip slice, a week column's
+ * "+N more" preview) reliably surface the important ones instead of
+ * whichever happened to be inserted first.
+ */
+export function sortItemsByUrgency(items: ScheduleItem[], referenceDate: Date): ScheduleItem[] {
+  return items.slice().sort((a, b) => {
+    const rankA = PRIORITY_RANK[a.priority ?? 'medium'];
+    const rankB = PRIORITY_RANK[b.priority ?? 'medium'];
+    if (rankA !== rankB) return rankA - rankB;
+
+    const overdueA = !a.completed && new Date(a.dueDate) < referenceDate;
+    const overdueB = !b.completed && new Date(b.dueDate) < referenceDate;
+    if (overdueA !== overdueB) return overdueA ? -1 : 1;
+
+    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+  });
 }
 
 /** Groups schedule items by their local-time due day. */

--- a/src/lib/workload/uiClasses.ts
+++ b/src/lib/workload/uiClasses.ts
@@ -30,6 +30,22 @@ export const WORKLOAD_CHIP_CLASS: Record<WorkloadLevel, string> = {
   critical: 'border-load-critical/30 bg-load-critical/10',
 };
 
+/**
+ * Quiet "prep window" indicator (CA-1): a thin colored underline, deliberately
+ * lighter-weight than WORKLOAD_TINT_CLASS's full-cell background wash. Use
+ * this for a day that only carries spread-out prep-time load (from an item
+ * due on a *different* day) so it reads as "lighter signal, not the real
+ * thing" next to a day something is actually due/scheduled on. Never apply
+ * both classes to the same cell - they're meant to be mutually exclusive
+ * ("due here" vs "prep window only"), not stacked.
+ */
+export const WORKLOAD_PREP_INDICATOR_CLASS: Record<WorkloadLevel, string> = {
+  low: '',
+  medium: 'border-b-2 border-load-medium/50',
+  high: 'border-b-2 border-load-high/60',
+  critical: 'border-b-2 border-load-critical/70',
+};
+
 /** Text color, for labels that need to read as the level's color. */
 export const WORKLOAD_TEXT_CLASS: Record<WorkloadLevel, string> = {
   low: 'text-load-low',


### PR DESCRIPTION
## Summary

Calendar slice of the UX-audit backlog: CA-1 through CA-5, plus this slice's portion of VA-4. Files touched: `src/components/calendar/MonthCalendar.tsx`, `src/components/calendar/WeekView.tsx`, `src/lib/workload/uiClasses.ts` (new shared class token), `src/lib/calendar/dates.ts` (new shared sort helper), `src/app/(app)/calendar/page.tsx` (subhead copy).

---

### CA-1 — Heat-tint no longer colors empty days
**What changed:** A day cell only gets the full-strength "due here" tint when something is literally due or in session that day. A day that merely picked up spread-out prep-time load from a *different* day's due date now gets a thin, quieter underline instead of a full background wash. Applied to both the month grid and WeekView's day columns.
**Why:** The heatmap is the one feature that beats a plain calendar - a workload signal at a glance. When a student clicks a shaded day and finds "Nothing on this day," they stop trusting the heatmap for the rest of the term. This keeps the two signals ("something's due here" vs. "you're in the prep window for something else") visually distinct instead of conflated.

### CA-2 — The grid now renders the icons the legend promises
**What changed:** Due-item chips now show the flag glyph, and class-session markers now show the graduation-cap glyph, matching what the legend has always claimed. Both class-session and due-item data genuinely exist in the model, so both markers were added rather than removing either legend entry.
**Why:** A legend is a decoder key. Promising symbols the grid never actually shows is actively confusing rather than merely decorative.

### CA-3 — Mobile chips are distinguishable again
**What changed:** At mobile chip widths, a chip now leads with the item's short, uppercase TYPE (EXAM, PROJECT, READING, ...) instead of its title. Full titles remain visible at tablet/desktop widths and always in the day-detail panel.
**Why:** In a busy month, several similarly-titled items ("Final Exam," "Final Project," "Final Portfolio") all truncated to the same illegible "Fina..." on mobile, defeating the entire point of showing chips - at-a-glance recognition.

### CA-4 — A proactive "busiest stretch" callout, term-wide
**What changed:** A compact banner ("Heads up: your busiest stretch this term is [range] ([X]h)") now surfaces the single busiest upcoming 7-day window across the *entire* known dataset, shown regardless of which month is currently in view. Clicking it jumps to that stretch.
**Why:** This is exactly the foresight a workload-aware calendar should offer that a plain calendar structurally can't - but it was invisible unless a student manually paged through every future month. Now it's visible from the moment they open Calendar.

### CA-5 — The 2 visible chips are the important ones
**What changed:** A day's items (and WeekView's column preview) are sorted by priority/urgency - high priority first, then overdue, then soonest due - before slicing to the visible chips shown ahead of "+N more."
**Why:** On the busiest days, where at-a-glance triage matters most, chips previously showed whichever 2 items happened to be inserted first. Busy days now reliably surface the high-priority/urgent items instead of an arbitrary pair.

### VA-4 (Calendar portion) — Subhead now states the real differentiator
**What changed:** "Click a day to see what's due" → "See your workload build before it hits — not just what's due."
**Why:** The old caption was placeholder-grade utility copy, tonally flat against the app's punchier moments elsewhere. The new line references the actual differentiator (workload foresight via the heat-tint, now trustworthy per CA-1) instead of describing a feature any calendar app has.

---

## Screenshots

Before/after pairs for CA-1 through CA-5 (desktop 1000×900 for CA-1/2/4/5, mobile 375×812 for CA-3) were captured against a seeded harness (temporary, not part of this diff) comparing this branch against the unmodified base commit. All 5 pairs confirm the fix: empty days lose their full tint, grid chips show the promised icons, mobile "Final..." chips become distinguishable ("EXAM"/"PROJECT"/...), the busiest-stretch banner correctly reaches into a later month (Nov 13–19 in the test data) from the August view, and the Aug 25 cell's visible chips flip from two low-priority items to the high/medium-priority ones.

## Test plan
- [x] `npm run lint` - clean
- [x] `npx tsc --noEmit` - clean (only the 2 known pre-existing `workload.test.ts` `MapIterator` errors, unrelated to this change)
- [x] `npm run build` - succeeds with zero env vars
- [x] `npm test` - 215/215 passing across 25 test files
- [x] Manual before/after screenshot comparison for CA-1 through CA-5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_