### PR TITLE
Dashboard: fix mobile overflow, dedupe task lists, fix color collision, reframe stat card, positive framing (DA-1..5, MO-3/4/5, VA-5)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "next/typescript", "prettier"]
 }

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
-import { CardActionLink, CardActionButton } from '@/components/ui/CardAction';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
@@ -31,6 +31,34 @@ function getGreeting(hour: number): string {
   if (hour < 12) return 'Good morning';
   if (hour < 18) return 'Good afternoon';
   return 'Good evening';
+}
+
+/**
+ * DA-5: a plain, low-emphasis "view more" navigation link - deliberately
+ * lighter than CardActionLink's bordered-pill `ghost` styling, so secondary
+ * navigation ("View all", "Open planner") doesn't visually compete with the
+ * real actions on the dashboard (the Autofill banner, "+ Add Task"/"+ Add
+ * Course"). Local to this file rather than a CardAction variant change,
+ * since CardActionLink's current look is still correct elsewhere it's used.
+ */
+function QuietLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex shrink-0 items-center gap-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-primary"
+    >
+      {children}
+      <svg
+        className="h-3 w-3"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2.5}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </Link>
+  );
 }
 
 export function DashboardView() {
@@ -80,12 +108,34 @@ export function DashboardView() {
     .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
     .slice(0, 4);
 
+  // DA-4: what the stat card leads with. The soonest-due pending item, plus
+  // how many days out it is, so the card can open with something
+  // forward-looking ("Next: ... in 2 days") instead of the bare completion
+  // percentage.
+  const nextTask = upcomingTasks[0];
+  const nextTaskDaysUntil = nextTask
+    ? Math.ceil((new Date(nextTask.dueDate).getTime() - now) / (1000 * 60 * 60 * 24))
+    : null;
+  const dueThisWeekCount = pendingTasks.filter((item) => {
+    const days = (new Date(item.dueDate).getTime() - now) / (1000 * 60 * 60 * 24);
+    return days >= 0 && days <= 7;
+  }).length;
+
   const referenceDate = useMemo(() => getLocalReferenceDate(), []);
   const plan = useMemo(
     () => computeSmartPlan(termScheduleItems, referenceDate),
     [termScheduleItems, referenceDate],
   );
-  const plannerPreview = [...plan.startToday, ...plan.startThisWeek].slice(0, 4);
+  // DA-2: Planner Preview used to show the same due-soonest items as
+  // Upcoming Tasks (identical rows, contradicting badges - "Overdue" vs
+  // "Overloaded" - seconds apart). Excluding whatever Upcoming Tasks
+  // already surfaced means Planner Preview only ever shows genuinely
+  // different information: what the workload-aware planner recommends
+  // starting soon that isn't already covered by the plain due-date list.
+  const upcomingTaskIds = useMemo(() => new Set(upcomingTasks.map((t) => t.id)), [upcomingTasks]);
+  const plannerPreview = [...plan.startToday, ...plan.startThisWeek]
+    .filter((p) => !upcomingTaskIds.has(p.item.id))
+    .slice(0, 4);
 
   const greeting = useMemo(() => getGreeting(new Date().getHours()), []);
   const firstName = (user?.displayName || user?.email?.split('@')[0] || 'there').split(' ')[0];
@@ -181,20 +231,31 @@ export function DashboardView() {
 
         <div className="space-y-4">
           <Card accent="left" className="rounded-2xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-3">
-                <SectionIcon icon="tasks" />
-                <h2 className="text-lg font-bold text-foreground">Upcoming Tasks</h2>
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-4">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
+                <div className="flex items-center gap-3">
+                  <SectionIcon icon="tasks" />
+                  <h2 className="text-lg font-bold text-foreground">Upcoming Tasks</h2>
+                </div>
                 {overdueCount > 0 && (
                   <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
                     {overdueCount} overdue
                   </span>
                 )}
+                {/* VA-5: pair the alarming overdue count with a real, positive
+                    number so the dashboard doesn't only ever talk in red
+                    pills. Scoped to the current term, same as the count
+                    above - "this term" rather than "this week" since
+                    ScheduleItem has no completion timestamp to narrow it
+                    further. */}
+                {completedTasksCount > 0 && (
+                  <span className="rounded-full bg-load-low/10 px-2 py-0.5 text-[10px] font-semibold text-load-low">
+                    {completedTasksCount} completed this term
+                  </span>
+                )}
               </div>
-              <div className="flex items-center gap-2">
-                <CardActionLink href="/tasks" withChevron>
-                  View all
-                </CardActionLink>
+              <div className="flex shrink-0 items-center gap-3">
+                <QuietLink href="/tasks">View all</QuietLink>
                 <CardActionButton variant="solid" withPlus onClick={() => setAddTaskOpen(true)}>
                   Add Task
                 </CardActionButton>
@@ -210,11 +271,24 @@ export function DashboardView() {
                     stroke="currentColor"
                     strokeWidth={2}
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d={courses.length === 0 ? 'M12 4.5v15m7.5-7.5h-15' : 'M5 13l4 4L19 7'}
+                    />
                   </svg>
                 }
-                title="Nothing due"
-                description="You're all caught up."
+                title={courses.length === 0 ? 'Add your first course' : 'Nothing due'}
+                description={
+                  courses.length === 0
+                    ? 'Get started by adding a course or two.'
+                    : "You're all caught up."
+                }
+                action={
+                  courses.length === 0
+                    ? { label: '+ Add Course', onClick: () => setAddCourseOpen(true) }
+                    : undefined
+                }
               />
             ) : (
               <div className="flex flex-col gap-2">
@@ -236,16 +310,22 @@ export function DashboardView() {
                       priority={item.priority}
                       onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                       trailing={
-                        <>
+                        // DA-1: stacked (badge above date) rather than
+                        // side-by-side - side-by-side was the widest
+                        // non-shrinking part of the row, the main reason due
+                        // dates got pushed off-screen on a real phone.
+                        // Stacking keeps the same information at roughly
+                        // half the horizontal footprint.
+                        <div className="flex flex-col items-end gap-0.5">
                           {overdue && (
-                            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
+                            <span className="whitespace-nowrap rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-semibold text-destructive">
                               Overdue
                             </span>
                           )}
-                          <span className="text-xs text-muted-foreground">
-                            Due {dueDateFormatter.format(new Date(item.dueDate))}
+                          <span className="whitespace-nowrap text-xs text-muted-foreground">
+                            {dueDateFormatter.format(new Date(item.dueDate))}
                           </span>
-                        </>
+                        </div>
                       }
                     />
                   );
@@ -256,18 +336,16 @@ export function DashboardView() {
 
           <div className="grid gap-4 sm:grid-cols-2">
             <Card className="rounded-2xl p-4">
-              <div className="flex items-center justify-between mb-3">
-                <div className="flex items-center gap-2.5">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+                <div className="flex min-w-0 items-center gap-2.5">
                   <SectionIcon icon="courseLoad" className="h-6 w-6" />
-                  <div>
+                  <div className="min-w-0">
                     <h2 className="text-sm font-semibold text-foreground">Course Load</h2>
                     {currentTerm && <p className="text-xs text-muted-foreground">{currentTerm}</p>}
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <CardActionLink href="/courses" withChevron>
-                    View all
-                  </CardActionLink>
+                <div className="flex shrink-0 items-center gap-3">
+                  <QuietLink href="/courses">View all</QuietLink>
                   <CardActionButton variant="solid" withPlus onClick={() => setAddCourseOpen(true)}>
                     Add Course
                   </CardActionButton>
@@ -329,47 +407,99 @@ export function DashboardView() {
               )}
             </Card>
 
-            <Card className="rounded-2xl p-4">
+            {/* DA-4/MO-5: `self-start` stops this card stretching to match
+                Course Load's height in the sm:grid-cols-2 row (the default
+                grid stretch left ~300-400px of dead space at both desktop
+                and tablet widths) - it now sizes to its own content. */}
+            <Card className="rounded-2xl p-4 self-start">
               <div className="mb-3 flex items-center gap-2.5">
                 <SectionIcon icon="star" className="h-6 w-6" />
                 <h2 className="text-sm font-semibold text-foreground">Term Progress</h2>
               </div>
-              <div className="flex items-center gap-4">
-                <ProgressRing percent={termProgressPct} size={80} strokeWidth={7}>
-                  <div className="text-center">
-                    <div className="text-lg font-bold text-foreground">{termProgressPct}%</div>
+              {courses.length === 0 ? (
+                // MO-4: a brand-new account with zero courses/zero everything
+                // used to render this same ring-at-0%-plus-zeros grid, which
+                // reads as "something failed to load" rather than "welcome".
+                // A distinct onboarding message replaces it instead.
+                <div className="flex flex-col items-start gap-2 py-1">
+                  <p className="text-sm font-semibold text-foreground">Welcome aboard</p>
+                  <p className="text-xs text-muted-foreground">
+                    Add your first course to start tracking assignments and workload.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setAddCourseOpen(true)}
+                    className="mt-1 rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                  >
+                    + Add Course
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <div className="min-w-0">
+                    {nextTask ? (
+                      <>
+                        <p className="truncate text-sm font-semibold text-foreground">
+                          Next: {nextTask.title}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {nextTaskDaysUntil !== null && nextTaskDaysUntil < 0
+                            ? 'Overdue'
+                            : nextTaskDaysUntil === 0
+                              ? 'Due today'
+                              : `Due in ${nextTaskDaysUntil} day${nextTaskDaysUntil === 1 ? '' : 's'}`}
+                          {dueThisWeekCount > 1 ? ` · ${dueThisWeekCount} due this week` : ''}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-sm font-semibold text-foreground">
+                        Nothing due - you&rsquo;re clear
+                      </p>
+                    )}
                   </div>
-                </ProgressRing>
-                <div className="grid flex-1 grid-cols-3 gap-2 text-center">
-                  <div>
-                    <div className="text-base font-bold text-primary">{semesterCourses.length}</div>
-                    <div className="text-[10px] text-muted-foreground">Courses</div>
-                  </div>
-                  <div>
-                    <div className="text-base font-bold text-load-medium">
-                      {pendingTasks.length}
+                  <div className="flex items-center gap-3">
+                    {/* Percentage demoted to a small secondary stat - no
+                        longer the dominant, discouraging first number on
+                        the card. */}
+                    <ProgressRing percent={termProgressPct} size={52} strokeWidth={5}>
+                      <span className="text-[11px] font-bold text-foreground">
+                        {termProgressPct}%
+                      </span>
+                    </ProgressRing>
+                    <div className="grid flex-1 grid-cols-3 gap-2 text-center">
+                      <div>
+                        <div className="text-sm font-bold text-primary">
+                          {semesterCourses.length}
+                        </div>
+                        <div className="text-[10px] text-muted-foreground">Courses</div>
+                      </div>
+                      <div>
+                        <div className="text-sm font-bold text-load-medium">
+                          {pendingTasks.length}
+                        </div>
+                        <div className="text-[10px] text-muted-foreground">Pending</div>
+                      </div>
+                      <div>
+                        <div className="text-sm font-bold text-load-low">{completedTasksCount}</div>
+                        <div className="text-[10px] text-muted-foreground">Done</div>
+                      </div>
                     </div>
-                    <div className="text-[10px] text-muted-foreground">Pending</div>
-                  </div>
-                  <div>
-                    <div className="text-base font-bold text-load-low">{completedTasksCount}</div>
-                    <div className="text-[10px] text-muted-foreground">Done</div>
                   </div>
                 </div>
-              </div>
+              )}
             </Card>
           </div>
         </div>
 
         <Card className="rounded-2xl p-4 sm:p-6">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center gap-3">
-              <SectionIcon icon="forecast" />
-              <h2 className="text-base font-semibold text-foreground">7-Day Load</h2>
-            </div>
-            <CardActionLink href="/planner" withChevron>
-              Open planner
-            </CardActionLink>
+          {/* DA-5: this card used to duplicate Planner Preview's "Open
+              planner" link below - two links to the same destination on
+              one screen. Planner Preview's is the more specific one (it
+              links from actual recommended items), so it's the one kept;
+              this header is now just a label. */}
+          <div className="mb-4 flex items-center gap-3">
+            <SectionIcon icon="forecast" />
+            <h2 className="text-base font-semibold text-foreground">7-Day Load</h2>
           </div>
           <div className="grid grid-cols-7 gap-1 sm:gap-2">
             {plan.weekLoad.map(({ key, day, hours, level }) => {
@@ -403,14 +533,12 @@ export function DashboardView() {
         </Card>
 
         <Card className="rounded-2xl p-6">
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
             <div className="flex items-center gap-3">
               <SectionIcon icon="planner" />
               <h2 className="text-base font-semibold text-foreground">Planner Preview</h2>
             </div>
-            <CardActionLink href="/planner" withChevron>
-              Open planner
-            </CardActionLink>
+            <QuietLink href="/planner">Open planner</QuietLink>
           </div>
           {plannerPreview.length === 0 ? (
             <EmptyState
@@ -449,8 +577,15 @@ export function DashboardView() {
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                     trailing={
                       overloaded ? (
-                        <span className="rounded-full bg-load-critical/10 px-2 py-0.5 text-[10px] font-semibold text-load-critical">
-                          Overloaded
+                        // VA-5: "Overloaded" read as alarm-only red - the
+                        // same hue as a destructive/error state - with no
+                        // suggested next step. "Tight" + an action (start
+                        // today) reads as a coach's nudge instead of a
+                        // warning, and load-high (amber) instead of
+                        // load-critical (red) keeps it out of destructive-
+                        // red territory entirely.
+                        <span className="rounded-full bg-load-high/10 px-2 py-0.5 text-[10px] font-semibold text-load-high">
+                          Tight · start today
                         </span>
                       ) : (
                         <span

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -19,7 +19,21 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
             <Navbar />
             <div className="flex flex-1 pt-20">
               <Sidebar />
-              <main className="flex-1 p-6 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pl-72 md:p-8 md:pb-8 max-w-7xl transition-all duration-300">
+              {/* DA-1 (dashboard mobile-overflow audit finding): `main` is a
+                  flex item of the row above (Sidebar + main) but had no
+                  min-w-0, so its default `min-width: auto` floors it at the
+                  min-content size of whatever page it renders - on the
+                  dashboard specifically, several header rows and unwrapped
+                  flex children that were happy to truncate/wrap at a real
+                  375px width instead forced `main` (and the whole page)
+                  wider than the viewport, verified via
+                  `document.documentElement.scrollWidth` (549px) vs
+                  `window.innerWidth` (375px) at that breakpoint. No
+                  restructuring inside the page content itself can fix this -
+                  the missing min-w-0 is on this flex item, not a descendant -
+                  confirmed empirically that adding it here alone resolves
+                  the overflow with no other changes needed. */}
+              <main className="min-w-0 flex-1 p-6 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pl-72 md:p-8 md:pb-8 max-w-7xl transition-all duration-300">
                 {children}
               </main>
             </div>

--- a/src/lib/courseColors.ts
+++ b/src/lib/courseColors.ts
@@ -17,7 +17,15 @@ export interface CoursePreset {
   hex: string;
 }
 
-export const COURSE_COLOR_PRESETS: CoursePreset[] = [
+/**
+ * DA-3 (dashboard UX audit): the full historical set of presets, including
+ * red/rose. Kept separate from the exported `COURSE_COLOR_PRESETS` below so
+ * a course saved with `bg-red-500`/`bg-rose-500` before this fix still
+ * resolves its real hex (via `resolveCourseHex`) and chip tint (via
+ * `COURSE_CHIP_TINT_CLASS`, unchanged below) instead of silently falling
+ * back to a default color or breaking.
+ */
+const ALL_COURSE_COLOR_PRESETS: CoursePreset[] = [
   { value: 'bg-blue-500', hex: '#3b82f6' },
   { value: 'bg-green-500', hex: '#22c55e' },
   { value: 'bg-purple-500', hex: '#a855f7' },
@@ -33,6 +41,24 @@ export const COURSE_COLOR_PRESETS: CoursePreset[] = [
   { value: 'bg-violet-500', hex: '#8b5cf6' },
   { value: 'bg-emerald-500', hex: '#10b981' },
 ];
+
+/**
+ * Presets offered for a NEW color choice - the course creation/edit form's
+ * picker, and the least-used-preset auto-assignment below
+ * (`pickNextCourseColor`/`pickSuggestedCourseColor`, used for manually
+ * added and AI-autofilled courses alike).
+ *
+ * DA-3 fix: red/rose used to be in this list, so a course could land on
+ * (or be auto-assigned) the exact hue the app already uses for destructive/
+ * "Overdue" state - a course card tinted red reads as "you're failing this
+ * class" next to an unrelated red Overdue badge. Removing them here only
+ * stops *new* assignment; a course already saved with one of these two
+ * colors keeps rendering exactly as before (see `ALL_COURSE_COLOR_PRESETS`
+ * above and `resolveCourseHex` below).
+ */
+export const COURSE_COLOR_PRESETS: CoursePreset[] = ALL_COURSE_COLOR_PRESETS.filter(
+  (preset) => preset.value !== 'bg-red-500' && preset.value !== 'bg-rose-500',
+);
 
 /** Back-compat alias - the old 6-entry list some components imported by
  * this name. Kept as the first 6 presets so previously-saved courses using
@@ -111,7 +137,7 @@ export function getCourseChipTintClass(color: string | undefined): string {
 function resolveCourseHex(color: string | undefined): string {
   return isCustomColor(color)
     ? color
-    : (COURSE_COLOR_PRESETS.find((p) => p.value === color)?.hex ?? '#7c3aed');
+    : (ALL_COURSE_COLOR_PRESETS.find((p) => p.value === color)?.hex ?? '#7c3aed');
 }
 
 /** A faint full-surface background wash (course cards, list rows) - subtler


### PR DESCRIPTION
## Summary

Dashboard slice of the UX audit backlog. All changes are scoped to `src/components/dashboard/DashboardView.tsx`, with three small, unavoidable exceptions explained below. Verified with Playwright screenshots (before/after, real `scrollWidth` measurements for the mobile bug) and the full verification suite (lint, typecheck, build with zero env vars, unit tests).

---

## DA-1 — Mobile layout overflows the viewport

**What changed:** Confirmed the bug with Playwright at a real 375px viewport: `document.documentElement.scrollWidth` measured 549px against `window.innerWidth` of 375px (the exact class of defect the audit flagged, even though the specific pixel counts differ from the audit's session). Root-caused it to `<main>` in `LayoutWrapper.tsx` being a flex item of the sidebar row with no `min-w-0` — its default `min-width: auto` floors it at the *minimum content width* of whatever it renders, and several places on the dashboard (card header rows with an icon+title on one side and buttons on the other, and each task row's badge+due-date block) were wide enough, unwrapped, to push that floor past 375px. Fixed by adding `min-w-0` to `main` (the one line that actually stops the flex item from being held open), then made the dashboard itself robust to a real 375px width: card header rows now wrap onto a second line instead of forcing extra width, and each task row's "Overdue" badge + due date are stacked instead of side-by-side, cutting their footprint roughly in half. After the fix, `scrollWidth` measures exactly 375px — no overflow, confirmed via the same Playwright check.

**Why it hurts (ties to audit finding):** This was the single most-confirmed defect in the audit, flagged independently by four review passes. A majority-mobile audience literally could not read due dates or overdue badges without discovering a horizontal scroll they had no visual cue existed. Fixing it means every phone user sees their actual due dates without extra taps or luck.

*Unavoidable file outside DashboardView.tsx:* `src/components/layout/LayoutWrapper.tsx` (one line, `min-w-0` added to `main`) — the missing constraint is on that flex item itself; no restructuring inside the page content can substitute for it, confirmed empirically (see commit for detail).

---

## DA-2 — Two lists show the same 4 tasks with contradicting labels

**What changed:** Planner Preview now excludes anything already shown in Upcoming Tasks (`plannerPreview` filters out ids already in `upcomingTasks`), so the two lists only ever show non-overlapping tasks. Planner Preview also no longer inherits the "Overdue"/"Overloaded" naming confusion, since it can no longer show the same rows Upcoming Tasks already labeled "Overdue."

**Why it hurts (ties to audit finding):** Seeing the identical three assignments tagged "Overdue" in one card and "Overloaded" in the next reads as the app being confused about its own state — a trust problem, not just a cosmetic one. With the dedupe, each list now carries genuinely different information: Upcoming Tasks answers "what's due soonest," Planner Preview answers "what does the workload-aware planner say to start now."

---

## DA-3 — Course color and "danger" color collide

**What changed:** `bg-red-500` and `bg-rose-500` are removed from the pool of colors offered to *new* courses (course creation, and the least-used-color auto-assignment used by manual add and AI syllabus autofill). A course already saved with either color keeps rendering exactly as it did before — its chip tint and swatch resolution are untouched — so nothing breaks for existing users; only new assignment stops offering the colliding hues.

**Why it hurts (ties to audit finding):** A course that happened to land on red tinted its Course Load row the same hue as the destructive "Overdue" badges right above it — a false "you're failing this class" alarm at a glance. New courses (including ones the AI autofill suggests) can no longer land on that hue.

*Unavoidable file outside DashboardView.tsx:* `src/lib/courseColors.ts` — DashboardView doesn't define the color preset list; it only consumes it via `courseChipTint`/`courseSwatch`. The fix has to live where the presets are defined.

---

## DA-4 / MO-5 — Stat card is mostly empty space, and leads with discouragement

**What changed:** The Term Progress card now leads with a forward-looking line — "Next: `<task>` / Due in N days" (or "Overdue" / "Due today" / "Nothing due — you're clear") — computed from the same pending-tasks data already driving the rest of the dashboard. The completion percentage is demoted to a small secondary ring next to the Courses/Pending/Done counts instead of being the first, biggest thing on the card. The card also no longer stretches to match Course Load's height (`self-start` in the grid row) — it now sizes to its own content, confirmed at both a 1000px desktop viewport and a 768px tablet viewport (MO-5).

**Why it hurts (ties to audit finding):** Leading with "12% progress" next to "22 Pending" in orange framed the semester as already-behind before the student had even looked at anything else. And the ~300-400px of dead space (desktop and tablet) below a bare ring read as the page not finishing loading. The card now answers "what's next" first, and its size matches what's actually in it.

---

## DA-5 — Seven competing calls-to-action, no clear primary

**What changed:** "View all" (Upcoming Tasks, Course Load) and "Open planner" (Planner Preview) are now plain, quiet text links with no border/pill background, clearly subordinate to the Autofill banner and the solid "+ Add Task"/"+ Add Course" buttons. The 7-Day Load card's duplicate "Open planner" link (pointing at the same destination as Planner Preview's) is removed entirely — its header is now just a label.

**Why it hurts (ties to audit finding):** Seven same-weight buttons plus two links to the identical destination made the dashboard feel like a button grid instead of guidance on what to do right now. There is now exactly one dominant CTA (Autofill from Syllabus), two real creation actions (Add Task/Add Course), and quiet secondary navigation that doesn't compete for attention — and only one path to the planner instead of two.

---

## MO-3 — Empty states use identical "you're done!" copy for both "nothing left" and "nothing started"

**What changed:** Upcoming Tasks' empty state now checks whether the student has any courses at all. With zero courses, it shows "Add your first course" / "Get started by adding a course or two." with a "+ Add Course" action. With courses but no pending work, it still shows the original "Nothing due / You're all caught up." Only the props passed to the existing `EmptyState` component changed — the component itself is untouched.

**Why it hurts (ties to audit finding):** Telling a brand-new student with zero courses that they're "all caught up" is reassuring but false — there's nothing to be caught up *on* yet. The copy now tells the truth about which situation the student is actually in.

---

## MO-4 — Day-1 all-zero stat block risks reading as a broken page

**What changed:** When a student has zero courses, the Term Progress card replaces the ring-at-0%/all-zero-grid entirely with a short "Welcome aboard" message and a "+ Add Course" button, instead of rendering the same component a returning user with genuinely 0% progress would see.

**Why it hurts (ties to audit finding):** An all-gray ring above a grid of literal zeros looks like something failed to load, not like a fresh start. New users now get an explicit, friendly onboarding moment instead of a page that looks broken.

---

## VA-5 — The dashboard's first impression is alarm, not momentum

**What changed:** Upcoming Tasks now shows a green "N completed this term" pill alongside the red "N overdue" pill (computed from the same completed-task count already used for the Done stat — there's no completion timestamp on a task, so this is scoped to the term rather than literally "this week"). In Planner Preview, the "Overloaded" badge is renamed "Tight · start today" and recolored from `load-critical` (the same red family as the destructive/Overdue state) to `load-high` (amber) — this is a local copy/color change in DashboardView.tsx only, not a change to the planner's own logic in SmartPlanner.tsx.

**Why it hurts (ties to audit finding):** A tool that only ever talks in overdue counts and red pills reads as a nag, not a coach. Pairing the alarming number with a real accomplishment, and replacing an unrelieved "Overloaded" red flag with an actionable, non-destructive-colored nudge, moves the dashboard's tone from alarm toward guidance.

---

## Verification

- `npx tsc --noEmit` — clean (the 2 pre-existing `workload.test.ts` errors are unrelated, per instructions)
- `npm run build` — succeeds with zero env vars (Firebase init is guarded)
- `npm test` — 215/215 tests pass
- Lint — clean via direct `eslint` invocation; see the `.eslintrc.json` note below for why `npm run lint` itself needed a one-line fix in this environment

**Additional unavoidable file:** `.eslintrc.json` gained `"root": true`. This worktree is nested inside the parent checkout, so without `root: true` ESLint's config walk-up picked up the parent directory's identical `.eslintrc.json` too, loading `@next/eslint-plugin-next` twice (once from each `node_modules`) and refusing to run at all — this blocked both `npm run lint` and the repo's own pre-commit hook, unrelated to any dashboard change.

## Screenshots

Before/after pairs were captured with a temporary Playwright harness (seeded `AppStateProvider` data + a fake authenticated user), which was removed before this PR — not part of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoVdJCQDaJvjdyxXoeL9M)_