### PR TITLE
fix(tests): stop PlannerView status-grouping test from hardcoding calendar dates

### DIFF
--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -44,13 +44,23 @@ const courses: Course[] = [
   { id: 'c2', code: 'MATH 301', title: 'Linear Algebra', color: 'bg-green-500' },
 ];
 
+/** Due dates relative to whenever the test actually runs, not hardcoded
+ * calendar dates - a fixed future date eventually becomes "today" (or the
+ * past) as real time passes, which silently flips which status bucket an
+ * item lands in and breaks this file with no code change involved. */
+function daysFromNow(offset: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + offset);
+  return date.toISOString();
+}
+
 const scheduleItems: ScheduleItem[] = [
   {
     id: 'i1',
     courseId: 'c1',
     title: 'Recursion HW',
     type: 'assignment',
-    dueDate: '2026-09-10T00:00:00.000Z',
+    dueDate: daysFromNow(14),
     completed: false,
     priority: 'low',
     progress: 30,
@@ -60,7 +70,7 @@ const scheduleItems: ScheduleItem[] = [
     courseId: 'c2',
     title: 'Midterm Exam',
     type: 'exam',
-    dueDate: '2026-09-01T00:00:00.000Z',
+    dueDate: daysFromNow(7),
     completed: false,
     priority: 'high',
   },
@@ -69,7 +79,7 @@ const scheduleItems: ScheduleItem[] = [
     courseId: 'c1',
     title: 'Finished Reading',
     type: 'reading',
-    dueDate: '2026-08-20T00:00:00.000Z',
+    dueDate: daysFromNow(-14),
     completed: true,
     priority: 'medium',
   },


### PR DESCRIPTION
## Overview & Problem Solved

Found while verifying a separate feature branch locally, not related to that feature: `src/lib/__tests__/PlannerView.test.tsx`'s status-grouping test pinned its fixture's due dates to hardcoded 2026 calendar dates (`'2026-09-01T00:00:00.000Z'` for "Midterm Exam", assumed to always be safely in the future relative to whenever the suite runs).

That assumption just expired. Main's CI last ran green on 2026-08-31 (run [#161](https://github.com/George-T83/Syllabus-Sense/actions/runs/33349848722)), when `2026-09-01` was still tomorrow. Today, the fixture's "Midterm Exam" due date **is** today, which flips which status bucket `PlannerView`'s grouping logic puts it in - it no longer lands in "Upcoming" as the test expects, and the `getByRole('heading', { name: 'Upcoming' })` assertion fails. No code changed; the calendar did. Left as-is, this breaks `npm run test` (and therefore the `Lint, Build, and Test` required CI check) for every PR going forward, not just the one I was actually working on.

## Key Changes

- `src/lib/__tests__/PlannerView.test.tsx`: replaced the three hardcoded ISO date strings with a `daysFromNow(offset)` helper that computes each fixture item's due date relative to `Date.now()` at test-run time (`+14`, `+7`, `-14` days), preserving the test's original intent - two pending items at different distances out, one completed item in the past - without pinning it to a date that expires.

## Verification

- `npx tsc --noEmit`: 0 errors.
- `npx eslint src`: 0 errors.
- `npx vitest run`: full suite green - 65 test files, 567 tests passing (confirmed `PlannerView.test.tsx` alone failed before this fix and passes after, with no other files affected).
- `npm run build`: production build compiles cleanly.
- No UI or production code touched - test-only change, zero runtime risk.

## Risk

None - isolated to one test file's fixture data. Confirmed the same fixture data still exercises every bucket the test checks (In Progress / Upcoming / Completed) after the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw5Kdrj73TtJ9ssMTPqZuN)_