### PR TITLE
feat(security): rate limiting and DDoS prevention on public API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,14 @@ NEXT_PUBLIC_FIRESTORE_DATABASE_ID=your-value-here
 # Set to 'true' to run the Local Emulator Suite in local development, or 'false' otherwise.
 NEXT_PUBLIC_USE_FIREBASE_EMULATOR=false
 
+# Rate limiting (optional, recommended for production)
+# API rate limiting (src/lib/security/rateLimit.ts) works with zero config -
+# it falls back to an in-memory limiter that's correct on a single warm
+# instance but resets on cold start and doesn't share state across Vercel's
+# concurrent Lambda instances. Set both of these (a free Upstash Redis
+# database's REST credentials - https://upstash.com) to get a real
+# distributed limiter that's accurate across every instance and region.
+# Leave unset for local dev; the in-memory fallback is fine there.
+UPSTASH_REDIS_REST_URL=your-value-here
+UPSTASH_REDIS_REST_TOKEN=your-value-here
+

--- a/src/app/api/auth/reset-password/__tests__/resetPasswordRoute.test.ts
+++ b/src/app/api/auth/reset-password/__tests__/resetPasswordRoute.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { __resetMemoryRateLimitStore } from '@/lib/security/rateLimit';
+
+const mockGeneratePasswordResetLink = vi.fn();
+
+vi.mock('@/lib/firebase/admin', () => ({
+  adminAuth: {
+    generatePasswordResetLink: (...args: unknown[]) => mockGeneratePasswordResetLink(...args),
+  },
+}));
+
+vi.mock('@/lib/email/passwordResetEmailTemplate', () => ({
+  renderPasswordResetEmailHtml: () => '<html>reset</html>',
+}));
+
+import { POST } from '@/app/api/auth/reset-password/route';
+
+function makeRequest(email: string | undefined, ip = '203.0.113.7') {
+  return new NextRequest('http://localhost:3000/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': ip },
+    body: JSON.stringify({ email }),
+  });
+}
+
+describe('/api/auth/reset-password route contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetMemoryRateLimitStore();
+    mockGeneratePasswordResetLink.mockResolvedValue('https://example.com/reset?oob=abc');
+  });
+
+  it('rejects a request with no email with 400', async () => {
+    const res = await POST(makeRequest(undefined, '203.0.113.100'));
+    expect(res.status).toBe(400);
+  });
+
+  it('generates a reset link for a valid request', async () => {
+    const res = await POST(makeRequest('student@example.edu', '203.0.113.101'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockGeneratePasswordResetLink).toHaveBeenCalledWith(
+      'student@example.edu',
+      expect.any(Object),
+    );
+  });
+
+  it('rate-limits a single IP after 5 requests within the window (429)', async () => {
+    const ip = '203.0.113.42';
+    for (let i = 0; i < 5; i++) {
+      const res = await POST(makeRequest('student@example.edu', ip));
+      expect(res.status).not.toBe(429);
+    }
+
+    const blocked = await POST(makeRequest('student@example.edu', ip));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+    // The 6th call to generatePasswordResetLink never happens - blocked
+    // before any Firebase Admin or email work is done.
+    expect(mockGeneratePasswordResetLink).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not let a different IP be blocked by another IP exhausting its budget', async () => {
+    const exhaustedIp = '203.0.113.50';
+    for (let i = 0; i < 6; i++) {
+      await POST(makeRequest('student@example.edu', exhaustedIp));
+    }
+
+    const otherIpRes = await POST(makeRequest('student@example.edu', '203.0.113.51'));
+    expect(otherIpRes.status).toBe(200);
+  });
+});

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,9 +1,23 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { adminAuth } from '@/lib/firebase/admin';
 import { renderPasswordResetEmailHtml } from '@/lib/email/passwordResetEmailTemplate';
