### PR TITLE
Navigation: fix nested-route highlighting, global overflow guard, real search + notifications, custom term switcher (NV-1..4, NV-5 confirmed moot)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,10 +47,11 @@
        light-mode look. */
     --modal-shadow: var(--card-shadow);
 
-    /* Popover tier: reserved, unused. There's no custom dropdown/popover
-       component in this app yet (TermSwitcher etc. are native <select>
-       elements, which can't be styled with a custom box-shadow), so this
-       token intentionally has no consumer today. */
+    /* Popover tier: reserved, still unused. NV-4 replaced TermSwitcher's
+       native <select> with a custom dropdown, and the navbar's search/
+       notification panels follow the same pattern, but all of them reuse
+       the existing --card-shadow-backed `shadow-glass` utility rather than
+       a dedicated popover elevation, so this token still has no consumer. */
   }
 
   .dark {
@@ -100,7 +101,18 @@
 }
 
 @layer base {
+  /* NV-2 global safety net: the navbar is `position: fixed`, so it stays
+     put while any page's real horizontal overflow pans the body underneath
+     it - the classic "desktop site squeezed into a phone" tell. This is a
+     backstop, not a fix for the root cause on any individual page (those
+     are handled per-page elsewhere); it just guarantees the chrome itself
+     can never be undermined by a page that hasn't been fixed yet. */
+  html {
+    overflow-x: hidden;
+  }
+
   body {
+    overflow-x: hidden;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
     @apply font-sans;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,18 +1,295 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import type { Course, ScheduleItem } from '@/types/schedule';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
+
+/** NV-3: how far ahead of "now" a pending item counts as "due soon" in the
+ * notification bell's dropdown (as opposed to "overdue"). Purely a display
+ * bucket - doesn't affect the badge count, which mirrors the app's existing
+ * overdue definition (see DashboardView's `overdueCount`). */
+const DUE_SOON_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+
+function SearchIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-5.2-5.2m1.7-5.3a7 7 0 11-14 0 7 7 0 0114 0z"
+      />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+      />
+    </svg>
+  );
+}
+
+/** Shared "click anywhere outside" catcher for the search/bell popovers,
+ * matching the transparent full-screen backdrop pattern MobileTabBar's
+ * "More" popover already uses elsewhere in the app. */
+function PopoverBackdrop({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-[60] bg-transparent"
+      onClick={onClose}
+      aria-hidden="true"
+    />
+  );
+}
+
+function useSearchResults(query: string) {
+  const { state } = useAppState();
+  return useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return { courses: [] as Course[], tasks: [] as { item: ScheduleItem; course?: Course }[] };
+    const courseById = new Map(state.courses.map((c) => [c.id, c]));
+    const courses = state.courses
+      .filter((c) => c.title.toLowerCase().includes(q) || c.code.toLowerCase().includes(q))
+      .slice(0, 6);
+    const tasks = state.scheduleItems
+      .filter((item) => item.title.toLowerCase().includes(q))
+      .slice(0, 6)
+      .map((item) => ({ item, course: courseById.get(item.courseId) }));
+    return { courses, tasks };
+  }, [query, state.courses, state.scheduleItems]);
+}
+
+/** NV-3 (1/2): a lightweight, real search over the user's own courses and
+ * tasks - client-side substring match against AppState, no backend call.
+ * Not a command palette; just a working filtered list of clickable links. */
+function SearchPanel({ onClose }: { onClose: () => void }) {
+  const [query, setQuery] = useState('');
+  const { courses, tasks } = useSearchResults(query);
+  const hasResults = courses.length > 0 || tasks.length > 0;
+
+  return (
+    <>
+      <PopoverBackdrop onClose={onClose} />
+      <div
+        role="dialog"
+        aria-label="Search courses and tasks"
+        className="absolute right-0 top-full z-[61] mt-2 w-80 max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-glass border border-border/40 bg-card glass shadow-glass"
+      >
+        <div className="border-b border-border/40 p-3">
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search courses and tasks…"
+            aria-label="Search courses and tasks"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div className="max-h-80 overflow-y-auto py-1">
+          {query.trim() === '' ? (
+            <p className="px-4 py-3 text-sm text-muted-foreground">
+              Type to search your courses and tasks.
+            </p>
+          ) : !hasResults ? (
+            <p className="px-4 py-3 text-sm text-muted-foreground">No matches for &ldquo;{query}&rdquo;.</p>
+          ) : (
+            <>
+              {courses.length > 0 && (
+                <div>
+                  <p className="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Courses
+                  </p>
+                  {courses.map((course) => (
+                    <Link
+                      key={course.id}
+                      href={`/courses/${course.id}`}
+                      onClick={onClose}
+                      className="flex items-center gap-2 px-4 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      <span className="font-medium">{course.code}</span>
+                      <span className="truncate text-muted-foreground">{course.title}</span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+              {tasks.length > 0 && (
+                <div>
+                  <p className="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Tasks
+                  </p>
+                  {tasks.map(({ item, course }) => (
+                    <Link
+                      key={item.id}
+                      href={`/tasks/${item.id}`}
+                      onClick={onClose}
+                      className="flex items-center justify-between gap-2 px-4 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      <span className="truncate">{item.title}</span>
+                      {course && (
+                        <span className="shrink-0 text-xs text-muted-foreground">{course.code}</span>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function useOverdueAndDueSoon() {
+  const { state } = useAppState();
+  return useMemo(() => {
+    const now = Date.now();
+    const soonThreshold = now + DUE_SOON_WINDOW_MS;
+    const courseById = new Map(state.courses.map((c) => [c.id, c]));
+    const byDueDate = (a: ScheduleItem, b: ScheduleItem) =>
+      new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+
+    // Mirrors DashboardView's overdueCount: pending items whose due date has
+    // already passed. Kept in sync deliberately rather than imported, since
+    // this chrome component shouldn't reach into a page-level file.
+    const overdue = state.scheduleItems
+      .filter((item) => !item.completed && new Date(item.dueDate).getTime() < now)
+      .sort(byDueDate);
+    const dueSoon = state.scheduleItems
+      .filter((item) => {
+        if (item.completed) return false;
+        const due = new Date(item.dueDate).getTime();
+        return due >= now && due <= soonThreshold;
+      })
+      .sort(byDueDate);
+
+    const withCourse = (item: ScheduleItem) => ({ item, course: courseById.get(item.courseId) });
+    return {
+      overdueCount: overdue.length,
+      overdue: overdue.map(withCourse),
+      dueSoon: dueSoon.map(withCourse),
+    };
+  }, [state.scheduleItems, state.courses]);
+}
+
+/** NV-3 (2/2): notification bell reusing the app's existing overdue
+ * definition (badge count) and additionally surfacing due-soon items in the
+ * dropdown, each a real link to that task. */
+function NotificationBell({
+  open,
+  onToggle,
+  onClose,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+}) {
+  const { overdueCount, overdue, dueSoon } = useOverdueAndDueSoon();
+  const hasAny = overdue.length > 0 || dueSoon.length > 0;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={onToggle}
+        aria-label={overdueCount > 0 ? `Notifications, ${overdueCount} overdue` : 'Notifications'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="relative p-2 rounded-md hover:bg-accent text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+      >
+        <BellIcon />
+        {overdueCount > 0 && (
+          <span
+            className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground"
+            aria-hidden="true"
+          >
+            {overdueCount > 9 ? '9+' : overdueCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <>
+          <PopoverBackdrop onClose={onClose} />
+          <div
+            role="menu"
+            aria-label="Notifications"
+            className="absolute right-0 top-full z-[61] mt-2 w-80 max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-glass border border-border/40 bg-card glass shadow-glass"
+          >
+            <div className="max-h-80 overflow-y-auto py-1">
+              {!hasAny ? (
+                <p className="px-4 py-3 text-sm text-muted-foreground">Nothing overdue or due soon.</p>
+              ) : (
+                <>
+                  {overdue.length > 0 && (
+                    <div>
+                      <p className="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-destructive">
+                        Overdue
+                      </p>
+                      {overdue.map(({ item, course }) => (
+                        <Link
+                          key={item.id}
+                          href={`/tasks/${item.id}`}
+                          onClick={onClose}
+                          role="menuitem"
+                          className="flex items-center justify-between gap-2 px-4 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                        >
+                          <span className="truncate">{item.title}</span>
+                          {course && (
+                            <span className="shrink-0 text-xs text-muted-foreground">{course.code}</span>
+                          )}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                  {dueSoon.length > 0 && (
+                    <div>
+                      <p className="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Due soon
+                      </p>
+                      {dueSoon.map(({ item, course }) => (
+                        <Link
+                          key={item.id}
+                          href={`/tasks/${item.id}`}
+                          onClick={onClose}
+                          role="menuitem"
+                          className="flex items-center justify-between gap-2 px-4 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                        >
+                          <span className="truncate">{item.title}</span>
+                          {course && (
+                            <span className="shrink-0 text-xs text-muted-foreground">{course.code}</span>
+                          )}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
 
 export default function Navbar() {
   const { resolvedTheme, setTheme } = useTheme();
   const { user, signOut } = useAuth();
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
+  // NV-3: mutually exclusive so opening one popover closes the other.
+  const [openPanel, setOpenPanel] = useState<'search' | 'bell' | null>(null);
 
   const handleSignOut = async () => {
     const success = await signOut();
@@ -38,6 +315,27 @@ export default function Navbar() {
 
       <div className="flex items-center gap-2 sm:gap-4">
         {mounted && user && <TermSwitcher />}
+        {mounted && user && (
+          <div className="relative">
+            <button
+              onClick={() => setOpenPanel((p) => (p === 'search' ? null : 'search'))}
+              aria-label="Search courses and tasks"
+              aria-haspopup="dialog"
+              aria-expanded={openPanel === 'search'}
+              className="p-2 rounded-md hover:bg-accent text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+            >
+              <SearchIcon />
+            </button>
+            {openPanel === 'search' && <SearchPanel onClose={() => setOpenPanel(null)} />}
+          </div>
+        )}
+        {mounted && user && (
+          <NotificationBell
+            open={openPanel === 'bell'}
+            onToggle={() => setOpenPanel((p) => (p === 'bell' ? null : 'bell'))}
+            onClose={() => setOpenPanel(null)}
+          />
+        )}
         {mounted && user && (
           <Link
             href="/profile"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -131,7 +131,12 @@ export default function Sidebar() {
     <aside className="hidden md:flex fixed top-20 bottom-0 left-0 z-[45] w-64 flex-col border-r border-border/40 bg-card/90 glass">
       <nav className="flex-1 space-y-1 px-4 py-6">
         {navItems.map((item) => {
-          const isActive = pathname === item.href;
+          // NV-1: a plain exact match goes fully un-highlighted the moment
+          // a student drills one level deeper than a top-level route (e.g.
+          // /courses/[id] or /tasks/[id] never equals /courses or /tasks).
+          // A prefix match keeps the parent section highlighted for every
+          // nested route underneath it.
+          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (
             <Link
               key={item.href}

--- a/src/components/layout/TermSwitcher.tsx
+++ b/src/components/layout/TermSwitcher.tsx
@@ -1,16 +1,51 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { inferCurrentTerm, useAppState } from '@/context/AppStateContext';
+import { cn } from '@/lib/utils';
+
+/** NV-4 (b): season ordering within a year - Spring < Summer < Fall < Winter.
+ * Terms that don't parse (unrecognized format) sort after every parseable
+ * term, alphabetically among themselves, rather than throwing or silently
+ * keeping their arbitrary insertion order. */
+const SEASON_ORDER: Record<string, number> = { spring: 0, summer: 1, fall: 2, winter: 3 };
+
+function parseTermSortKey(term: string): number | null {
+  const match = term.match(/(spring|summer|fall|winter)\s+(\d{4})/i);
+  if (!match) return null;
+  const season = match[1].toLowerCase();
+  const year = Number(match[2]);
+  return year * 10 + SEASON_ORDER[season];
+}
+
+function sortTermsChronologically(terms: string[]): string[] {
+  return [...terms].sort((a, b) => {
+    const keyA = parseTermSortKey(a);
+    const keyB = parseTermSortKey(b);
+    if (keyA !== null && keyB !== null) return keyA - keyB;
+    if (keyA !== null) return -1;
+    if (keyB !== null) return 1;
+    return a.localeCompare(b);
+  });
+}
 
 /** #101 semester switcher. Hidden entirely when there's nothing to switch
  * between (zero or one distinct term across the user's courses) so it
- * doesn't clutter the navbar for the common case of a single-semester user. */
+ * doesn't clutter the navbar for the common case of a single-semester user.
+ *
+ * NV-4: rebuilt as a custom pill/glass dropdown (matching the rest of the
+ * app's chrome) instead of a bare native `<select>`, with a real 44px+ tap
+ * target, and with its options sorted chronologically by parsed year+season
+ * rather than left in insertion order. */
 export function TermSwitcher() {
   const { state, dispatch } = useAppState();
+  const [open, setOpen] = useState(false);
 
   const terms = useMemo(
-    () => Array.from(new Set(state.courses.map((c) => c.term).filter(Boolean))) as string[],
+    () =>
+      sortTermsChronologically(
+        Array.from(new Set(state.courses.map((c) => c.term).filter(Boolean))) as string[],
+      ),
     [state.courses],
   );
 
@@ -20,25 +55,81 @@ export function TermSwitcher() {
   // always matches what the rest of the app is actually scoped to, even
   // before the user has made an explicit choice.
   const displayValue = state.selectedTerm ?? inferCurrentTerm(state.courses) ?? 'all';
+  const displayLabel = displayValue === 'all' ? 'All Terms' : displayValue;
+
+  const select = (term: string) => {
+    dispatch({ type: 'SELECT_TERM', payload: term });
+    setOpen(false);
+  };
 
   return (
-    <select
-      value={displayValue}
-      onChange={(e) =>
-        dispatch({
-          type: 'SELECT_TERM',
-          payload: e.target.value === 'all' ? 'all' : e.target.value,
-        })
-      }
-      aria-label="Select term"
-      className="rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-    >
-      <option value="all">All Terms</option>
-      {terms.map((term) => (
-        <option key={term} value={term}>
-          {term}
-        </option>
-      ))}
-    </select>
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Select term"
+        className="flex h-11 min-w-[7rem] items-center justify-between gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <span className="truncate">{displayLabel}</span>
+        <svg
+          className={cn('h-4 w-4 shrink-0 text-muted-foreground transition-transform', open && 'rotate-180')}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-[60] bg-transparent"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div
+            role="listbox"
+            aria-label="Select term"
+            className="absolute left-0 top-full z-[61] mt-2 w-full min-w-[9rem] overflow-hidden rounded-glass border border-border/40 bg-card glass shadow-glass"
+          >
+            <button
+              type="button"
+              role="option"
+              aria-selected={displayValue === 'all'}
+              onClick={() => select('all')}
+              className={cn(
+                'flex w-full items-center px-4 py-3 text-left text-sm font-medium transition-colors',
+                displayValue === 'all'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+              )}
+            >
+              All Terms
+            </button>
+            {terms.map((term) => (
+              <button
+                key={term}
+                type="button"
+                role="option"
+                aria-selected={displayValue === term}
+                onClick={() => select(term)}
+                className={cn(
+                  'flex w-full items-center px-4 py-3 text-left text-sm font-medium transition-colors',
+                  displayValue === term
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+                )}
+              >
+                {term}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Scope

Navigation & app chrome slice of the UX-audit backlog. Files touched: `src/components/layout/Navbar.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/TermSwitcher.tsx`, `src/app/globals.css` (small addition).

---

### NV-1 — Active-page highlight breaks on every nested route

**What changed:** `Sidebar.tsx`'s active-link check now does `pathname === item.href || pathname.startsWith(item.href + '/')` instead of a plain exact match.

**Why:** The sidebar's whole job is "orient me" — a student one click into a course or task (`/courses/[id]`, `/tasks/[id]`) was losing the only visual cue for where they are, because those routes never equal their parent's `/courses` or `/tasks` href. The fix keeps the parent section highlighted for every route nested under it.

Verified on a real nested route (`/courses/course-csci213`): before, nothing in the sidebar is highlighted; after, "Courses" is correctly highlighted.

---

### NV-2 — Fixed navbar, page pans sideways underneath on mobile

**What changed:** added a global `overflow-x: hidden` backstop on both `html` and `body` in `globals.css`.

**Why:** the navbar is `position: fixed`, so any page with real horizontal overflow makes it look like the chrome itself is broken — the classic "desktop site squeezed into a phone" tell — even though the overflow originates on individual pages. This is a backstop, not a fix for any one page's root cause (those are separate per-page fixes landing elsewhere this round).

**Real Playwright measurement at 375px** (`document.documentElement.scrollWidth` vs `clientWidth`), against a harness page carrying a deliberately non-wrapping wide row (the real gated routes this finding names, `/profile`/`/calendar`, need a live Firebase project this sandbox doesn't have, so the harness reproduces the same class of overflow bug directly):

| | before | after |
|---|---|---|
| `document.documentElement.scrollWidth` | **1212px** | **375px** |
| `document.documentElement.clientWidth` | 375px | 375px |
| `window.innerWidth` | 375px | 375px |

Before: the document itself is 1212px wide against a 375px viewport — the page can pan sideways. After: the CSS guard clips `documentElement.scrollWidth` down to the viewport width, so the page can no longer pan horizontally, regardless of what's overflowing underneath. (`body.scrollWidth` itself still reports 1212 in both cases, as expected — `overflow-x: hidden` prevents *that element* from being the thing that scrolls/pans; it's `documentElement`, the actual scrolling box for the whole page, whose clamped `scrollWidth` proves the pan is gone.)

---

### NV-3 — No search, no notifications

**What changed:** added two real, functional affordances to `Navbar.tsx`:
1. **Search** — a search icon that opens a lightweight dropdown with a text input, client-side substring-filtering `AppState`'s courses (by title/code) and tasks (by title) as you type, each result a real link to `/courses/[id]` or `/tasks/[id]`.
2. **Notification bell** — a bell icon with a count badge mirroring the app's existing overdue definition (same logic as `DashboardView`'s `overdueCount`: pending items past their due date), opening a dropdown that lists overdue items plus items due in the next 3 days, each a real link to that task.

**Why:** for a student juggling many tasks across courses, jumping straight to something or getting proactively warned about overdue work are exactly the moments chrome should serve — and previously there was no way to do either from anywhere but the Courses list's own local search.

Both are wired to real `AppState`, not decorative: the search screenshot shows typing "data" filtering live to "CSCI 213 — Data Structures"; the bell screenshot shows real seeded overdue/due-soon items with a live badge count of 2.

---

### NV-4 — Term switcher looks and behaves like a leftover native `<select>`

**What changed:**
(a) `TermSwitcher.tsx` is now a custom `<button>` + absolutely-positioned dropdown using the app's existing `.glass`/`shadow-glass` styling, with a real 44px-tall tap target (was ~30px), instead of a bare native `<select>`.
(b) Term options are now sorted chronologically (parsed season + year, Spring < Summer < Fall < Winter within a year) instead of left in insertion/course order.

**Why:** it's the one control students use every new semester, and it was both the least-polished element in the header and liable to list terms in a visibly wrong order.

Verified with terms seeded deliberately out of chronological order: raw insertion order was `Fall 2026, Spring 2027, Spring 2026`; after the fix the dropdown lists `Spring 2026, Fall 2026, Spring 2027` — correctly chronological.

---

### NV-5 — Hamburger never signals the drawer is open

**STATUS: MOOT, confirmed.** Read the current `Navbar.tsx` in full before starting this slice — there is no hamburger button and no drawer anywhere in it. The mobile hamburger + drawer pattern this finding describes was entirely replaced by `MobileTabBar.tsx` in a prior PR (#153). No code changed for this finding; `MobileTabBar.tsx` was left untouched per this round's assignment.

---

## Verification

- `npm run lint` — clean, no warnings or errors
- `npx tsc --noEmit` — clean (only the 2 known pre-existing `workload.test.ts` `MapIterator` errors, unrelated to this change)
- `npm run build` — succeeds with zero env vars
- `npm test` — 25 test files / 215 tests pass, including the existing `Sidebar.test.tsx` (its 3 tests only assert exact-route matches, which still hold true under the new prefix match, so no test changes were needed)

## Screenshots

Built with a throwaway harness (`AuthContext` temporarily exported + a `src/app/preview-harness/*` route mounting the real chrome via `SidebarProvider` + `Navbar` + `Sidebar`, seeded `AppStateProvider`, and a Next.js-internal `PathnameContext` override to exercise a real nested route) against a second worktree at the base commit for "before" shots. Fully removed before this branch was committed — `git status` is clean except the 4 files listed above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_