### PR TITLE
Tasks: grade-weight badges, month sub-grouping, syllabus-context panel, quieter row actions, mobile overflow fix (TA-1..5, MO-1/2)

### DIFF
--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -13,16 +13,18 @@ import { courseSwatch } from '@/lib/courseColors';
 import { clampProgress } from '@/lib/taskStatus';
 import { cn } from '@/lib/utils';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
-import type { ScheduleItem, AssignmentType } from '@/types/schedule';
+import type { ScheduleItem, AssignmentType, Priority } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 
 type StatusFilter = 'all' | 'pending' | 'completed';
 /** What organizes the list into sections. 'date' buckets by due-date
- * proximity (Overdue/Today/This Week/Later), 'course' buckets by class,
- * 'status' buckets by Overdue/In Progress/Upcoming/Completed, 'flat' renders
- * one unsectioned list (today's original behavior). */
-type GroupBy = 'date' | 'course' | 'status' | 'flat';
+ * proximity (Overdue/Today/This Week/Later - the Later bucket is further
+ * split into month sub-headers, see monthSubGroups below), 'course' buckets
+ * by class, 'status' buckets by Overdue/In Progress/Upcoming/Completed,
+ * 'priority' buckets by High/Medium/Low, 'flat' renders one unsectioned
+ * list (today's original behavior). */
+type GroupBy = 'date' | 'course' | 'status' | 'priority' | 'flat';
 /** Ordering applied within each group (and across the whole list when
  * groupBy is 'flat'). Exposed as its own control mainly so a course group
  * can be re-ordered by status instead of just due date. */
@@ -41,6 +43,7 @@ const GROUP_BY_LABELS: Record<GroupBy, string> = {
   date: 'Due Date',
   course: 'Course',
   status: 'Status',
+  priority: 'Priority',
   flat: 'Flat',
 };
 
@@ -96,6 +99,56 @@ interface ItemGroup {
   courseColor?: string;
   dotClassName?: string;
   items: ScheduleItem[];
+  /** Month sub-headers nested inside this group (TA-2). Used only for the
+   * 'date' groupBy's Later bucket, which otherwise spans however many
+   * months of due dates exist as one undifferentiated wall - a due-next-
+   * week lab and a finals-week final would render as the exact same kind
+   * of row. When present, the UI renders these instead of `items` flat. */
+  monthSubGroups?: { key: string; label: string; items: ScheduleItem[] }[];
+}
+
+/** "September", or "September 2027" once the item's due date crosses into a
+ * different year than today - so a Later bucket spanning a year boundary
+ * (e.g. viewed in December) doesn't silently conflate next January with
+ * this one. */
+function monthSubGroupLabel(date: Date, today: Date): string {
+  const sameYear = date.getFullYear() === today.getFullYear();
+  const formatter = new Intl.DateTimeFormat(
+    'en-US',
+    sameYear ? { month: 'long' } : { month: 'long', year: 'numeric' },
+  );
+  return formatter.format(date);
+}
+
+/** Chunks an already-sorted list of items into per-calendar-month buckets,
+ * ordered chronologically by month regardless of the within-group sort
+ * (priority/status sorts may otherwise interleave items across months). */
+function groupByMonth(
+  items: ScheduleItem[],
+  today: Date,
+): { key: string; label: string; items: ScheduleItem[] }[] {
+  const byMonth = new Map<string, ScheduleItem[]>();
+  for (const item of items) {
+    const due = new Date(item.dueDate);
+    const monthKey = `${due.getFullYear()}-${due.getMonth()}`;
+    const list = byMonth.get(monthKey);
+    if (list) list.push(item);
+    else byMonth.set(monthKey, [item]);
+  }
+  return Array.from(byMonth.entries())
+    .sort(([a], [b]) => {
+      const [aYear, aMonth] = a.split('-').map(Number);
+      const [bYear, bMonth] = b.split('-').map(Number);
+      return aYear !== bYear ? aYear - bYear : aMonth - bMonth;
+    })
+    .map(([monthKey, monthItems]) => {
+      const [year, month] = monthKey.split('-').map(Number);
+      return {
+        key: monthKey,
+        label: monthSubGroupLabel(new Date(year, month, 1), today),
+        items: monthItems,
+      };
+    });
 }
 
 export function PlannerView() {
@@ -160,6 +213,26 @@ export function PlannerView() {
           };
         })
         .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+    }
