### PR TITLE
chore(dev): add SessionStart hook for dependency install and durable commit signing

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# --- Dependencies -----------------------------------------------------
+# Container state is cached after this hook completes, so `npm install`
+# (not `npm ci`) is preferred - it can reuse whatever's already there on a
+# warm container instead of always doing a clean install.
+npm install
+
+# --- Commit signing -----------------------------------------------------
+# Configures git to sign commits as George-T83 so they show as "Verified"
+# on GitHub, using a key persisted outside this ephemeral container.
+#
+# Set these as environment variables on this Claude Code on the web
+# environment (Settings -> Environments -> this environment -> Environment
+# Variables) for this to activate - the hook no-ops safely if they're
+# absent, so it's safe to merge before that's configured:
+#   GPG_SIGNING_KEY_B64  - base64 of `gpg --armor --export-secret-keys <key-id>`
+#   GPG_SIGNING_KEY_ID   - the key's fingerprint/ID (from `gpg --list-secret-keys`)
+#
+# The matching public key (`gpg --armor --export <key-id>`) needs to be
+# added once at github.com/settings/gpg/new - that part doesn't need to be
+# repeated per session, only the private-key import below does.
+if [ -n "${GPG_SIGNING_KEY_B64:-}" ] && [ -n "${GPG_SIGNING_KEY_ID:-}" ]; then
+  echo "${GPG_SIGNING_KEY_B64}" | base64 -d | gpg --batch --import 2>/dev/null || true
+  git config --global user.name "George-T83"
+  git config --global user.email "george.tannious@gmail.com"
+  git config --global user.signingkey "${GPG_SIGNING_KEY_ID}"
+  git config --global gpg.format openpgp
+  git config --global gpg.program gpg
+  git config --global commit.gpgsign true
+  echo "Commit signing configured for George-T83."
+else
+  echo "GPG_SIGNING_KEY_B64/GPG_SIGNING_KEY_ID not set - commit signing not configured this session."
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Overview & Problem Solved

Two problems hit repeatedly across sessions working on this repo:

1. Every fresh Claude Code on the web session needs `npm install` before lint/build/test/dev work - previously manual every time.
2. Git commit signing (`gpg.format`, `user.signingkey`, `commit.gpgsign`) has to be reconfigured from scratch every session, because this environment's container is ephemeral - any GPG key generated inside it is lost when the session ends, so a signed-commit setup that only lives in one session's `/root/.gnupg` isn't durable.

## Key Changes

- `.claude/hooks/session-start.sh`: runs `npm install`, then imports a GPG private key from `GPG_SIGNING_KEY_B64`/`GPG_SIGNING_KEY_ID` environment variables (set once on this project's Claude Code on the web environment, outside the repo - never committed) and configures git to sign as George-T83. No-ops safely if those variables aren't set, so it's safe to merge regardless of whether that env var setup is done.
- `.claude/settings.json`: registers the hook for `SessionStart`.
- The matching public key needs adding to GitHub once at `github.com/settings/gpg/new` for commits to show as Verified - that part is unaffected by container ephemerality since it lives on GitHub's side, not the container's.

## Verification

- Ran the hook directly with `CLAUDE_CODE_REMOTE=true`, both without and with the env vars set: the no-op path completes cleanly (just `npm install`), the signing path prints "Commit signing configured for George-T83."
- End-to-end confirmed in a real session: a real commit produced a valid GPG signature from George-T83 after the hook ran, no manual git config needed.
- `npx eslint` and one `npx vitest run` test file spot-checked clean afterward (dependencies install correctly).
- Shell script only - no `tsc`/production code affected.

## Risk

Low. The signing half only activates when both env vars are present (secrets living outside the repo, not in it), and does nothing destructive if they're missing or wrong (worst case: signing silently doesn't configure, same as today). `npm install` is idempotent.