+import { checkRateLimit } from '@/lib/security/rateLimit';
+import { getClientIp, rateLimitedResponse } from '@/lib/security/rateLimitResponse';
 import nodemailer from 'nodemailer';
 
-export async function POST(request: Request) {
+// No auth token exists yet at this point in the flow (that's the whole
+// point of password reset), so this is the most exposed route in the app -
+// anyone can POST an arbitrary email and trigger a Firebase Admin call plus
+// an outbound email send. Limited tightly (5 / 10 min) per client IP to stop
+// both a spam/cost DDoS and email-enumeration-by-timing abuse.
+const RESET_PASSWORD_RATE_LIMIT = { limit: 5, windowMs: 10 * 60_000 };
+
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limitResult = await checkRateLimit(`ip:${ip}:reset-password`, RESET_PASSWORD_RATE_LIMIT);
+  const blocked = rateLimitedResponse(limitResult);
+  if (blocked) return blocked;
+
   try {
     const { email } = await request.json();
     if (!email) {

--- a/src/app/api/syllabus/chat/route.ts
+++ b/src/app/api/syllabus/chat/route.ts
@@ -3,9 +3,18 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
 import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
 import { generateOfflineSyllabusAnswer, type ChatRequestBody } from '@/lib/syllabus/chatEngine';
+import { checkRateLimit } from '@/lib/security/rateLimit';
+import { getClientIp, rateLimitedResponse } from '@/lib/security/rateLimitResponse';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+// Auth is only enforced here when FIREBASE_ADMIN_PROJECT_ID is set in
+// production (see requireUser below) - in dev, or if that env var is
+// unset, this route is reachable with no token at all. Limited per-uid
+// when authenticated, per-IP otherwise, so an unauthenticated caller can't
+// hide behind "no uid" and skip the limit entirely.
+const CHAT_RATE_LIMIT = { limit: 20, windowMs: 60_000 };
 
 function detectFileKind(fileBase64: string): 'pdf' | 'docx' | null {
   if (fileBase64.startsWith('JVBERi0')) return 'pdf';
@@ -43,6 +52,11 @@ export async function POST(req: NextRequest) {
   if (isProd && !user && process.env.FIREBASE_ADMIN_PROJECT_ID) {
     return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
   }
+
+  const rateLimitKey = user ? `uid:${user.uid}:chat` : `ip:${getClientIp(req)}:chat`;
+  const limitResult = await checkRateLimit(rateLimitKey, CHAT_RATE_LIMIT);
+  const blocked = rateLimitedResponse(limitResult);
+  if (blocked) return blocked;
 
   // Parse file if provided
   let fileKind: 'pdf' | 'docx' | null = null;

--- a/src/app/api/syllabus/extract/__tests__/extractRoute.test.ts
+++ b/src/app/api/syllabus/extract/__tests__/extractRoute.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { __resetMemoryRateLimitStore } from '@/lib/security/rateLimit';
 
 const mockVerifyToken = vi.fn();
 const mockAnthropicCreate = vi.fn();
@@ -22,6 +23,7 @@ import { POST } from '@/app/api/syllabus/extract/route';
 describe('/api/syllabus/extract route contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetMemoryRateLimitStore();
     process.env.FIREBASE_ADMIN_PROJECT_ID = 'test-project';
     mockVerifyToken.mockResolvedValue({ uid: 'user-123' });
   });
@@ -112,5 +114,29 @@ describe('/api/syllabus/extract route contract', () => {
     expect(json.result.course.code).toBe('CS 101');
     expect(json.result.scheduleItems).toHaveLength(1);
     expect(json.result.scheduleItems[0].title).toBe('Problem Set 1');
+  });
+
+  it('rate-limits a single account after 10 requests within a minute (429)', async () => {
+    mockVerifyToken.mockResolvedValue({ uid: 'rate-limit-test-user' });
+    const makeRequest = () =>
+      new NextRequest('http://localhost:3000/api/syllabus/extract', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        // Deliberately not a valid PDF/DOCX - the rate-limit check runs
+        // before file-kind validation, so this only needs to exercise the
+        // request count, not produce a successful extraction.
+        body: JSON.stringify({ fileBase64: 'bm90LWEtcmVhbC1maWxl', fileName: 'x.txt' }),
+      });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(makeRequest());
+      expect(res.status).not.toBe(429);
+    }
+
+    const blockedRes = await POST(makeRequest());
+    expect(blockedRes.status).toBe(429);
+    expect(blockedRes.headers.get('Retry-After')).toBeTruthy();
+    const json = await blockedRes.json();
+    expect(json.error).toMatch(/too many requests/i);
   });
 });