+
+    if (groupBy === 'priority') {
+      const buckets: Record<Priority, ScheduleItem[]> = { high: [], medium: [], low: [] };
+      for (const item of filteredItems) {
+        buckets[item.priority ?? 'medium'].push(item);
+      }
+      const order: { key: Priority; label: string; dot: string }[] = [
+        { key: 'high', label: 'High Priority', dot: 'bg-destructive' },
+        { key: 'medium', label: 'Medium Priority', dot: 'bg-load-medium' },
+        { key: 'low', label: 'Low Priority', dot: 'bg-load-low' },
+      ];
+      return order
+        .filter((g) => buckets[g.key].length > 0)
+        .map((g) => ({
+          key: g.key,
+          label: g.label,
+          dotClassName: g.dot,
+          items: sortedWithin(buckets[g.key]),
+        }));
     }
 
     if (groupBy === 'status') {
@@ -227,12 +300,19 @@ export function PlannerView() {
     ];
     return order
       .filter((g) => buckets[g.key].length > 0)
-      .map((g) => ({
-        key: g.key,
-        label: g.label,
-        dotClassName: g.dot,
-        items: sortedWithin(buckets[g.key]),
-      }));
+      .map((g) => {
+        const items = sortedWithin(buckets[g.key]);
+        return {
+          key: g.key,
+          label: g.label,
+          dotClassName: g.dot,
+          items,
+          // Later otherwise renders as one flat wall spanning however many
+          // months out the syllabus goes - split it into month sub-headers
+          // so it reads as a calendar-scale structure (TA-2).
+          monthSubGroups: g.key === 'later' && items.length > 0 ? groupByMonth(items, today) : undefined,
+        };
+      });
   }, [filteredItems, groupBy, withinSort, today, courses]);
 
   const handleToggleComplete = async (item: ScheduleItem) => {
@@ -268,6 +348,91 @@ export function PlannerView() {
 
   const selectClass =
     'rounded-lg border border-border bg-background px-3 py-1.5 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+  // Factored out of the group-rendering loop so the same row (with its
+  // trailing Overdue/Due/Edit/Delete controls) can be rendered both for a
+  // group's flat item list and for each of a group's month sub-groups
+  // (TA-2's Later-bucket split).
+  const renderTaskRow = (item: ScheduleItem) => {
+    const course = courses.find((c) => c.id === item.courseId);
+    const overdue = isOverdue(item, today);
+    const isConfirmingThisDelete = confirmingDeleteId === item.id;
+    return (
+      <TaskRow
+        key={item.id}
+        variant={state.preferences.taskRowVariant}
+        title={item.title}
+        href={'/tasks/' + item.id}
+        type={item.type}
+        courseCode={course ? course.code : 'General'}
+        courseColor={course?.color}
+        courseIcon={course?.icon}
+        completed={item.completed}
+        progress={item.progress}
+        priority={item.priority}
+        gradeWeight={item.gradeWeight}
+        onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
+        trailing={
+          <>
+            {overdue && (
+              <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                Overdue
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground">
+              Due {dueDateFormatter.format(new Date(item.dueDate))}
+            </span>
+            {/* Edit/Delete: de-emphasized (not full-strength) for a completed
+             * task so finished work doesn't compete visually with
+             * active/urgent rows - see TA-5. Full opacity while a delete
+             * confirmation on THIS row is in flight, so that flow never
+             * gets harder to see/tap mid-confirm. */}
+            <span
+              className={cn(
+                'flex items-center gap-2',
+                item.completed &&
+                  !isConfirmingThisDelete &&
+                  'opacity-50 transition-opacity hover:opacity-100 focus-within:opacity-100',
+              )}
+            >
+              <button
+                onClick={() => setEditingItem(item)}
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+              >
+                Edit
+              </button>
+              {isConfirmingThisDelete ? (
+                <div className="flex items-center gap-2 text-xs">
+                  <button
+                    onClick={() => handleDeleteTask(item)}
+                    className="font-semibold text-foreground hover:underline"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setConfirmingDeleteId(null)}
+                    className="text-muted-foreground hover:underline"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                // Neutral/muted, not red - red is reserved for Overdue/
+                // urgency badges (TA-5), so this common, low-stakes action
+                // doesn't compete with the one badge that should stand out.
+                <button
+                  onClick={() => setConfirmingDeleteId(item.id)}
+                  className="text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                >
+                  Delete
+                </button>
+              )}
+            </span>
+          </>
+        }
+      />
+    );
+  };
 
   return (
     <>
@@ -414,69 +579,20 @@ export function PlannerView() {
                         </span>
                       </div>
                     )}
-                    <div className="flex flex-col gap-2">
-                      {group.items.map((item) => {
-                        const course = courses.find((c) => c.id === item.courseId);
-                        const overdue = isOverdue(item, today);
-                        return (
-                          <TaskRow
-                            key={item.id}
-                            variant={state.preferences.taskRowVariant}
-                            title={item.title}
-                            href={'/tasks/' + item.id}
-                            type={item.type}
-                            courseCode={course ? course.code : 'General'}
-                            courseColor={course?.color}
-                            courseIcon={course?.icon}
-                            completed={item.completed}
-                            progress={item.progress}
-                            priority={item.priority}
-                            onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
-                            trailing={
-                              <>
-                                {overdue && (
-                                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
-                                    Overdue
-                                  </span>
-                                )}
-                                <span className="text-xs text-muted-foreground">
-                                  Due {dueDateFormatter.format(new Date(item.dueDate))}
-                                </span>
-                                <button
-                                  onClick={() => setEditingItem(item)}
-                                  className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
-                                >
-                                  Edit
-                                </button>
-                                {confirmingDeleteId === item.id ? (
-                                  <div className="flex items-center gap-2 text-xs">
-                                    <button
-                                      onClick={() => handleDeleteTask(item)}
-                                      className="font-semibold text-destructive hover:underline"
-                                    >
-                                      Confirm
-                                    </button>
-                                    <button
-                                      onClick={() => setConfirmingDeleteId(null)}
-                                      className="text-muted-foreground hover:underline"
-                                    >
-                                      Cancel
-                                    </button>
-                                  </div>
-                                ) : (
-                                  <button
-                                    onClick={() => setConfirmingDeleteId(item.id)}
-                                    className="text-xs font-semibold text-destructive hover:underline"
-                                  >
-                                    Delete
-                                  </button>
-                                )}
-                              </>
-                            }
-                          />
-                        );
-                      })}
-                    </div>
+                    {group.monthSubGroups ? (
+                      <div className="space-y-4">
+                        {group.monthSubGroups.map((sub) => (
+                          <div key={sub.key}>
+                            <h4 className="mb-1.5 px-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                              {sub.label}
+                            </h4>
+                            <div className="flex flex-col gap-2">{sub.items.map(renderTaskRow)}</div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="flex flex-col gap-2">{group.items.map(renderTaskRow)}</div>
+                    )}
                   </div>
                 );
               })}

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -14,8 +14,109 @@ import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
 import { clampProgress, TASK_STATUS_LABEL } from '@/lib/taskStatus';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
-import type { AssignmentType } from '@/types/schedule';
+import type { AssignmentType, Course, ScheduleItem } from '@/types/schedule';
 import { cn } from '@/lib/utils';
+
+const shortDueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+
+/** Plain-English sentence comparing `item`'s grade weight to the rest of
+ * its course, so "worth 25%" comes with a sense of scale instead of a bare
+ * number. Only ever called once item.gradeWeight is known to be set. */
+function describeGradeImpact(item: ScheduleItem, courseItems: ScheduleItem[], courseLabel: string): string {
+  const weightedOthers = courseItems.filter((i) => i.id !== item.id && i.gradeWeight != null);
+  if (weightedOthers.length === 0) {
+    return `Worth ${item.gradeWeight}% of your grade in ${courseLabel} - no other item's weight is on record yet, so there's nothing to compare it to.`;
+  }
+  const maxOtherWeight = Math.max(...weightedOthers.map((i) => i.gradeWeight ?? 0));
+  if ((item.gradeWeight ?? 0) >= maxOtherWeight) {
+    return `This is your highest-weighted item in ${courseLabel}.`;
+  }
+  const higherCount = weightedOthers.filter((i) => (i.gradeWeight ?? 0) > (item.gradeWeight ?? 0)).length;
+  return `${higherCount} other item${higherCount === 1 ? '' : 's'} in ${courseLabel} ${
+    higherCount === 1 ? 'is' : 'are'
+  } weighted higher than this.`;
+}
+
+/** Grade-impact module (TA-3): fills the mostly-empty detail card with
+ * something real for weighted items - what this task is worth, and how
+ * that compares to the rest of the course - instead of leaving "From
+ * syllabus" as a promise the page never pays off. Renders nothing for a
+ * task with no gradeWeight on record. */
+function GradeImpactPanel({
+  item,
+  course,
+  courseItems,
+}: {
+  item: ScheduleItem;
+  course: Course | undefined;
+  courseItems: ScheduleItem[];
+}) {
+  if (item.gradeWeight === undefined) return null;
+
+  const courseLabel = course ? course.code : 'this course';
+  const others = courseItems.filter((i) => i.id !== item.id);
+  const maxWeight = Math.max(item.gradeWeight, ...others.map((i) => i.gradeWeight ?? 0));
+
+  // A short list of other still-open work in the course - "natural
+  // additional module" the audit called out as a nice-to-have once the
+  // required grade-impact comparison is in place.
+  const relatedUpcoming = others
+    .filter((i) => !i.completed)
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
+    .slice(0, 3);
+
+  return (
+    <div className="p-6">
+      <div className="rounded-xl border border-primary/20 bg-primary/5 p-4">
+        <div className="flex items-center gap-4">
+          <div className="shrink-0">
+            <p className="text-xs font-medium text-muted-foreground">Grade impact</p>
+            <p className="mt-1 text-3xl font-bold leading-none text-primary">{item.gradeWeight}%</p>
+            <p className="mt-1 text-xs text-muted-foreground">of your grade in {courseLabel}</p>
+          </div>
+          {/* A quick visual sense of scale next to the other items in this
+           * course - not just a number in isolation. */}
+          <div className="h-10 w-px shrink-0 bg-border" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-card">
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${Math.max(4, (item.gradeWeight / maxWeight) * 100)}%` }}
+              />
+            </div>
+            <p className="mt-2 text-sm text-foreground">
+              {describeGradeImpact(item, courseItems, courseLabel)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {relatedUpcoming.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">
+            Related work in {courseLabel}
+          </p>
+          <ul className="space-y-1.5">
+            {relatedUpcoming.map((related) => (
+              <li key={related.id} className="flex items-center justify-between gap-3 text-sm">
+                <Link
+                  href={`/tasks/${related.id}`}
+                  className="min-w-0 truncate text-foreground hover:text-primary hover:underline"
+                >
+                  {related.title}
+                </Link>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {shortDueDateFormatter.format(new Date(related.dueDate))}
+                  {related.gradeWeight != null ? ` · ${related.gradeWeight}%` : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
 
 /** 5-point steps rather than 1% - self-reported task progress is never
  * that precise, and 1% increments would turn a drag into 100 discrete
@@ -101,6 +202,7 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
   }
 
   const overdue = !item.completed && new Date(item.dueDate) < new Date();
+  const courseItems = state.scheduleItems.filter((i) => i.courseId === item.courseId);
 
   const handleToggleComplete = async () => {
     if (!user) return;
@@ -465,6 +567,8 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
               </div>
             </div>
           </div>
+
+          <GradeImpactPanel item={item} course={course} courseItems={courseItems} />
 
           {item.notes && (
             <div className="p-6">

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -18,6 +18,27 @@ const TYPE_LABEL: Record<AssignmentType, string> = {
   other: 'Other',
 };
 
+/** Minimum gradeWeight (%) for the weight pill to show at all (TA-1). Below
+ * this, an item is treated as trivial/ungraded-in-effect and the pill would
+ * just be noise next to every row; at/above it, the item is worth calling
+ * out at a glance since it meaningfully moves the course grade. */
+export const GRADE_WEIGHT_BADGE_THRESHOLD = 15;
+
+/** Small "worth N%" pill shown next to a row's title, but only once a task
+ * is weighted heavily enough to matter (see GRADE_WEIGHT_BADGE_THRESHOLD) -
+ * a 2% reading-check shouldn't visually compete with a 25% midterm. */
+function GradeWeightPill({ gradeWeight }: { gradeWeight: number | undefined }) {
+  if (gradeWeight === undefined || gradeWeight < GRADE_WEIGHT_BADGE_THRESHOLD) return null;
+  return (
+    <span
+      className="shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold leading-none text-primary"
+      title={`Worth ${gradeWeight}% of your grade`}
+    >
+      {gradeWeight}%
+    </span>
+  );
+}
+
 type CheckAnimState = 'idle' | 'checked' | 'unchecked';
 
 /** Time to hold the 'checked' animation state open: long enough for the
@@ -67,6 +88,13 @@ export interface TaskRowProps {
    * in-progress indicator. See lib/taskStatus.ts. */
   progress?: number;
   priority?: Priority;
+  /** Weight of this item toward the course's final grade, as a percentage
+   * (ScheduleItem.gradeWeight). Optional/additive - omit at call-sites that
+   * don't have it and nothing changes. Renders a small "N%" pill next to
+   * the title, but only once it clears GRADE_WEIGHT_BADGE_THRESHOLD, so
+   * this stays a signal for genuinely high-stakes work (an exam, a big
+   * project) rather than noise on every graded item. */
+  gradeWeight?: number;
   onToggleComplete?: () => void;
   /** Right-aligned custom content: due labels, badges, edit/delete links. */
   trailing?: ReactNode;
@@ -95,6 +123,7 @@ export function TaskRow({
   trailing,
   href,
   variant = 'card',
+  gradeWeight,
 }: TaskRowProps) {
   if (variant === 'touch') {
     return (
@@ -106,9 +135,11 @@ export function TaskRow({
         courseIcon={courseIcon}
         completed={completed}
         progress={progress}
+        priority={priority}
         onToggleComplete={onToggleComplete}
         trailing={trailing}
         href={href}
+        gradeWeight={gradeWeight}
       />
     );
   }
@@ -126,6 +157,7 @@ export function TaskRow({
       onToggleComplete={onToggleComplete}
       trailing={trailing}
       href={href}
+      gradeWeight={gradeWeight}
     />
   );
 }
@@ -185,6 +217,7 @@ function CardRow({
   onToggleComplete,
   trailing,
   href,
+  gradeWeight,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed' | 'priority'>> &
   Pick<
     TaskRowProps,
@@ -195,119 +228,138 @@ function CardRow({
     | 'onToggleComplete'
     | 'trailing'
     | 'href'
+    | 'gradeWeight'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
   const checkAnim = useCheckAnimState(completed);
+  // flex-wrap (not a single unbreakable line): once the checkbox+icon+title
+  // group and the trailing Overdue/Due/Edit/Delete group can't both fit on
+  // one line at a narrow width, trailing wraps entirely onto its own line
+  // below rather than the two groups fighting for the same line and either
+  // overflowing (pre-fix) or overlapping (MO-1).
   const rowClass = cn(
-    'flex items-start gap-3 rounded-xl border border-border/60 p-3',
+    'flex flex-wrap items-start gap-x-3 gap-y-2 rounded-xl border border-border/60 p-3',
     href && 'transition-colors hover:border-border',
     checkAnim === 'checked' && 'animate-task-row-glow',
   );
 
   const content = (
     <>
-      {onToggleComplete && (
-        <label
-          className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <input
-            type="checkbox"
-            checked={completed}
-            onChange={onToggleComplete}
-            className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
-            aria-label={`Mark ${title} complete`}
-          />
-          {checkAnim === 'checked' && (
-            <>
-              <span
-                aria-hidden="true"
-                className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
-              />
-              <span
-                aria-hidden="true"
-                className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
-              />
-            </>
-          )}
-          <span
-            className={cn(
-              'flex h-4 w-4 items-center justify-center rounded border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
-              completed && 'border-primary bg-primary',
-              checkAnim === 'checked' && 'animate-task-check-pop',
-            )}
+      {/* checkbox + course icon + title/meta as a single flex item (not
+       * three separate ones) so the outer row's flex-wrap always keeps them
+       * together and only ever wraps `trailing` away as a whole unit. */}
+      <div className="flex min-w-0 flex-auto items-start gap-3">
+        {onToggleComplete && (
+          <label
+            className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
           >
-            {(completed || checkAnim === 'unchecked') && (
+            <input
+              type="checkbox"
+              checked={completed}
+              onChange={onToggleComplete}
+              className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              aria-label={`Mark ${title} complete`}
+            />
+            {checkAnim === 'checked' && (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+                />
+                <span
+                  aria-hidden="true"
+                  className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-4 w-4 rounded-full border border-primary"
+                />
+              </>
+            )}
+            <span
+              className={cn(
+                'flex h-4 w-4 items-center justify-center rounded border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
+                completed && 'border-primary bg-primary',
+                checkAnim === 'checked' && 'animate-task-check-pop',
+              )}
+            >
+              {(completed || checkAnim === 'unchecked') && (
+                <svg
+                  className={cn(
+                    'h-2.5 w-2.5 stroke-primary-foreground',
+                    checkAnim === 'checked' && 'animate-task-check-mark-in',
+                    checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                  )}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={4}
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </span>
+          </label>
+        )}
+        <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={7} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            {priority === 'high' && !completed && (
               <svg
-                className={cn(
-                  'h-2.5 w-2.5 stroke-primary-foreground',
-                  checkAnim === 'checked' && 'animate-task-check-mark-in',
-                  checkAnim === 'unchecked' && 'animate-task-check-mark-out',
-                )}
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={4}
-                aria-hidden="true"
+                className="h-3.5 w-3.5 shrink-0"
+                viewBox="0 0 16 16"
+                role="img"
+                aria-label="High priority"
               >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                <title>High priority</title>
+                <path d="M8 1.5l7 12.5H1z" fill="hsl(0 84% 60%)" />
+                <rect x="7.25" y="6" width="1.5" height="4" rx="0.75" fill="white" />
+                <circle cx="8" cy="11.5" r="0.9" fill="white" />
               </svg>
             )}
-          </span>
-        </label>
-      )}
-      <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={7} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          {priority === 'high' && !completed && (
-            <svg
-              className="h-3.5 w-3.5 shrink-0"
-              viewBox="0 0 16 16"
-              role="img"
-              aria-label="High priority"
-            >
-              <title>High priority</title>
-              <path d="M8 1.5l7 12.5H1z" fill="hsl(0 84% 60%)" />
-              <rect x="7.25" y="6" width="1.5" height="4" rx="0.75" fill="white" />
-              <circle cx="8" cy="11.5" r="0.9" fill="white" />
-            </svg>
-          )}
-          {priority === 'medium' && !completed && (
-            <svg
-              className="h-3.5 w-3.5 shrink-0"
-              viewBox="0 0 16 16"
-              role="img"
-              aria-label="Medium priority"
-            >
-              <title>Medium priority</title>
-              <path d="M8 1.5l7 12.5H1z" fill="hsl(38 92% 50%)" />
-            </svg>
-          )}
-          {priority === 'low' && !completed && (
-            <svg
-              className="h-3 w-3 shrink-0"
-              viewBox="0 0 16 16"
-              role="img"
-              aria-label="Low priority"
-            >
-              <title>Low priority</title>
-              <circle cx="8" cy="8" r="6.5" fill="hsl(142 71% 40%)" />
-            </svg>
-          )}
-          <div
-            className={cn(
-              'text-sm font-medium truncate',
-              completed ? 'text-muted-foreground line-through' : 'text-foreground',
+            {priority === 'medium' && !completed && (
+              <svg
+                className="h-3.5 w-3.5 shrink-0"
+                viewBox="0 0 16 16"
+                role="img"
+                aria-label="Medium priority"
+              >
+                <title>Medium priority</title>
+                <path d="M8 1.5l7 12.5H1z" fill="hsl(38 92% 50%)" />
+              </svg>
             )}
-          >
-            {title}
+            {priority === 'low' && !completed && (
+              <svg
+                className="h-3 w-3 shrink-0"
+                viewBox="0 0 16 16"
+                role="img"
+                aria-label="Low priority"
+              >
+                <title>Low priority</title>
+                <circle cx="8" cy="8" r="6.5" fill="hsl(142 71% 40%)" />
+              </svg>
+            )}
+            <div
+              className={cn(
+                'text-sm font-medium truncate',
+                completed ? 'text-muted-foreground line-through' : 'text-foreground',
+              )}
+            >
+              {title}
+            </div>
+            {!completed && <GradeWeightPill gradeWeight={gradeWeight} />}
           </div>
+          <div className="mt-1 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+          {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
         </div>
-        <div className="mt-1 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
-        {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
       </div>
       {trailing && (
-        <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
+        // A sibling of the checkbox/icon/title group above (not nested
+        // inside it) so the outer row's flex-wrap can drop this whole block
+        // onto its own line at a narrow width (MO-1), instead of it either
+        // overflowing (shrink-0) or fighting the title for the same line.
+        <div
+          className="flex min-w-0 flex-wrap items-center justify-end gap-x-2 gap-y-1"
+          onClick={(e) => e.stopPropagation()}
+        >
           {trailing}
         </div>
       )}
@@ -331,6 +383,45 @@ function CardRow({
   );
 }
 
+/** Same three priority glyphs as CardRow (see there for the color
+ * rationale) - kept in sync so 'touch' rows carry the same at-a-glance
+ * priority signal as 'card' rows instead of dropping it entirely (TA-4). */
+function PriorityGlyph({
+  priority,
+  completed,
+  className,
+}: {
+  priority: Priority | undefined;
+  completed: boolean;
+  className: string;
+}) {
+  if (completed || !priority) return null;
+  if (priority === 'high') {
+    return (
+      <svg className={className} viewBox="0 0 16 16" role="img" aria-label="High priority">
+        <title>High priority</title>
+        <path d="M8 1.5l7 12.5H1z" fill="hsl(0 84% 60%)" />
+        <rect x="7.25" y="6" width="1.5" height="4" rx="0.75" fill="white" />
+        <circle cx="8" cy="11.5" r="0.9" fill="white" />
+      </svg>
+    );
+  }
+  if (priority === 'medium') {
+    return (
+      <svg className={className} viewBox="0 0 16 16" role="img" aria-label="Medium priority">
+        <title>Medium priority</title>
+        <path d="M8 1.5l7 12.5H1z" fill="hsl(38 92% 50%)" />
+      </svg>
+    );
+  }
+  return (
+    <svg className={className} viewBox="0 0 16 16" role="img" aria-label="Low priority">
+      <title>Low priority</title>
+      <circle cx="8" cy="8" r="6.5" fill="hsl(142 71% 40%)" />
+    </svg>
+  );
+}
+
 function TouchRow({
   title,
   type,
@@ -339,9 +430,11 @@ function TouchRow({
   courseIcon,
   completed,
   progress,
+  priority,
   onToggleComplete,
   trailing,
   href,
+  gradeWeight,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed'>> &
   Pick<
     TaskRowProps,
@@ -349,9 +442,11 @@ function TouchRow({
     | 'courseColor'
     | 'courseIcon'
     | 'progress'
+    | 'priority'
     | 'onToggleComplete'
     | 'trailing'
     | 'href'
+    | 'gradeWeight'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
@@ -366,71 +461,87 @@ function TouchRow({
   const content = (
     <>
       <div className={cn('h-1 w-full', swatch.className)} style={swatch.style} />
-      <div className="flex items-center gap-3 px-3.5 py-3">
-        {onToggleComplete && (
-          <label
-            className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <input
-              type="checkbox"
-              checked={completed}
-              onChange={onToggleComplete}
-              className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
-              aria-label={`Mark ${title} complete`}
-            />
-            {checkAnim === 'checked' && (
-              <>
-                <span
-                  aria-hidden="true"
-                  className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
-                />
-                <span
-                  aria-hidden="true"
-                  className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
-                />
-              </>
-            )}
-            <span
-              className={cn(
-                'flex h-6 w-6 items-center justify-center rounded-full border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
-                completed && 'border-primary bg-primary',
-                checkAnim === 'checked' && 'animate-task-check-pop',
-              )}
+      {/* flex-wrap, and checkbox+icon+title grouped into one flex item: see
+       * CardRow above for why (MO-1) - trailing wraps to its own line as a
+       * whole unit at a narrow width instead of overflowing or overlapping. */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-3.5 py-3">
+        <div className="flex min-w-0 flex-auto items-center gap-3">
+          {onToggleComplete && (
+            <label
+              className="relative flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center"
+              onClick={(e) => e.stopPropagation()}
             >
-              {(completed || checkAnim === 'unchecked') && (
-                <svg
-                  className={cn(
-                    'h-3.5 w-3.5 stroke-primary-foreground',
-                    checkAnim === 'checked' && 'animate-task-check-mark-in',
-                    checkAnim === 'unchecked' && 'animate-task-check-mark-out',
-                  )}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={3}
-                  aria-hidden="true"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
+              <input
+                type="checkbox"
+                checked={completed}
+                onChange={onToggleComplete}
+                className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                aria-label={`Mark ${title} complete`}
+              />
+              {checkAnim === 'checked' && (
+                <>
+                  <span
+                    aria-hidden="true"
+                    className="animate-task-check-ripple pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="animate-task-check-ripple-delayed pointer-events-none absolute inset-0 m-auto h-6 w-6 rounded-full border border-primary"
+                  />
+                </>
               )}
-            </span>
-          </label>
-        )}
-        <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={6} />
-        <div className="min-w-0 flex-1">
-          <div
-            className={cn(
-              'text-sm font-semibold truncate',
-              completed ? 'text-muted-foreground line-through' : 'text-foreground',
-            )}
-          >
-            {title}
+              <span
+                className={cn(
+                  'flex h-6 w-6 items-center justify-center rounded-full border-2 border-border bg-card transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card',
+                  completed && 'border-primary bg-primary',
+                  checkAnim === 'checked' && 'animate-task-check-pop',
+                )}
+              >
+                {(completed || checkAnim === 'unchecked') && (
+                  <svg
+                    className={cn(
+                      'h-3.5 w-3.5 stroke-primary-foreground',
+                      checkAnim === 'checked' && 'animate-task-check-mark-in',
+                      checkAnim === 'unchecked' && 'animate-task-check-mark-out',
+                    )}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={3}
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </span>
+            </label>
+          )}
+          <CourseIconBadge courseColor={courseColor} courseIcon={courseIcon} size={6} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <PriorityGlyph
+                priority={priority}
+                completed={completed}
+                className="h-3.5 w-3.5 shrink-0"
+              />
+              <div
+                className={cn(
+                  'text-sm font-semibold truncate',
+                  completed ? 'text-muted-foreground line-through' : 'text-foreground',
+                )}
+              >
+                {title}
+              </div>
+              {!completed && <GradeWeightPill gradeWeight={gradeWeight} />}
+            </div>
+            <div className="mt-0.5 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
+            {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
           </div>
-          <div className="mt-0.5 text-xs text-muted-foreground">{metaLine(courseCode, type)}</div>
-          {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
         </div>
         {trailing && (
-          <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="flex min-w-0 flex-wrap items-center justify-end gap-x-2 gap-y-1"
+            onClick={(e) => e.stopPropagation()}
+          >
             {trailing}
           </div>
         )}

--- a/src/lib/__tests__/TaskRow.test.tsx
+++ b/src/lib/__tests__/TaskRow.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { TaskRow } from '@/components/ui/TaskRow';
+import { TaskRow, GRADE_WEIGHT_BADGE_THRESHOLD } from '@/components/ui/TaskRow';
 
 describe('TaskRow', () => {
   it('renders the title and a course code + type meta line', () => {
@@ -63,5 +63,32 @@ describe('TaskRow', () => {
     const { container } = render(<TaskRow title="Icon set" courseIcon="calculator" />);
     // The 'calculator' glyph is built from a <rect> plus dot <circle>s.
     expect(container.querySelector('svg rect')).not.toBeNull();
+  });
+
+  describe('grade weight pill (TA-1)', () => {
+    it('shows the pill at/above the threshold', () => {
+      render(<TaskRow title="Midterm" gradeWeight={GRADE_WEIGHT_BADGE_THRESHOLD} />);
+      expect(screen.getByText(`${GRADE_WEIGHT_BADGE_THRESHOLD}%`)).toBeDefined();
+    });
+
+    it('hides the pill below the threshold - trivial/ungraded items stay quiet', () => {
+      render(<TaskRow title="Reading check" gradeWeight={GRADE_WEIGHT_BADGE_THRESHOLD - 1} />);
+      expect(screen.queryByText(`${GRADE_WEIGHT_BADGE_THRESHOLD - 1}%`)).toBeNull();
+    });
+
+    it('renders nothing when gradeWeight is not provided (optional/additive)', () => {
+      const { container } = render(<TaskRow title="No weight" />);
+      expect(container.querySelector('[title^="Worth "]')).toBeNull();
+    });
+
+    it('hides the pill on completed tasks even if heavily weighted', () => {
+      render(<TaskRow title="Done exam" gradeWeight={30} completed />);
+      expect(screen.queryByText('30%')).toBeNull();
+    });
+
+    it('also renders for the touch variant', () => {
+      render(<TaskRow title="Touch weight" gradeWeight={25} variant="touch" />);
+      expect(screen.getByText('25%')).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
## Scope
This PR covers the **Tasks (list + detail)** slice of the UX-audit backlog: `PlannerView.tsx` (the Tasks list page), `TaskDetailView.tsx`, and `TaskRow.tsx`. No other files were touched, aside from adding tests to the existing `TaskRow.test.tsx` per the verification checklist.

---

## TA-1 — Grade weight is invisible where students actually scan tasks

**What changed:** `TaskRow` gains an optional `gradeWeight` prop. When a task's weight is ≥15% of the course grade, a small "N%" pill now renders next to the title. Below that threshold (participation, small homeworks, etc.) nothing renders — the list stays quiet for low-stakes work. Wired through in `PlannerView` from `ScheduleItem.gradeWeight`, which already existed in the data model.

**Why:** Grade-weighted parsing from the syllabus is the product's core differentiator over a plain task list. Before this change, a 25%-of-grade midterm and a 2%-of-grade recitation looked pixel-identical in the list — the one signal that should make this app feel smarter than a generic to-do list was a click away, buried on the detail page.

**Design choice:** The prop is optional and additive, so the handful of other `TaskRow` call-sites elsewhere in the app (dashboard, calendar, course detail, smart planner) that don't pass `gradeWeight` are completely unaffected.

---

## TA-2 — "Later" is one flat, months-long wall of identical rows

**What changed:** The "Later" bucket in the default due-date grouping is now sub-chunked into month headers (September, October, November, December, …) instead of rendering every task 7+ days out as one undifferentiated list.

**Why:** A lab due next week and a final due in December were rendering as the exact same kind of row, with no sense of calendar scale. For a student planning a semester, "everything past next week" collapsing into one wall defeats the purpose of a due-date view. Month sub-headers make a long list actually readable as a calendar.

---

## TA-3 — Task detail is mostly empty white space with no syllabus context

**What changed:** Added a grade-impact module to the task detail page for any weighted item: the item's weight, a small visual bar comparing it to the course's other graded items, and a plain-English line ("This is your highest-weighted item in MATH 201" / "1 other item in MATH 201 is weighted higher than this"). Also added a "Related work in this course" list showing up to 3 other open items in the same course with their due dates and weights.

**Why:** The detail page previously ended well before the bottom of a typical viewport, with only a "From syllabus" badge to justify the AI-parsing promise — the page never actually used the syllabus data it had. This module fills that space with something genuinely useful (how much this item actually matters, and what else is coming up in the same course) instead of decoration.

---

## TA-4 — Priority is nearly invisible — a hover-only dot

**What changed / confirmed:**
- Verified on the Tasks list specifically: the priority glyph (colored triangle for high/medium, circle for low) already renders visibly without hovering in the default card row — this was genuinely fixed by the earlier PR (#155/#157). Screenshot attached below as confirmation.
- **Gap found and fixed:** the `touch` row variant had *no* priority indicator at all. Added the same glyph there for parity, since some contexts (e.g. a mobile calendar day view) use that variant.
- **Group-by-Priority:** this did not previously exist as a `groupBy` option (only as a "Then by" sort within another grouping), and turned out to be a small, well-contained addition following the existing `status` grouping's pattern, so it's included here (High/Medium/Low buckets, same style as the existing groupings).

---

## TA-5 — Edit/Delete repeat on every row, diluting the one badge that should stand out

**What changed:**
- (a) "Delete" recolored from red to a neutral/muted gray. Red is now reserved exclusively for Overdue/urgency badges.
- (b) For completed tasks specifically, the Edit/Delete controls render at reduced opacity (fading in to full strength on hover/focus) so finished work doesn't visually compete with active/urgent rows.

**Why:** Every row — including every completed item — previously rendered a full-strength red "Delete." Combined with red "Overdue" pills, red was doing two unrelated jobs on the same page (a rarely-used destructive action, and an urgency signal), and finished work looked exactly as actionable as urgent work.

---

## MO-1 — Card headers overflow the viewport on Tasks specifically (mobile)

**What changed:** Reworked `TaskRow`'s internal layout so the checkbox+icon+title group and the trailing Overdue/Due-date/Edit/Delete group are two independently-wrapping flex groups, instead of the trailing group being a rigid, non-shrinking block sharing one line with the title.

**Why / measurement:** At a 375px viewport, the trailing block's content (Overdue badge + due date + Edit + Delete) didn't fit next to the title, and — because it never modified its size or wrapped — Chromium either collapsed the title to 0px width or silently clipped content against the page's card `overflow: hidden` (both reproduced and screenshotted). Real Playwright measurement of the single row with the most trailing content (Overdue + weighted + Edit + Delete): **71px of clipped overflow before → 0px after**, at 375px width, with the title fully readable (truncated, not vanished) in every row afterward. (Note: because the row list sits inside a `Card` with `overflow-hidden`, `document.documentElement.scrollWidth` itself stays pinned to the viewport width in both states — the real, audit-worthy overflow was happening, and is now fixed, at the row level, which is what this fix targets and what the screenshots make visible.)

## MO-2 — Default checkbox target size

**Already resolved.** Confirmed both `CardRow` and `TouchRow` checkboxes sit in a 44px `min-h-11 min-w-11` hit area (from #155) on the Tasks list. No code change made here. `DEFAULT_PREFERENCES.taskRowVariant` ("Comfortable"/card) was left untouched per instructions — that's an intentional prior product decision, not a bug.

---

## Verification
- `npm run lint` — clean
- `npx tsc --noEmit` — clean except the 2 known pre-existing `workload.test.ts` errors (unrelated, pre-existing on base)
- `npm run build` — succeeds with zero env vars
- `npm test` — 220/220 passing (25 test files), including 5 new tests covering the `gradeWeight` badge threshold logic (shows at/above 15%, hides below, hides when absent, hides on completed items, works for both row variants)

## Screenshots
Before/after pairs were captured with a throwaway Playwright harness seeded with realistic fixture data (3 courses, mixed high/low grade weights, overdue + completed items, and Later-bucket items spanning September–December) — desktop 1000×900 and mobile 375×812. The harness was fully removed before this PR; `git status` was clean except the 4 files in this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_