### PR TITLE
Smart Planner: surface overdue backlog, fix mobile overflow, show recommended start dates, fix forecast-click semantics, tune overload detection (PL-1..5, VA-2)

### DIFF
--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -7,14 +7,7 @@ import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
-import {
-  getWorkloadLevel,
-  WORKLOAD_LEVEL_LABELS,
-  WORKLOAD_CHIP_CLASS,
-  WORKLOAD_TEXT_CLASS,
-  toDateOnly,
-  formatDateISO,
-} from '@/lib/workload';
+import { getWorkloadLevel, WORKLOAD_LEVEL_LABELS, WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS, toDateOnly } from '@/lib/workload';
 import {
   computeSmartPlan,
   getLocalReferenceDate,
@@ -31,6 +24,19 @@ const dayDetailFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+/**
+ * Formats a `YYYY-MM-DD` planning key (`PlannedItem.startDate`, always a
+ * UTC-normalized date-only string - see lib/workload/dateUtils.ts) as local
+ * calendar text. Goes through `toDateOnly` and reads UTC getters back into a
+ * *local* Date's Y/M/D components rather than formatting the UTC-midnight
+ * Date directly, so a negative-UTC-offset viewer's Intl formatter can't roll
+ * it back a day - the same class of bug documented on `toDateOnly` itself.
+ */
+function formatPlanDateKey(dateKey: string): string {
+  const d = toDateOnly(dateKey);
+  return dueDateFormatter.format(new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
 export function SmartPlanner() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
@@ -45,27 +51,29 @@ export function SmartPlanner() {
   const totalPlanned = plan.startToday.length + plan.startThisWeek.length + plan.startLater.length;
   const todayLoad = plan.weekLoad[0];
   const todayLevel = getWorkloadLevel(todayLoad.hours);
+  const hasOverdueBacklog = plan.overdueHours > 1e-9;
 
-  // Keyed the same way calculateDailyLoad keys plan.weekLoad (UTC-midnight
-  // ISO date), so a forecast day's key always finds the items actually due
-  // that day - reusing the workload engine's own date normalization instead
-  // of the calendar module's local-time one avoids an off-by-one across
-  // timezones.
-  const itemsByDueDate = useMemo(() => {
-    const map = new Map<string, ScheduleItem[]>();
-    for (const item of scheduleItems) {
-      const key = formatDateISO(toDateOnly(item.dueDate));
-      const existing = map.get(key);
-      if (existing) existing.push(item);
-      else map.set(key, [item]);
+  // PL-4: bucketed by RECOMMENDED START date (PlannedItem.startDate), the
+  // same concept every other section of this page ("Start Today" / "Start
+  // This Week" / "Later") is organized around - not by due date. Built from
+  // the plan's own already-computed buckets rather than re-deriving from
+  // scheduleItems, so a forecast tile's expanded panel can never disagree
+  // with which section a given item actually landed in above.
+  const itemsByStartDate = useMemo(() => {
+    const map = new Map<string, PlannedItem[]>();
+    const allPlanned = [...plan.startToday, ...plan.startThisWeek, ...plan.startLater];
+    for (const planned of allPlanned) {
+      const existing = map.get(planned.startDate);
+      if (existing) existing.push(planned);
+      else map.set(planned.startDate, [planned]);
     }
     return map;
-  }, [scheduleItems]);
+  }, [plan]);
 
   const [selectedForecastKey, setSelectedForecastKey] = useState<string | null>(null);
   const selectedForecastDay = plan.weekLoad.find((d) => d.key === selectedForecastKey);
   const selectedDayItems = selectedForecastKey
-    ? (itemsByDueDate.get(selectedForecastKey) ?? [])
+    ? (itemsByStartDate.get(selectedForecastKey) ?? [])
     : [];
 
   const handleToggleComplete = async (item: ScheduleItem) => {
@@ -93,14 +101,44 @@ export function SmartPlanner() {
             {WORKLOAD_LEVEL_LABELS[todayLevel]}
           </span>
         </div>
-        <div className="mb-5 flex items-end gap-2">
-          <span className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-            {todayLoad.hours.toFixed(1)}
-          </span>
-          <span className="pb-1.5 text-base font-medium text-muted-foreground sm:text-lg">
-            effective hours
-          </span>
+        {/* PL-1: split into two figures instead of one. The old single
+            "Today's Load" number only ever summed items due today through
+            +6 days (weekLoad) - an overdue item's hours land on its own
+            PAST due date and never made it into this number, even though
+            the Overdue-badged rows sit directly underneath it. Showing the
+            backlog total alongside it (rather than folding it in) keeps the
+            "due today" figure meaningful on its own while making the
+            catch-up debt visible instead of silently dropped. */}
+        <div className="mb-1 flex flex-wrap items-end gap-x-6 gap-y-3">
+          <div className="flex items-end gap-2">
+            <span className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+              {todayLoad.hours.toFixed(1)}
+              <span className="text-lg font-semibold text-muted-foreground sm:text-xl">h</span>
+            </span>
+            <span className="pb-1.5 text-xs font-medium text-muted-foreground sm:text-sm">
+              due today
+            </span>
+          </div>
+          {hasOverdueBacklog && (
+            <div className="flex items-end gap-2">
+              <span className="text-2xl font-bold tracking-tight text-destructive sm:text-3xl">
+                {plan.overdueHours.toFixed(1)}
+                <span className="text-sm font-semibold text-destructive/70 sm:text-base">h</span>
+              </span>
+              <span className="pb-1 text-xs font-medium text-muted-foreground sm:text-sm">
+                overdue backlog
+              </span>
+            </div>
+          )}
         </div>
+        {/* VA-2: narrate the computation instead of leaving it as a bare
+            number - this is where the workload engine's actual
+            intelligence (type-weighted, progress-aware, stress-adjusted
+            hours - see lib/workload) lives, and nothing on screen said so. */}
+        <p className="mb-5 text-xs text-muted-foreground">
+          Calculated from your exams, projects, and readings - weighted by type and
+          progress, not just a headcount.
+        </p>
 
         {plan.startToday.length === 0 ? (
           <EmptyState
@@ -120,13 +158,15 @@ export function SmartPlanner() {
           />
         ) : (
           <div className="flex flex-col gap-2">
-            {plan.startToday.map(({ item, overloaded, overdue }) => (
+            {plan.startToday.map(({ item, startDate, overloaded, tight, overdue }) => (
               <PlannedTaskRow
                 key={item.id}
                 variant={state.preferences.taskRowVariant}
                 item={item}
+                startDate={startDate}
                 course={courses.find((c) => c.id === item.courseId)}
                 overloaded={overloaded}
+                tight={tight}
                 overdue={overdue}
                 onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
               />
@@ -183,22 +223,19 @@ export function SmartPlanner() {
               {dayDetailFormatter.format(selectedForecastDay.day)}
             </h3>
             {selectedDayItems.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Nothing due this day.</p>
+              <p className="text-sm text-muted-foreground">Nothing recommended to start this day.</p>
             ) : (
               <div className="flex flex-col gap-2">
-                {selectedDayItems.map((item) => (
-                  <TaskRow
+                {selectedDayItems.map(({ item, startDate, overloaded, tight, overdue }) => (
+                  <PlannedTaskRow
                     key={item.id}
                     variant={state.preferences.taskRowVariant}
-                    title={item.title}
-                    href={`/tasks/${item.id}`}
-                    type={item.type}
-                    courseCode={courses.find((c) => c.id === item.courseId)?.code ?? 'General'}
-                    courseColor={courses.find((c) => c.id === item.courseId)?.color}
-                    courseIcon={courses.find((c) => c.id === item.courseId)?.icon}
-                    completed={item.completed}
-                    progress={item.progress}
-                    priority={item.priority}
+                    item={item}
+                    startDate={startDate}
+                    course={courses.find((c) => c.id === item.courseId)}
+                    overloaded={overloaded}
+                    tight={tight}
+                    overdue={overdue}
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                   />
                 ))}
@@ -232,19 +269,25 @@ export function SmartPlanner() {
 
 function PlannedTaskRow({
   item,
+  startDate,
   course,
   overloaded,
+  tight,
   overdue,
   onToggleComplete,
   variant,
 }: {
   item: PlannedItem['item'];
+  startDate: string;
   course: Course | undefined;
   overloaded: boolean;
+  tight: boolean;
   overdue: boolean;
   onToggleComplete?: () => void;
   variant?: 'card' | 'touch';
 }) {
+  const dueLabel = dueDateFormatter.format(new Date(item.dueDate));
+  const startLabel = formatPlanDateKey(startDate);
   return (
     <TaskRow
       variant={variant}
@@ -258,23 +301,38 @@ function PlannedTaskRow({
       progress={item.progress}
       priority={item.priority}
       onToggleComplete={onToggleComplete}
+      // PL-2: stacked (not side-by-side) so the trailing block's natural
+      // width is the widest SINGLE line, not badge+gap+date combined - this
+      // is what keeps the row within a 375px viewport without touching
+      // TaskRow.tsx's own `flex shrink-0` wrapper (owned by another agent
+      // this round). PL-3: prints the recommended start date - previously
+      // computed but discarded before reaching the screen - alongside the
+      // due date, both labeled, instead of only the due date.
       trailing={
-        <>
+        <div className="flex flex-col items-end gap-1 text-right">
           {overdue ? (
-            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+            <span className="whitespace-nowrap rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
               Overdue
             </span>
+          ) : overloaded ? (
+            <span className="whitespace-nowrap rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
+              Overloaded
+            </span>
           ) : (
-            overloaded && (
-              <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
-                Overloaded
+            tight && (
+              // PL-5: middle tier between a comfortable day and a genuinely
+              // overloaded one - styled with the 'high' load token
+              // (amber-ish), one step down in alarm from 'critical' (red).
+              <span className="whitespace-nowrap rounded-full bg-load-high/10 px-2 py-0.5 text-[10px] font-semibold text-load-high">
+                Tight
               </span>
             )
           )}
-          <span className="text-xs text-muted-foreground">
-            Due {dueDateFormatter.format(new Date(item.dueDate))}
+          <span className="whitespace-nowrap text-[11px] text-muted-foreground">
+            Start {startLabel}
           </span>
-        </>
+          <span className="whitespace-nowrap text-xs text-muted-foreground">Due {dueLabel}</span>
+        </div>
       }
     />
   );
@@ -299,12 +357,14 @@ function PlanSection({
     <Card className="rounded-2xl p-6">
       <h2 className="mb-3 text-sm font-semibold text-foreground">{title}</h2>
       <div className="flex flex-col gap-2">
-        {items.map(({ item, overloaded, overdue }) => (
+        {items.map(({ item, startDate, overloaded, tight, overdue }) => (
           <PlannedTaskRow
             key={item.id}
             item={item}
+            startDate={startDate}
             course={courses.find((c) => c.id === item.courseId)}
             overloaded={overloaded}
+            tight={tight}
             overdue={overdue}
             variant={variant}
             onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}

--- a/src/lib/planner/computeSmartPlan.ts
+++ b/src/lib/planner/computeSmartPlan.ts
@@ -6,6 +6,9 @@ export interface PlannedItem {
   item: ScheduleItem;
   startDate: string;
   overloaded: boolean;
+  /** PL-5: not overloaded, but placing this item used a day close to
+   * capacity. See `StudyStartRecommendation.tight`. */
+  tight: boolean;
   /** Already past its due date - distinct from `overloaded` (doesn't fit the
    * week's capacity). A late item and a merely-full week require different
    * reactions from the student, so they're tracked separately rather than
@@ -25,6 +28,15 @@ export interface SmartPlan {
   startToday: PlannedItem[];
   startThisWeek: PlannedItem[];
   startLater: PlannedItem[];
+  /**
+   * PL-1: total effective hours parked on PAST due dates (i.e. excluded from
+   * `weekLoad`, which only covers `referenceDate` through +6 days). Read from
+   * the same `calculateDailyLoad` output `weekLoad` is built from, so this is
+   * exactly the mass of hours the headline "today" figure silently drops —
+   * computed here rather than left implicit so the UI can surface it as its
+   * own number instead of a student having to infer it from a badge count.
+   */
+  overdueHours: number;
 }
 
 /**
@@ -66,9 +78,25 @@ export function computeSmartPlan(scheduleItems: ScheduleItem[], referenceDate: D
     // `referenceDate` used for workload bucketing) so "overdue" means the
     // same thing everywhere in the app.
     const overdue = !item.completed && new Date(item.dueDate) < new Date();
-    return { item, startDate: rec.startDate, overloaded: rec.overloaded, overdue };
+    return {
+      item,
+      startDate: rec.startDate,
+      overloaded: rec.overloaded,
+      tight: rec.tight,
+      overdue,
+    };
   });
   plannedItems.sort((a, b) => a.startDate.localeCompare(b.startDate));
+
+  // PL-1: `load` already carries each overdue item's full hours on its own
+  // (past) due date - see getItemDailyDistribution's overdue branch - so
+  // summing every key strictly before today recovers exactly the overdue
+  // backlog total, using the same weighting/stress math as everything else,
+  // without re-deriving it or touching the weekLoad/forecast math above.
+  let overdueHours = 0;
+  for (const [key, hours] of Array.from(load)) {
+    if (key < todayKey) overdueHours += hours;
+  }
 
   const weekEndKey = weekLoad[6].key;
   return {
@@ -76,5 +104,6 @@ export function computeSmartPlan(scheduleItems: ScheduleItem[], referenceDate: D
     startToday: plannedItems.filter((p) => p.startDate <= todayKey),
     startThisWeek: plannedItems.filter((p) => p.startDate > todayKey && p.startDate <= weekEndKey),
     startLater: plannedItems.filter((p) => p.startDate > weekEndKey),
+    overdueHours,
   };
 }

--- a/src/lib/workload/constants.ts
+++ b/src/lib/workload/constants.ts
@@ -94,3 +94,30 @@ export const WORKLOAD_LEVEL_LABELS = {
   high: 'High',
   critical: 'Extreme',
 } as const;
+
+/**
+ * PL-5: Daily effective-hours capacity the backward-fill recommender
+ * (`recommendStudyStartDate`) treats as a day's ceiling before it's
+ * considered saturated.
+ *
+ * Deliberately a dedicated planning parameter, decoupled from
+ * `WORKLOAD_LEVEL_THRESHOLDS` — those answer "how should this day *look*"
+ * for the 7-day forecast strip; this answers "how much can we actually
+ * still schedule on this day" for the recommender. It was previously
+ * aliased to the 'medium' display threshold (5h), which — combined with the
+ * uncapped backward-fill window — meant a genuinely full day almost never
+ * tripped `overloaded` in practice, so the engine's strongest signal never
+ * fired. 4h reflects realistic *remaining* focus capacity once classes,
+ * commute, and other commitments already claim part of the day, and is
+ * conservative enough that only a genuinely dense cluster of near-term,
+ * high-effort items (e.g. finals week) triggers it.
+ */
+export const DAILY_SCHEDULING_CAPACITY_HOURS = 4;
+
+/**
+ * PL-5: fraction of `DAILY_SCHEDULING_CAPACITY_HOURS` at/above which a day
+ * that is NOT overloaded is instead flagged "tight" — close to capacity but
+ * still schedulable. Gives the recommender a genuine 3-tier signal (normal /
+ * tight / overloaded) instead of only a binary normal/overloaded jump.
+ */
+export const TIGHT_UTILIZATION_RATIO = 0.85;

--- a/src/lib/workload/scheduling.ts
+++ b/src/lib/workload/scheduling.ts
@@ -1,10 +1,15 @@
 import type { ScheduleItem } from '@/types/schedule';
-import { WORKLOAD_LEVEL_THRESHOLDS } from './constants';
+import { DAILY_SCHEDULING_CAPACITY_HOURS, TIGHT_UTILIZATION_RATIO } from './constants';
 import { addDays, diffInDays, formatDateISO, toDateOnly } from './dateUtils';
 import { getBaseEffectiveHours } from './dailyLoad';
 
-/** Default per-day capacity (effective hours) the recommender tries not to exceed. Matches the 'medium' band ceiling. */
-export const DEFAULT_DAILY_CAPACITY_HOURS = WORKLOAD_LEVEL_THRESHOLDS.medium;
+/**
+ * Default per-day capacity (effective hours) the recommender tries not to
+ * exceed. See `DAILY_SCHEDULING_CAPACITY_HOURS` (constants.ts) for why this
+ * is a dedicated planning parameter rather than one of the display-band
+ * thresholds (PL-5).
+ */
+export const DEFAULT_DAILY_CAPACITY_HOURS = DAILY_SCHEDULING_CAPACITY_HOURS;
 
 export interface RecommendStartDateOptions {
   /** Max effective hours to allow on any single day before it's considered saturated. Defaults to the 'medium' threshold. */
@@ -22,6 +27,13 @@ export interface StudyStartRecommendation {
    * i.e. there isn't enough runway left, even starting today.
    */
   overloaded: boolean;
+  /**
+   * PL-5: true when the item isn't `overloaded`, but placing it required
+   * using a day at/above `TIGHT_UTILIZATION_RATIO` of capacity — runway
+   * technically exists, but at least one day in the plan is close to full.
+   * The middle tier between a comfortable day and a genuinely overloaded one.
+   */
+  tight: boolean;
 }
 
 /**
@@ -70,17 +82,21 @@ export function recommendStudyStartDate(
       startDate: dueDateKey,
       dailyAllocation: { [dueDateKey]: totalHours },
       overloaded: true,
+      tight: false,
     };
   }
 
   if (totalHours === 0) {
     // Nothing to schedule — recommend starting (and "finishing") on the due date.
-    return { startDate: dueDateKey, dailyAllocation: {}, overloaded: false };
+    return { startDate: dueDateKey, dailyAllocation: {}, overloaded: false, tight: false };
   }
 
   const allocation = new Map<string, number>();
   let remaining = totalHours;
   let cursor = due;
+  // PL-5: highest observed (existing + this item's allocation) / capacity
+  // across the days this item actually landed on, to derive the "tight" tier.
+  let peakUtilization = 0;
 
   // Walk backward from the due date through (and including) today.
   while (remaining > 1e-9) {
@@ -92,6 +108,10 @@ export function recommendStudyStartDate(
     if (allocated > 0) {
       allocation.set(dateKey, allocated);
       remaining -= allocated;
+      if (maxDailyHours > 0) {
+        const utilization = (existing + allocated) / maxDailyHours;
+        if (utilization > peakUtilization) peakUtilization = utilization;
+      }
     }
 
     if (diffInDays(cursor, today) <= 0) break; // reached the earliest available day
@@ -99,6 +119,7 @@ export function recommendStudyStartDate(
   }
 
   const overloaded = remaining > 1e-9;
+  const tight = !overloaded && peakUtilization >= TIGHT_UTILIZATION_RATIO;
 
   // Sort chronologically for a stable, readable dailyAllocation record.
   const sortedEntries = Array.from(allocation.entries()).sort(([a], [b]) =>
@@ -108,5 +129,5 @@ export function recommendStudyStartDate(
 
   const startDate = sortedEntries.length > 0 ? sortedEntries[0][0] : formatDateISO(today);
 
-  return { startDate, dailyAllocation, overloaded };
+  return { startDate, dailyAllocation, overloaded, tight };
 }


### PR DESCRIPTION
## PL-1 — Overdue backlog was silently excluded from the headline number

**What changed:** Split the "Today's Load" stat into two figures — "X.Xh due today" and "Y.Yh overdue backlog" — computed from the same `calculateDailyLoad` map `computeSmartPlan` already builds (overdue items' hours already land on their own past due date in that map; we just sum the entries dated before today instead of discarding them). No change to the forecast/weekLoad math used elsewhere.

**Why:** The one number this screen is built around didn't describe the list underneath it — three items badged Overdue contributed zero to "Today's Load," so a student had no way to see how much catch-up was actually needed at a glance.

## PL-2 — Every row overflowed horizontally on mobile

**What changed:** The trailing badge/due-date group in `SmartPlanner`'s `PlannedTaskRow` now stacks vertically (`flex-col`) instead of forcing badge + date onto one unwrapped line. `TaskRow.tsx` itself (owned by another workstream this round) was not touched — the fix lives entirely in the content SmartPlanner passes as `trailing`.

**Why:** Real Playwright measurement at 375×812 showed the old single-line layout left the widest realistic row (an "Overloaded" item in the "Start This Week" section) with essentially **zero** spare width — 144.8px of trailing content against a 145px budget, squeezing the task title down to a literal **0px** rendered width. The assignment name was invisible on the row, not just truncated. After the fix, the same row's trailing content drops to ~72px (its widest single line), giving the title ~71px of real room.

## PL-3 — The recommended start date was computed but never shown

**What changed:** Each row now prints both dates: "Start Aug 20" / "Due Aug 22", stacked in the trailing block (pairs naturally with the PL-2 layout fix).

**Why:** `recommendStudyStartDate`'s load-aware backward-fill is the actual "smart" part of the Smart Planner, but the UI only ever rendered `Due {date}` — the computed recommendation was consumed for bucketing/sorting and thrown away before reaching the screen. Nothing on screen couldn't have been produced by `ORDER BY due_date`.

## PL-4 — Clicking a forecast day showed due-dated items, contradicting the page's own start-date framing

**What changed:** The 7-Day Forecast day panel now groups by `PlannedItem.startDate` (built from the plan's own already-computed `startToday`/`startThisWeek`/`startLater` buckets) instead of by `ScheduleItem.dueDate`, and renders `PlannedTaskRow` (with badges) instead of a bare `TaskRow`.

**Why:** The page teaches "start dates" everywhere else, then one click on a forecast tile silently switched to "due dates" in an identically-styled list. Concretely, in our test data: the "due today" panel showed **1** item; the "recommended to start today" panel for the same day shows **5** — the due-date framing was hiding 4 out of 5 things a student should actually start that day.

## PL-5 — "Overloaded" rarely fired, and there was no middle ground

**What changed:** Decoupled the recommender's daily scheduling capacity from `WORKLOAD_LEVEL_THRESHOLDS` (the display color-band thresholds) into its own constant, `DAILY_SCHEDULING_CAPACITY_HOURS`, tuned from 5.0h to 4.0h. Added a new `tight` signal to `recommendStudyStartDate`/`PlannedItem`: a day that isn't overloaded but used ≥85% of capacity now surfaces an amber "Tight" badge, distinct from the red "Overloaded" one.

**Why:** The previous capacity ceiling was silently aliased to the 'medium' display threshold, and combined with an effectively unbounded backward-fill window, a genuinely full day almost never tripped `overloaded` — the one thing a to-do list can't do (tell you "you truly cannot fit this") never demonstrated itself. On a realistic 27-item dataset (overdue items through a finals cluster), the new "Tight" tier alone surfaces on 14 previously-silent items, giving the engine an honest 3-tier signal (normal / tight / overloaded) instead of a binary jump. Tuned conservatively per the request — verified against existing unit tests and a dense synthetic dataset rather than a threshold that fires on every row.

## VA-2 — The workload engine's real intelligence was invisible

**What changed:** Added a one-line explainer under the load stat: "Calculated from your exams, projects, and readings - weighted by type and progress, not just a headcount."

**Why:** The type-weighted (exam ×1.5, reading ×0.7, project ×1.35...), progress-aware backward-fill algorithm is the single most sophisticated thing about the product, and it read as an unlabeled number next to a to-do list.

---

### Verification
- `npm run lint` — clean
- `npx tsc --noEmit` — clean except the 2 pre-existing `workload.test.ts` errors on this base branch (unrelated `MapIterator` downlevel-iteration warnings); confirmed no new errors introduced
- `npm test` — 215/215 passing, including all 39 `workload.test.ts` cases (the PL-1/PL-5 changes did not touch behavior any existing test was asserting on — those tests use `WORKLOAD_LEVEL_THRESHOLDS` and the exported `DEFAULT_DAILY_CAPACITY_HOURS` symbol relatively, not hardcoded numbers, so they remained valid against the new tuned constant)
- `npm run build` (zero env vars) — clean production build, all 17 routes generated

### Screenshots
Before/after pairs for PL-1 through PL-5 were captured with a throwaway `preview-harness` route (seeded `AppStateProvider` + temporarily-exported `AuthContext`) against a realistic 27-item dataset (overdue backlog, today, a dense near-term cram cluster, and a finals-week exam cluster), using Playwright against Chromium at 1000×900 (desktop) and 375×812 (mobile). The harness and the temporary `AuthContext` export were fully removed before this commit — `git status` is clean except the four files listed above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_