### PR TITLE
test(planner): make PlannerView test due dates relative, not hardcoded

### DIFF
--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -44,13 +44,25 @@ const courses: Course[] = [
   { id: 'c2', code: 'MATH 301', title: 'Linear Algebra', color: 'bg-green-500' },
 ];
 
+// Due dates are relative to whenever the suite actually runs, not hardcoded
+// calendar dates - a hardcoded date eventually lands in the past and flips
+// items between the Overdue/In Progress/Upcoming buckets, breaking the
+// 'groups by status' assertions below. Recursion HW and Midterm Exam both
+// stay comfortably in the future (isOverdue only trips once dueDate < now),
+// while keeping Midterm Exam's due date earlier than Recursion HW's
+// preserves the due-date ordering the other tests assert on.
+const DAY_MS = 24 * 60 * 60 * 1000;
+function daysFromNow(days: number): string {
+  return new Date(Date.now() + days * DAY_MS).toISOString();
+}
+
 const scheduleItems: ScheduleItem[] = [
   {
     id: 'i1',
     courseId: 'c1',
     title: 'Recursion HW',
     type: 'assignment',
-    dueDate: '2026-09-10T00:00:00.000Z',
+    dueDate: daysFromNow(30),
     completed: false,
     priority: 'low',
     progress: 30,
@@ -60,7 +72,7 @@ const scheduleItems: ScheduleItem[] = [
     courseId: 'c2',
     title: 'Midterm Exam',
     type: 'exam',
-    dueDate: '2026-09-01T00:00:00.000Z',
+    dueDate: daysFromNow(10),
     completed: false,
     priority: 'high',
   },
@@ -69,7 +81,7 @@ const scheduleItems: ScheduleItem[] = [
     courseId: 'c1',
     title: 'Finished Reading',
     type: 'reading',
-    dueDate: '2026-08-20T00:00:00.000Z',
+    dueDate: daysFromNow(-14),
     completed: true,
     priority: 'medium',
   },


### PR DESCRIPTION
## What changed

`PlannerView.test.tsx` hardcoded absolute due dates (`2026-09-01`, `2026-09-10`) for its fixture schedule items. `isOverdue()` compares an item's due date against `new Date()` at render time, so once real time passed `2026-09-01`, "Midterm Exam" flipped from the Upcoming bucket into Overdue — and the `'groups by status into Overdue/In Progress/Upcoming/Completed'` test's assertion for the "Upcoming" heading started failing, since nothing was left in that bucket. Confirmed this is exactly what was happening: CI on `main` currently fails the same way, and PR #192 (unrelated Firestore rules work) picked up the identical failure just from being based on `main`.

Fix: due dates are now computed relative to `Date.now()` instead of hardcoded, so the Overdue/In Progress/Upcoming/Completed split stays correct no matter when the suite runs. Midterm Exam's due date is still kept earlier than Recursion HW's, preserving the due-date ordering the other tests in the file assert on.

## Why

This is a pre-existing, unrelated bug independent of any other in-flight work — a "ticking time bomb" hardcoded date, not a PlannerView regression. It currently blocks CI (and therefore merging) on every PR in the repo, not just one, so it's worth fixing on its own rather than folding into an unrelated PR's diff.

## How it was verified

- `npx vitest run src/lib/__tests__/PlannerView.test.tsx` — 7/7 pass.
- `npm run test` — full suite, 567/567 pass.
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npm run build` — clean production build.