--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -7,11 +7,19 @@ import {
   SYLLABUS_EXTRACTION_TOOL,
 } from '@/lib/ai/syllabusExtractionTool';
 import { syllabusExtractionSchema } from '@/types/extraction';
+import { checkRateLimit } from '@/lib/security/rateLimit';
+import { rateLimitedResponse } from '@/lib/security/rateLimitResponse';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+// A full extraction call is an expensive Anthropic request (up to 8000
+// output tokens against a whole document) - limited per-uid to bound both
+// cost and abuse from a single compromised or scripted account, not just
+// unauthenticated traffic.
+const EXTRACT_RATE_LIMIT = { limit: 10, windowMs: 60_000 };
 
 /**
  * Detected from magic bytes, not the client-declared MIME type (spoofable)
@@ -44,6 +52,10 @@ export async function POST(req: NextRequest) {
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
   }
+
+  const limitResult = await checkRateLimit(`uid:${user.uid}:extract`, EXTRACT_RATE_LIMIT);
+  const blocked = rateLimitedResponse(limitResult);
+  if (blocked) return blocked;
 
   let body: { fileBase64?: string; fileName?: string };
   try {

--- a/src/app/api/syllabus/file/route.ts
+++ b/src/app/api/syllabus/file/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
 import { adminStorage } from '@/lib/firebase/adminStorage';
+import { checkRateLimit } from '@/lib/security/rateLimit';
+import { rateLimitedResponse } from '@/lib/security/rateLimitResponse';
 
 export const runtime = 'nodejs';
+
+// Cheaper per-request than the AI routes, but still a real storage-download
+// cost and a path-enumeration vector - a looser per-uid budget than the AI
+// routes rather than no limit at all.
+const FILE_RATE_LIMIT = { limit: 60, windowMs: 60_000 };
 
 /**
  * Same-origin relay for a syllabus file's bytes, authenticated per-request
@@ -54,6 +61,10 @@ export async function GET(req: NextRequest) {
   if (!path.startsWith(`users/${uid}/`)) {
     return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
   }
+
+  const limitResult = await checkRateLimit(`uid:${uid}:file`, FILE_RATE_LIMIT);
+  const blocked = rateLimitedResponse(limitResult);
+  if (blocked) return blocked;
 
   if (!adminStorage) {
     return NextResponse.json({ error: 'Storage is not configured.' }, { status: 500 });

--- a/src/app/api/syllabus/summarize/route.ts
+++ b/src/app/api/syllabus/summarize/route.ts
@@ -5,9 +5,15 @@ import { adminStorage } from '@/lib/firebase/adminStorage';
 import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
 import { COURSE_SUMMARY_SYSTEM_PROMPT, COURSE_SUMMARY_TOOL } from '@/lib/ai/courseSummaryTool';
 import { courseSummarySchema } from '@/types/courseSummary';
+import { checkRateLimit } from '@/lib/security/rateLimit';
+import { rateLimitedResponse } from '@/lib/security/rateLimitResponse';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
+
+// Same rationale as extract/route.ts - an expensive per-request Anthropic
+// call, limited per-uid to bound cost and abuse.
+const SUMMARIZE_RATE_LIMIT = { limit: 10, windowMs: 60_000 };
 
 async function requireUser(req: NextRequest) {
   const authHeader = req.headers.get('authorization');
@@ -38,6 +44,10 @@ export async function POST(req: NextRequest) {
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
   }
+
+  const limitResult = await checkRateLimit(`uid:${user.uid}:summarize`, SUMMARIZE_RATE_LIMIT);
+  const blocked = rateLimitedResponse(limitResult);
+  if (blocked) return blocked;
 
   let body: { storagePath?: string; fileName?: string };
   try {

--- a/src/lib/security/__tests__/rateLimit.test.ts
+++ b/src/lib/security/__tests__/rateLimit.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkRateLimit, __resetMemoryRateLimitStore } from '../rateLimit';
+
+describe('checkRateLimit (in-memory backend)', () => {
+  beforeEach(() => {
+    __resetMemoryRateLimitStore();
+    // No Upstash env vars set in the test environment, so every check below
+    // exercises the in-memory backend - asserted explicitly via `backend`
+    // on each result rather than assumed.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows requests under the limit and reports remaining budget', async () => {
+    const first = await checkRateLimit('test:a', { limit: 3, windowMs: 60_000 });
+    expect(first.allowed).toBe(true);
+    expect(first.backend).toBe('memory');
+    expect(first.remaining).toBe(2);
+
+    const second = await checkRateLimit('test:a', { limit: 3, windowMs: 60_000 });
+    expect(second.allowed).toBe(true);
+    expect(second.remaining).toBe(1);
+  });
+
+  it('blocks once the limit is exceeded within the window', async () => {
+    const opts = { limit: 2, windowMs: 60_000 };
+    await checkRateLimit('test:b', opts);
+    await checkRateLimit('test:b', opts);
+    const third = await checkRateLimit('test:b', opts);
+
+    expect(third.allowed).toBe(false);
+    expect(third.remaining).toBe(0);
+  });
+
+  it('keeps separate counters per key', async () => {
+    const opts = { limit: 1, windowMs: 60_000 };
+    await checkRateLimit('test:c1', opts);
+    const other = await checkRateLimit('test:c2', opts);
+
+    expect(other.allowed).toBe(true);
+  });
+
+  it('resets the counter once the window elapses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const opts = { limit: 1, windowMs: 1_000 };
+
+    const first = await checkRateLimit('test:d', opts);
+    expect(first.allowed).toBe(true);
+
+    const second = await checkRateLimit('test:d', opts);
+    expect(second.allowed).toBe(false);
+
+    vi.setSystemTime(1_001);
+    const third = await checkRateLimit('test:d', opts);
+    expect(third.allowed).toBe(true);
+  });
+});
+
+describe('checkRateLimit (Upstash backend)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    __resetMemoryRateLimitStore();
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example-upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it('allows a request when the pipelined INCR is under the limit', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ result: 1 }, { result: 1 }],
+    }) as unknown as typeof fetch;
+
+    const result = await checkRateLimit('test:upstash-a', { limit: 5, windowMs: 60_000 });
+
+    expect(result.backend).toBe('upstash');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example-upstash.io/pipeline',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    );
+  });
+
+  it('blocks once the INCR result exceeds the limit', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ result: 6 }, { result: 1 }],
+    }) as unknown as typeof fetch;
+
+    const result = await checkRateLimit('test:upstash-b', { limit: 5, windowMs: 60_000 });
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it('fails open to the in-memory backend when Upstash errors', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+
+    const result = await checkRateLimit('test:upstash-c', { limit: 5, windowMs: 60_000 });
+
+    expect(result.backend).toBe('memory');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('fails open to the in-memory backend when fetch itself throws', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+    const result = await checkRateLimit('test:upstash-d', { limit: 5, windowMs: 60_000 });
+
+    expect(result.backend).toBe('memory');
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/src/lib/security/rateLimit.ts
+++ b/src/lib/security/rateLimit.ts
@@ -1,0 +1,157 @@
+/**
+ * Fixed-window request rate limiting for public/expensive API routes.
+ *
+ * Two backends, chosen automatically:
+ *
+ * - Upstash Redis (REST API, plain `fetch` - no client library needed) when
+ *   `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set. Counters
+ *   live in Redis, so every Vercel Lambda instance (and every region) shares
+ *   the same count - the only backend that's correct under real concurrent
+ *   traffic across serverless instances. This is what production should run.
+ * - In-memory `Map`, otherwise. Correct within a single warm instance, but a
+ *   cold start clears it and a request that lands on a different instance
+ *   gets its own counter - so it under-counts, not over-counts, across
+ *   instances. Good enough for local dev and for a preview deploy without
+ *   Upstash credentials provisioned; not a substitute for Upstash in
+ *   production. `checkRateLimit` reports which backend served a given
+ *   check via the `backend` field so callers/logs can tell the difference.
+ */
+
+export interface RateLimitOptions {
+  /** Max requests allowed inside one window. */
+  limit: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  /** Requests still permitted in the current window (0 once blocked). */
+  remaining: number;
+  /** Unix ms timestamp when the current window resets. */
+  resetAt: number;
+  backend: 'upstash' | 'memory';
+}
+
+interface MemoryBucket {
+  count: number;
+  resetAt: number;
+}
+
+const memoryStore = new Map<string, MemoryBucket>();
+
+// Bounds unbounded growth from a flood of distinct keys (e.g. spoofed
+// X-Forwarded-For values) - once past this size, expired entries are swept
+// before inserting a new one. A real attack generating millions of distinct
+// keys is itself rate-limited by the same check using its own key, so this
+// is a memory backstop, not the primary defense.
+const MAX_MEMORY_ENTRIES = 50_000;
+
+function sweepExpired(now: number) {
+  for (const [key, bucket] of memoryStore) {
+    if (bucket.resetAt <= now) memoryStore.delete(key);
+  }
+}
+
+function checkInMemory(key: string, opts: RateLimitOptions, now: number): RateLimitResult {
+  if (memoryStore.size > MAX_MEMORY_ENTRIES) sweepExpired(now);
+
+  let bucket = memoryStore.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + opts.windowMs };
+    memoryStore.set(key, bucket);
+  }
+
+  bucket.count += 1;
+  const allowed = bucket.count <= opts.limit;
+  return {
+    allowed,
+    limit: opts.limit,
+    remaining: Math.max(0, opts.limit - bucket.count),
+    resetAt: bucket.resetAt,
+    backend: 'memory',
+  };
+}
+
+function upstashConfig(): { url: string; token: string } | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+/**
+ * INCR the window's counter and set its expiry in one round trip via
+ * Upstash's REST pipeline endpoint, keyed so every window gets a fresh
+ * Redis key (`rl:{key}:{windowIndex}`) rather than resetting a shared
+ * counter - avoids a race between "read count" and "reset if expired"
+ * that a plain INCR+TTL-if-absent would otherwise need a Lua script for.
+ */
+async function checkWithUpstash(
+  key: string,
+  opts: RateLimitOptions,
+  now: number,
+  config: { url: string; token: string },
+): Promise<RateLimitResult> {
+  const windowIndex = Math.floor(now / opts.windowMs);
+  const resetAt = (windowIndex + 1) * opts.windowMs;
+  const redisKey = `rl:${key}:${windowIndex}`;
+  const windowSeconds = Math.max(1, Math.ceil(opts.windowMs / 1000));
+
+  const response = await fetch(`${config.url}/pipeline`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([
+      ['INCR', redisKey],
+      ['EXPIRE', redisKey, windowSeconds],
+    ]),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Upstash rate-limit request failed: ${response.status}`);
+  }
+
+  const results = (await response.json()) as Array<{ result: number }>;
+  const count = results[0]?.result ?? 0;
+  const allowed = count <= opts.limit;
+
+  return {
+    allowed,
+    limit: opts.limit,
+    remaining: Math.max(0, opts.limit - count),
+    resetAt,
+    backend: 'upstash',
+  };
+}
+
+/**
+ * Checks and increments the rate-limit counter for `key` (typically
+ * `ip:<addr>` or `uid:<firebase-uid>`). Fails open on an Upstash error
+ * (network blip, misconfigured token) by falling back to the in-memory
+ * backend for that single check - a rate limiter that itself takes the
+ * app down on a transient Redis error is worse than best-effort limiting.
+ */
+export async function checkRateLimit(
+  key: string,
+  opts: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const now = Date.now();
+  const config = upstashConfig();
+  if (config) {
+    try {
+      return await checkWithUpstash(key, opts, now, config);
+    } catch (err) {
+      console.error('Rate limit: Upstash check failed, falling back to in-memory.', err);
+    }
+  }
+  return checkInMemory(key, opts, now);
+}
+
+/** Test-only: clears the in-memory backend's state between test cases. */
+export function __resetMemoryRateLimitStore() {
+  memoryStore.clear();
+}

--- a/src/lib/security/rateLimitResponse.ts
+++ b/src/lib/security/rateLimitResponse.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { RateLimitOptions, RateLimitResult } from './rateLimit';
+
+/**
+ * Best-effort client identity for rate-limit keys. Vercel sets
+ * `x-forwarded-for` to `client, proxy1, proxy2, ...` - the first entry is
+ * the original client. Not spoof-proof (a client can send its own
+ * `x-forwarded-for`), but Vercel's edge network overwrites this header
+ * rather than appending to a client-supplied one, so on Vercel it's
+ * trustworthy; the `'unknown'` fallback keeps every request with no header
+ * present (e.g. local `next dev`) sharing one bucket instead of bypassing
+ * the limit entirely.
+ */
+export function getClientIp(req: NextRequest): string {
+  const forwardedFor = req.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    const first = forwardedFor.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get('x-real-ip') || 'unknown';
+}
+
+function rateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
+  };
+}
+
+/**
+ * Runs a rate-limit check for `key` and returns a ready-to-return 429
+ * response when the caller is over budget, or `null` when the request
+ * should proceed. Callers attach the same rate-limit headers to their own
+ * success response via `rateLimitHeaders(result)` so a client can see its
+ * remaining budget even on a 200.
+ *
+ * ```ts
+ * const ip = getClientIp(req);
+ * const limitResult = await checkRateLimit(`ip:${ip}`, { limit: 5, windowMs: 10 * 60_000 });
+ * const blocked = rateLimitedResponse(limitResult);
+ * if (blocked) return blocked;
+ * ```
+ */
+export function rateLimitedResponse(result: RateLimitResult): NextResponse | null {
+  if (result.allowed) return null;
+
+  const retryAfterSeconds = Math.max(1, Math.ceil((result.resetAt - Date.now()) / 1000));
+  return NextResponse.json(
+    { error: 'Too many requests. Please slow down and try again shortly.' },
+    {
+      status: 429,
+      headers: {
+        ...rateLimitHeaders(result),
+        'Retry-After': String(retryAfterSeconds),
+      },
+    },
+  );
+}
+
+export { rateLimitHeaders };
+export type { RateLimitOptions };


### PR DESCRIPTION
## Overview & Problem Solved

Closes #76 (Epic 10 — Security, Privacy & E2E Testing). No API route in this app enforced any request-rate boundary before this PR:

- `/api/auth/reset-password` is fully unauthenticated — no token exists yet at that point in the flow, by design — so it's reachable by anyone with zero budget. Every call triggers a real Firebase Admin `generatePasswordResetLink` call plus (when SMTP is configured) an outbound email send. That's both a spam/cost DDoS surface and an email-enumeration vector.
- `/api/syllabus/extract` and `/api/syllabus/summarize` require auth, but had no per-account budget on what's a genuinely expensive Anthropic API call (up to 8000 output tokens against a whole document). A single compromised or scripted account could run up real API cost with nothing stopping it.
- `/api/syllabus/chat` only enforces auth in production when `FIREBASE_ADMIN_PROJECT_ID` is set — reachable with no token at all otherwise.
- `/api/syllabus/file` is cheaper per request but still a real Storage download cost and a path-enumeration vector.

## Key Changes

**`src/lib/security/rateLimit.ts`** — a fixed-window rate limiter with two backends, chosen automatically:
- **Upstash Redis** (plain REST `fetch`, no client library added) when `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are configured — a pipelined `INCR` + `EXPIRE` per window-keyed Redis key. This is the only backend that's actually correct across Vercel's concurrent Lambda instances and regions, and is what I'd recommend provisioning for production.
- **In-memory `Map`** fallback otherwise — correct within a single warm instance, resets on cold start, under-counts (not over-counts) across concurrent instances. Zero configuration needed, which is why local dev and this PR's Vercel preview work out of the box with no new secrets.
- Fails open to the in-memory backend if an Upstash call errors or throws, so a transient Redis blip degrades the limiter rather than taking a route down.

**`src/lib/security/rateLimitResponse.ts`** — wraps a rate-limit check into a ready-to-return `429` (with `Retry-After`, `X-RateLimit-Limit/Remaining/Reset` headers), plus `getClientIp()` reading Vercel's `x-forwarded-for`.

**Wired into every route that reaches Anthropic, Storage, or Admin Auth:**

| Route | Limit | Key |
|---|---|---|
| `/api/auth/reset-password` | 5 / 10 min | per IP (only fully public route) |
| `/api/syllabus/extract` | 10 / min | per uid |
| `/api/syllabus/summarize` | 10 / min | per uid |
| `/api/syllabus/chat` | 20 / min | per uid, or per IP if unauthenticated |
| `/api/syllabus/file` | 60 / min | per uid |

`.env.example` documents the optional Upstash variables and explains the in-memory fallback tradeoff.

## Verification

- **TypeScript / ESLint**: 0 errors.
- **Unit tests**: new `rateLimit.test.ts` covers both backends directly (window accounting, blocking, per-key isolation, window reset via fake timers, Upstash pipeline call shape, and fail-open behavior on Upstash error/throw — all via a mocked `fetch`). New `resetPasswordRoute.test.ts` and an added case in `extractRoute.test.ts` exercise the routes themselves end-to-end (mocked Firebase/Anthropic), confirming a 429 fires after the configured limit and a *different* key isn't affected by another key's exhausted budget.
- **Full suite**: 580 tests across 67 files — every test I touched or added passes. ⚠️ 5 tests in `PlannerView.test.tsx` fail on this branch, but that's a **pre-existing, unrelated bug** (hardcoded calendar dates in a test fixture that just became "today") already fixed in #188, opened separately since it affects every branch cut from `main` right now, not just this one. I'll merge `main` into this branch once #188 lands so this PR's CI goes fully green.
- **Live-verified against a running server**, not just mocked tests: `npm run dev`, then `curl -X POST /api/auth/reset-password` 6 times in a row — first 5 return normal responses, 6th returns a real `429` with `Retry-After: 600`, `X-RateLimit-Limit: 5`, `X-RateLimit-Remaining: 0`.
- **Production build**: compiles cleanly, all 5 API routes still listed correctly in the route manifest.

## Risk

Low. Every change is additive (new files, or a new check inserted before existing route logic) — no existing behavior changed for a request that stays under budget. The in-memory fallback's under-counting-across-instances is a known, documented tradeoff, not a bug; recommend provisioning Upstash for production-grade accuracy (details in `.env.example`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw5Kdrj73TtJ9ssMTPqZuN)_