### PR TITLE
Neon Edge card glow system + workload card rebuild

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -404,9 +404,17 @@
      card whose entire reason for being on screen is "something real is
      happening right now" (the Focus Timer while running, AI syllabus
      extraction, a Smart Plan recalculation, a post-edit syllabus re-diff) -
-     never to a static/settled card, no matter how important. */
+     never to a static/settled card, no matter how important.
+
+     Deliberately does NOT set `position` here: the ::after pseudo-element
+     only needs SOME positioning context on its parent (relative, fixed,
+     absolute, or sticky all work), and every real caller already has one
+     (Card.tsx is always `relative`; PomodoroTimer's floating widget is
+     `fixed`). Forcing `position: relative` here previously won the cascade
+     over Tailwind's `fixed` utility (same "utilities" layer, later in
+     source), silently breaking the Pomodoro widget out of its fixed
+     viewport position and letting it scroll away with the page. */
   .spin-border {
-    position: relative;
     border: 1px solid hsl(var(--border));
     overflow: hidden;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Registered as an <angle> so `.spin-border`'s keyframe can smoothly tween
+   the conic-gradient's rotation instead of the browser treating it as an
+   opaque, non-interpolable custom property value. */
+@property --spin-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
 @layer base {
   :root {
     --background: 240 20% 98%;
@@ -333,6 +342,103 @@
   .dark .glass {
     background-color: rgba(18, 18, 24, 0.94);
     border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  /* Neon Edge: a padding-box/border-box gradient (or solid) card border
+     plus a matching ambient glow, driven entirely by --glow-border/
+     --glow-color so one base rule serves every color variant below.
+     --glow-color is a raw "H S% L%" triple (no hsl() wrapper) so the pulse
+     keyframe can apply its own alpha at each breathing stage. Card.tsx's
+     `accent="glow"` uses .glow-edge-low (the calm, static brand look);
+     WORKLOAD_GLOW_CLASS (lib/workload/uiClasses.ts) picks the level-
+     matched variant for a card whose color should track real severity. */
+  .glow-edge {
+    position: relative;
+    border: 1.5px solid transparent;
+    background:
+      linear-gradient(hsl(var(--card)), hsl(var(--card))) padding-box,
+      var(--glow-border) border-box;
+    box-shadow:
+      var(--card-shadow),
+      0 0 28px -6px hsl(var(--glow-color) / 0.35);
+  }
+  .glow-edge-low {
+    --glow-border: linear-gradient(135deg, #8c6eff, #5b3df5, #00bfa0);
+    --glow-color: var(--primary);
+  }
+  .glow-edge-medium {
+    --glow-border: linear-gradient(135deg, hsl(var(--load-medium)), hsl(var(--load-medium)));
+    --glow-color: var(--load-medium);
+  }
+  .glow-edge-high {
+    --glow-border: linear-gradient(135deg, hsl(var(--load-high)), hsl(var(--load-high)));
+    --glow-color: var(--load-high);
+  }
+  .glow-edge-critical {
+    --glow-border: linear-gradient(135deg, hsl(var(--load-critical)), hsl(var(--load-critical)));
+    --glow-color: var(--load-critical);
+  }
+  /* Only medium/high/critical breathe (WORKLOAD_GLOW_CLASS applies this
+     alongside the color above) - low/calm stays still, matching the
+     Default (locked) static look everywhere else this class is used. */
+  .glow-edge-pulse {
+    animation: glow-edge-pulse 2.6s ease-in-out infinite;
+  }
+  @keyframes glow-edge-pulse {
+    0%,
+    100% {
+      box-shadow:
+        var(--card-shadow),
+        0 0 18px -6px hsl(var(--glow-color) / 0.28);
+    }
+    50% {
+      box-shadow:
+        var(--card-shadow),
+        0 0 52px -2px hsl(var(--glow-color) / 0.65);
+    }
+  }
+
+  /* Reusable "actively processing" card edge: a comet-like arc in the brand
+     gradient continuously sweeps the card's own perimeter, built by masking
+     a rotating conic-gradient down to just the border ring. Apply to any
+     card whose entire reason for being on screen is "something real is
+     happening right now" (the Focus Timer while running, AI syllabus
+     extraction, a Smart Plan recalculation, a post-edit syllabus re-diff) -
+     never to a static/settled card, no matter how important. */
+  .spin-border {
+    position: relative;
+    border: 1px solid hsl(var(--border));
+    overflow: hidden;
+  }
+  .spin-border::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    padding: 1.5px;
+    background: conic-gradient(
+      from var(--spin-angle),
+      transparent 0deg,
+      hsl(var(--primary) / 0) 0deg,
+      #8c6eff 20deg,
+      #5b3df5 45deg,
+      #00bfa0 65deg,
+      hsl(var(--primary) / 0) 95deg,
+      transparent 360deg
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    animation: spin-border-sweep 3.4s linear infinite;
+    pointer-events: none;
+  }
+  @keyframes spin-border-sweep {
+    to {
+      --spin-angle: 360deg;
+    }
   }
 
   /* Respect the OS-level "reduce motion" preference by collapsing every

--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -84,7 +84,8 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   // A summary generated from a since-deleted/replaced file is still shown -
   // it's better to have slightly stale info clearly labeled with its source
   // than to silently discard a real Anthropic result.
-  const isStale = !!summary && !!latestSyllabus && summary.sourceFileName !== latestSyllabus.fileName;
+  const isStale =
+    !!summary && !!latestSyllabus && summary.sourceFileName !== latestSyllabus.fileName;
 
   // CO-4: this card used to return null with no syllabus on file, so a fresh
   // course page showed nothing between the dropzone and Tasks - zero
@@ -95,7 +96,7 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   // "broken/missing".
   if (!latestSyllabus) {
     return (
-      <Card className="rounded-2xl border-dashed p-6 opacity-90">
+      <Card accent="none" className="rounded-2xl border-dashed p-6 opacity-90">
         <div className="flex items-center gap-2.5">
           <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
             <svg

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -197,7 +197,7 @@ export function PomodoroTimer({ taskId }: PomodoroTimerProps = {}) {
       role="dialog"
       aria-label="Pomodoro focus timer"
       className={cn(
-        'fixed bottom-20 left-5 z-50 rounded-2xl bg-card p-4 shadow-2xl w-52 md:bottom-6 md:left-6',
+        'fixed bottom-20 left-5 z-50 rounded-2xl bg-card p-4 shadow-2xl w-60 md:bottom-6 md:left-6',
         // Neon Edge "actively processing" sweep - only while genuinely
         // counting down. Paused or idle, this is just a plain bordered
         // card; running is the one state where "time is passing" is true.

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -196,108 +196,123 @@ export function PomodoroTimer({ taskId }: PomodoroTimerProps = {}) {
     <div
       role="dialog"
       aria-label="Pomodoro focus timer"
-      className="fixed bottom-20 left-5 z-50 flex flex-col items-center gap-3 rounded-2xl border border-border bg-card p-4 shadow-2xl w-52 md:bottom-6 md:left-6"
-    >
-      {/* Header */}
-      <div className="flex w-full items-center justify-between">
-        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          {isBreak ? '☕ Break' : '🍅 Focus'}
-        </span>
-        <button
-          onClick={() => setVisible(false)}
-          aria-label="Close focus timer"
-          className="rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-        >
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-
-      {/* Circular progress + time */}
-      <div className="relative flex h-24 w-24 items-center justify-center">
-        <svg className="absolute inset-0 -rotate-90" viewBox="0 0 96 96">
-          <circle
-            cx="48"
-            cy="48"
-            r="40"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="6"
-            className="text-border"
-          />
-          <circle
-            cx="48"
-            cy="48"
-            r="40"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="6"
-            strokeDasharray={circumference}
-            strokeDashoffset={circumference * (1 - progress)}
-            strokeLinecap="round"
-            className={cn(
-              'transition-all duration-1000',
-              isBreak ? 'text-emerald-500' : 'text-primary',
-            )}
-          />
-        </svg>
-        <span
-          aria-live="polite"
-          aria-label={`${formatTime(remaining)} remaining`}
-          className="text-2xl font-mono font-bold text-foreground tabular-nums"
-        >
-          {formatTime(remaining)}
-        </span>
-      </div>
-
-      {/* Controls */}
-      <div className="flex items-center gap-1.5">
-        {running ? (
-          <button
-            onClick={handlePause}
-            aria-label="Pause timer"
-            className="rounded-lg border border-border px-3 py-1.5 text-xs font-semibold transition-colors hover:bg-accent"
-          >
-            Pause
-          </button>
-        ) : (
-          <button
-            onClick={handleStart}
-            aria-label="Start timer"
-            className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
-          >
-            Start
-          </button>
-        )}
-        <button
-          onClick={handleReset}
-          aria-label="Reset timer"
-          className="rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent"
-        >
-          Reset
-        </button>
-        <button
-          onClick={handleSkip}
-          aria-label={`Skip to ${isBreak ? 'work' : 'break'}`}
-          className="rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent"
-        >
-          Skip
-        </button>
-      </div>
-
-      {/* Session counter */}
-      {sessionCount > 0 && (
-        <p className="text-center text-[10px] text-muted-foreground">
-          {sessionCount} session{sessionCount !== 1 ? 's' : ''} today 🎉
-        </p>
+      className={cn(
+        'fixed bottom-20 left-5 z-50 rounded-2xl bg-card p-4 shadow-2xl w-52 md:bottom-6 md:left-6',
+        // Neon Edge "actively processing" sweep - only while genuinely
+        // counting down. Paused or idle, this is just a plain bordered
+        // card; running is the one state where "time is passing" is true.
+        running ? 'spin-border' : 'border border-border',
       )}
+    >
+      <div className="relative z-10 flex flex-col items-center gap-3">
+        {/* Header */}
+        <div className="flex w-full items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {isBreak ? '☕ Break' : '🍅 Focus'}
+          </span>
+          <button
+            onClick={() => setVisible(false)}
+            aria-label="Close focus timer"
+            className="rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Circular progress + time - the focus ring's stroke is always the
+            brand gradient (Neon Edge identity, visible even while paused);
+            a break keeps its own distinct emerald so "resting" never reads
+            as "focusing." */}
+        <div className="relative flex h-24 w-24 items-center justify-center">
+          <svg className="absolute inset-0 -rotate-90" viewBox="0 0 96 96">
+            <defs>
+              <linearGradient id="pomodoroFocusGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="#8c6eff" />
+                <stop offset="55%" stopColor="#5b3df5" />
+                <stop offset="100%" stopColor="#00bfa0" />
+              </linearGradient>
+            </defs>
+            <circle
+              cx="48"
+              cy="48"
+              r="40"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="6"
+              className="text-border"
+            />
+            <circle
+              cx="48"
+              cy="48"
+              r="40"
+              fill="none"
+              stroke={isBreak ? undefined : 'url(#pomodoroFocusGradient)'}
+              strokeWidth="6"
+              strokeDasharray={circumference}
+              strokeDashoffset={circumference * (1 - progress)}
+              strokeLinecap="round"
+              className={cn('transition-all duration-1000', isBreak && 'text-emerald-500')}
+            />
+          </svg>
+          <span
+            aria-live="polite"
+            aria-label={`${formatTime(remaining)} remaining`}
+            className="text-2xl font-mono font-bold text-foreground tabular-nums"
+          >
+            {formatTime(remaining)}
+          </span>
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center gap-1.5">
+          {running ? (
+            <button
+              onClick={handlePause}
+              aria-label="Pause timer"
+              className="rounded-lg border border-border px-3 py-1.5 text-xs font-semibold transition-colors hover:bg-accent"
+            >
+              Pause
+            </button>
+          ) : (
+            <button
+              onClick={handleStart}
+              aria-label="Start timer"
+              className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+            >
+              Start
+            </button>
+          )}
+          <button
+            onClick={handleReset}
+            aria-label="Reset timer"
+            className="rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent"
+          >
+            Reset
+          </button>
+          <button
+            onClick={handleSkip}
+            aria-label={`Skip to ${isBreak ? 'work' : 'break'}`}
+            className="rounded-lg border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent"
+          >
+            Skip
+          </button>
+        </div>
+
+        {/* Session counter */}
+        {sessionCount > 0 && (
+          <p className="text-center text-[10px] text-muted-foreground">
+            {sessionCount} session{sessionCount !== 1 ? 's' : ''} today 🎉
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -245,7 +245,10 @@ export function SmartPlanner() {
 
       {/* Dedicated Overdue Backlog Section */}
       {plan.overdueItems.length > 0 && (
-        <Card className="rounded-2xl border-destructive/30 bg-destructive/5 p-4 sm:p-6">
+        <Card
+          accent="none"
+          className="rounded-2xl border-destructive/30 bg-destructive/5 p-4 sm:p-6"
+        >
           <div className="mb-3 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <span className="flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-[11px] font-bold text-destructive-foreground">

--- a/src/components/planner/WorkloadOverviewDashboard.tsx
+++ b/src/components/planner/WorkloadOverviewDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import { useAppState } from '@/context/AppStateContext';
 import {
   calculateWorkloadBreakdown,
@@ -13,7 +13,12 @@ import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useAuth } from '@/context/AuthContext';
 import { cn } from '@/lib/utils';
 import { toLocalDateStr } from '@/lib/planner/projectChunker';
-import { WORKLOAD_BADGE_CLASS } from '@/lib/workload';
+import {
+  WORKLOAD_BADGE_CLASS,
+  WORKLOAD_SWATCH_CLASS,
+  WORKLOAD_TEXT_CLASS,
+  WORKLOAD_GLOW_CLASS,
+} from '@/lib/workload';
 import type { ScheduleItem, WorkloadLevel } from '@/types/schedule';
 
 // This dashboard's "how busy is this day" scale comes from the chunker's own
@@ -27,16 +32,6 @@ const INTENSITY_TO_LEVEL: Record<WorkloadIntensity, WorkloadLevel> = {
   light: 'low',
   moderate: 'medium',
   heavy: 'critical',
-};
-
-/** Day-tile border/background per level, including hover - kept as literal
- * class strings (not built with template interpolation) so Tailwind's
- * static scanner can see them. */
-const DAY_TILE_LEVEL_CLASS: Record<WorkloadLevel, string> = {
-  low: 'border-load-low/30 bg-load-low/10 hover:bg-load-low/15',
-  medium: 'border-load-medium/30 bg-load-medium/10 hover:bg-load-medium/15',
-  high: 'border-load-high/30 bg-load-high/10 hover:bg-load-high/15',
-  critical: 'border-load-critical/40 bg-load-critical/10 hover:bg-load-critical/15',
 };
 
 export interface WorkloadOverviewDashboardProps {
@@ -81,6 +76,24 @@ export function WorkloadOverviewDashboard({
   }, [selectedDayDate, breakdown]);
 
   const activeDayHours = (activeDay.totalMinutes / 60).toFixed(1);
+
+  // Forecast bar widths are relative to the busiest of the visible 7 days,
+  // not an absolute hour scale - so the shape of the week reads clearly
+  // whether it's a light syllabus-free week or exam season. Floored at 4%
+  // so a genuinely empty day still shows a sliver rather than nothing.
+  const maxMinutes = useMemo(
+    () => Math.max(...breakdown.next7Days.map((d) => d.totalMinutes), 1),
+    [breakdown.next7Days],
+  );
+
+  // The Workload Load card's Neon Edge glow escalates with how heavy the
+  // inspected day actually is - a rollover/overdue task forces it to the
+  // loudest (critical) tier regardless of computed intensity, since an
+  // overdue item is urgent no matter how few hours it's estimated at.
+  const hasRollover = activeDay.items.some((item) => item.isRollover);
+  const glowLevel: WorkloadLevel = hasRollover
+    ? 'critical'
+    : INTENSITY_TO_LEVEL[activeDay.intensity];
 
   const handleToggleTask = async (taskId: string) => {
     if (onToggleComplete) {
@@ -164,22 +177,41 @@ export function WorkloadOverviewDashboard({
         </button>
       </Card>
 
-      {/* Grid: Day Details & Workload Load + 7-Day Forecast Grid */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Selected Day Workload Meter & Task Inspector */}
-        <Card className="lg:col-span-1 p-5">
-          <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
+      {/* Grid: Day Details & Workload Load + 7-Day Forecast Grid. Stacks
+          full-width up through `lg` (1024px) and only splits into columns
+          at `xl` (1280px) - at `lg` a 1/3-width Workload Load card is too
+          narrow for its own header badge, stat, and the task list's date-
+          shifter row to sit comfortably, so the extra headroom matters more
+          than an earlier-triggering two-column layout. */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        {/* Selected Day Workload Meter & Task Inspector - Neon Edge glow
+            escalates with glowLevel (low = calm brand violet and still;
+            medium/high/critical progress through amber/orange/red and
+            breathe), so a genuinely heavy or overdue day is visibly louder
+            than a merely busy one instead of every non-quiet day getting
+            an identical fixed "urgent" treatment. */}
+        <Card className={cn('xl:col-span-1 p-5', WORKLOAD_GLOW_CLASS[glowLevel])}>
+          <CardHeader className="flex-row items-start justify-between gap-3 space-y-0 border-b border-border p-0 pb-5">
             <div>
-              <CardTitle className="text-sm font-bold text-foreground">
-                Workload Load ({activeDay.dayName}, {activeDay.formattedDate})
-              </CardTitle>
-              {activeDay.dateStr === breakdown.today.dateStr && (
-                <span className="text-[10px] font-bold text-primary">● Today</span>
-              )}
+              <CardTitle>Workload Load</CardTitle>
+              {/* "Today" reads as a suffix on the date rather than its own
+                  floating badge - two differently-styled pills stacked on
+                  top of each other read as clutter, not information. */}
+              <CardDescription className="mt-1 flex flex-wrap items-center gap-1.5">
+                <span>
+                  {activeDay.dayName}, {activeDay.formattedDate}
+                </span>
+                {activeDay.dateStr === breakdown.today.dateStr && (
+                  <span className="inline-flex items-center gap-1 font-bold text-primary">
+                    <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                    Today
+                  </span>
+                )}
+              </CardDescription>
             </div>
             <span
               className={cn(
-                'rounded-full px-2.5 py-0.5 text-[10px] font-bold capitalize',
+                'shrink-0 rounded-full px-2.5 py-1 text-[10px] font-bold capitalize',
                 WORKLOAD_BADGE_CLASS[INTENSITY_TO_LEVEL[activeDay.intensity]],
               )}
             >
@@ -187,14 +219,14 @@ export function WorkloadOverviewDashboard({
             </span>
           </CardHeader>
 
-          <CardContent className="p-0 pt-2 space-y-4">
-            <div className="flex items-baseline justify-between border-b border-border/50 pb-3">
-              <div>
-                <span className="text-3xl font-extrabold text-foreground">
-                  {activeDayHours} hrs
-                </span>
-                <span className="text-xs text-muted-foreground"> total scheduled study load</span>
-              </div>
+          <CardContent className="p-0 pt-5 space-y-4">
+            <div className="border-b border-border/50 pb-4">
+              <span className="block text-3xl font-extrabold text-foreground">
+                {activeDayHours} hrs
+              </span>
+              <span className="mt-2 block text-xs font-semibold text-muted-foreground">
+                total scheduled study load
+              </span>
             </div>
 
             {/* Task list for selected day with manual date shifter */}
@@ -299,56 +331,62 @@ export function WorkloadOverviewDashboard({
           </CardContent>
         </Card>
 
-        {/* Weekly Workload Schedule (Interactive 7-Day Forecast Grid) */}
-        <Card className="lg:col-span-2 p-5">
-          <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
-            <div>
-              <CardTitle className="text-sm font-bold text-foreground">
-                7-Day Workload Forecast ({breakdown.thisWeek.weekLabel})
-              </CardTitle>
-              <p className="text-xs text-muted-foreground">
-                Click any day to inspect tasks or manually shift bites to balance heavy days.
-              </p>
-            </div>
+        {/* Weekly Workload Schedule - a single scannable list of rows
+            (day/date, a bar proportional to the week's busiest day, hours,
+            item count, intensity) rather than seven separate tiles, so
+            relative load reads top-to-bottom instead of being eyeballed
+            across seven disconnected boxes. Always the calm, static brand
+            Neon Edge (accent="glow") - this card never pulses; severity
+            escalation belongs to the Workload Load card's own glow. */}
+        <Card accent="glow" className="xl:col-span-2 p-5">
+          <CardHeader className="space-y-0 border-b border-border p-0 pb-5">
+            <CardTitle>7-Day Forecast</CardTitle>
+            <CardDescription className="mt-1">{breakdown.thisWeek.weekLabel}</CardDescription>
           </CardHeader>
-          <CardContent className="p-0 pt-3">
-            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4 lg:grid-cols-7">
+          <CardContent className="p-0 pt-1">
+            <div className="divide-y divide-border">
               {breakdown.next7Days.map((day) => {
                 const hrs = (day.totalMinutes / 60).toFixed(1);
                 const isSelected = activeDay.dateStr === day.dateStr;
+                const level = INTENSITY_TO_LEVEL[day.intensity];
+                const barPct = Math.max(4, (day.totalMinutes / maxMinutes) * 100);
 
                 return (
                   <button
                     key={day.dateStr}
                     type="button"
                     onClick={() => setSelectedDayDate(day.dateStr)}
+                    aria-current={isSelected}
                     className={cn(
-                      'flex flex-col justify-between rounded-2xl border p-3 text-center transition-all focus:outline-none focus:ring-2 focus:ring-primary',
-                      isSelected && 'ring-2 ring-primary border-primary',
-                      DAY_TILE_LEVEL_CLASS[INTENSITY_TO_LEVEL[day.intensity]],
+                      'grid w-full grid-cols-[3.25rem_1fr_auto] items-center gap-3 px-1 py-3 text-left transition-colors hover:bg-accent/40 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-inset sm:grid-cols-[4rem_1fr_auto_auto_4.5rem]',
+                      isSelected && 'bg-primary/5',
                     )}
                   >
-                    <div>
-                      <span className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
-                        {day.dayName}
-                      </span>
-                      <p className="text-xs font-semibold text-foreground mt-0.5">
+                    <span className="text-xs font-bold text-foreground">
+                      {day.dayName}
+                      <span className="block text-[10px] font-medium text-muted-foreground">
                         {day.formattedDate}
-                      </p>
-                    </div>
-
-                    <div className="my-3">
-                      <span className="text-lg font-extrabold text-foreground">{hrs}h</span>
-                      <p className="text-[10px] text-muted-foreground">{day.items.length} items</p>
-                    </div>
-
+                      </span>
+                    </span>
+                    <span className="hidden h-1.5 overflow-hidden rounded-full bg-muted sm:block">
+                      <span
+                        className={cn('block h-full rounded-full', WORKLOAD_SWATCH_CLASS[level])}
+                        style={{ width: `${barPct}%` }}
+                      />
+                    </span>
+                    <span className="text-right text-sm font-bold tabular-nums text-foreground sm:text-left">
+                      {hrs}h
+                    </span>
+                    <span className="hidden whitespace-nowrap text-[11px] text-muted-foreground sm:block">
+                      {day.items.length} {day.items.length === 1 ? 'item' : 'items'}
+                    </span>
                     <span
                       className={cn(
-                        'mt-auto rounded-full py-0.5 text-[9px] font-bold uppercase',
-                        WORKLOAD_BADGE_CLASS[INTENSITY_TO_LEVEL[day.intensity]],
+                        'hidden text-right text-[10px] font-bold uppercase tracking-wide sm:block',
+                        WORKLOAD_TEXT_CLASS[level],
                       )}
                     >
-                      {day.intensity === 'heavy' ? '⚠️ Heavy Peak' : day.intensity}
+                      {day.intensity === 'heavy' ? '⚠️ Heavy' : day.intensity}
                     </span>
                   </button>
                 );

--- a/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
+++ b/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
@@ -78,13 +78,28 @@ function getRelativeDateStr(offsetDays: number): string {
   return toLocalDateStr(d);
 }
 
-function renderDashboard(items: ScheduleItem[] = [], props: Partial<React.ComponentProps<typeof WorkloadOverviewDashboard>> = {}) {
+/** The 7-Day Forecast renders one row-button per day, each always showing
+ * an "X.Xh" hours figure - unlike the item count ("1 item" vs "N items"),
+ * the hour format never changes shape based on the count, so filtering on
+ * it reliably selects exactly the 7 forecast rows regardless of how many
+ * items happen to fall on any given day. */
+function getForecastDayButtons(): HTMLElement[] {
+  // No trailing \b: the item count's digit runs directly into this "h"
+  // with no separator in the concatenated textContent (e.g. "...0.0h0
+  // items..."), which would make a word-boundary assertion after "h" fail.
+  return screen.getAllByRole('button').filter((btn) => /\d+\.\d+h/.test(btn.textContent ?? ''));
+}
+
+function renderDashboard(
+  items: ScheduleItem[] = [],
+  props: Partial<React.ComponentProps<typeof WorkloadOverviewDashboard>> = {},
+) {
   return render(
     <AuthProvider>
       <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: items }}>
         <WorkloadOverviewDashboard {...props} />
       </AppStateProvider>
-    </AuthProvider>
+    </AuthProvider>,
   );
 }
 
@@ -102,21 +117,26 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       renderDashboard();
       expect(screen.getByText(/Daily & Weekly Workload Center/i)).toBeDefined();
       expect(screen.getByText(/Academic Workload & Pace Advisor/i)).toBeDefined();
-      expect(screen.getByText(/7-Day Workload Forecast/i)).toBeDefined();
+      expect(screen.getByText(/7-Day Forecast/i)).toBeDefined();
     });
 
     it('F4-2: renders exactly 7 day buttons in forecast grid', () => {
       renderDashboard();
-      const forecastButtons = screen.getAllByRole('button').filter(
-        (btn) => btn.textContent?.includes('items') || btn.textContent?.includes('0.0h')
-      );
+      const forecastButtons = getForecastDayButtons();
       expect(forecastButtons).toHaveLength(7);
     });
 
     it('F4-3: displays light pace indicator for days with <= 2.5h workload', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 't1', title: 'Light Reading', dueDate: todayStr, estimatedHours: 1.5, completed: false, type: 'reading' }),
+        createItem({
+          id: 't1',
+          title: 'Light Reading',
+          dueDate: todayStr,
+          estimatedHours: 1.5,
+          completed: false,
+          type: 'reading',
+        }),
       ];
       renderDashboard(items);
       const lightBadges = screen.getAllByText(/light/i);
@@ -126,7 +146,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F4-4: displays moderate pace indicator for days with 2.5h - 5.0h workload', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 't1', title: 'Moderate Problem Set', dueDate: todayStr, estimatedHours: 3.5, completed: false, type: 'assignment' }),
+        createItem({
+          id: 't1',
+          title: 'Moderate Problem Set',
+          dueDate: todayStr,
+          estimatedHours: 3.5,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText(/moderate Pace/i)).toBeDefined();
@@ -135,8 +162,22 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F4-5: displays heavy peak indicator for days with > 5.0h workload', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 't1', title: 'Algorithms Study', dueDate: todayStr, estimatedHours: 4, completed: false, type: 'exam' }),
-        createItem({ id: 't2', title: 'Math Homework', dueDate: todayStr, estimatedHours: 3, completed: false, type: 'assignment' }),
+        createItem({
+          id: 't1',
+          title: 'Algorithms Study',
+          dueDate: todayStr,
+          estimatedHours: 4,
+          completed: false,
+          type: 'exam',
+        }),
+        createItem({
+          id: 't2',
+          title: 'Math Homework',
+          dueDate: todayStr,
+          estimatedHours: 3,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getAllByText(/⚠️ Heavy Peak/i).length).toBeGreaterThan(0);
@@ -146,18 +187,25 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
   describe('Tier 1: Feature F5 - 1-Click Day Inspection', () => {
     it('F5-1: defaults active day inspector to Today', () => {
       renderDashboard();
-      expect(screen.getByText(/● Today/i)).toBeDefined();
+      expect(screen.getByText(/Today/i)).toBeDefined();
       expect(screen.getByText(/Workload Load/i)).toBeDefined();
     });
 
     it('F5-2: clicking a day in the 7-day forecast updates active day inspector', () => {
       const tomorrowStr = getRelativeDateStr(1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'tom-1', title: 'Tomorrow Chemistry Lab', dueDate: tomorrowStr, estimatedHours: 3, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'tom-1',
+          title: 'Tomorrow Chemistry Lab',
+          dueDate: tomorrowStr,
+          estimatedHours: 3,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
 
-      const buttons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('items'));
+      const buttons = getForecastDayButtons();
       const tomorrowBtn = buttons[1];
       fireEvent.click(tomorrowBtn);
 
@@ -168,8 +216,22 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F5-3: active day displays total scheduled hours and task count', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 't1', title: 'Task 1', dueDate: todayStr, estimatedHours: 1, completed: false, type: 'reading' }),
-        createItem({ id: 't2', title: 'Task 2', dueDate: todayStr, estimatedHours: 1.5, completed: false, type: 'quiz' }),
+        createItem({
+          id: 't1',
+          title: 'Task 1',
+          dueDate: todayStr,
+          estimatedHours: 1,
+          completed: false,
+          type: 'reading',
+        }),
+        createItem({
+          id: 't2',
+          title: 'Task 2',
+          dueDate: todayStr,
+          estimatedHours: 1.5,
+          completed: false,
+          type: 'quiz',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('2.5 hrs')).toBeDefined();
@@ -183,12 +245,12 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
     it('F5-5: clicking back to Today updates active day inspector to Today', () => {
       renderDashboard();
-      const buttons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('items'));
+      const buttons = getForecastDayButtons();
       fireEvent.click(buttons[2]); // click day 3
-      expect(screen.queryByText(/● Today/i)).toBeNull();
+      expect(screen.queryByText(/Today/i)).toBeNull();
 
       fireEvent.click(buttons[0]); // click day 1 (today)
-      expect(screen.getByText(/● Today/i)).toBeDefined();
+      expect(screen.getByText(/Today/i)).toBeDefined();
     });
   });
 
@@ -196,7 +258,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F6-1: uncompleted tasks display date picker and quick-shift buttons (-1d, Today, +1d)', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'shiftable-1', title: 'Shiftable Project Task', dueDate: todayStr, estimatedHours: 2, completed: false, type: 'project' }),
+        createItem({
+          id: 'shiftable-1',
+          title: 'Shiftable Project Task',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'project',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText(/Move to another day:/i)).toBeDefined();
@@ -208,12 +277,21 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('F6-2: changing date input calls updateScheduleItem with new dueDate', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
       const targetNewDate = getRelativeDateStr(3);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'item-to-shift', title: 'Research Draft', dueDate: todayStr, estimatedHours: 2, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'item-to-shift',
+          title: 'Research Draft',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
 
@@ -230,12 +308,21 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('F6-3: clicking +1d quick shift button shifts task forward by 1 day', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
       const tomorrowStr = getRelativeDateStr(1);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'quick-shift-item', title: 'Quick Shift Task', dueDate: todayStr, estimatedHours: 2, completed: false, type: 'project' }),
+        createItem({
+          id: 'quick-shift-item',
+          title: 'Quick Shift Task',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'project',
+        }),
       ];
       renderDashboard(items);
 
@@ -251,7 +338,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F6-4: completed tasks do not display date shifter controls', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'completed-item', title: 'Finished Lab', dueDate: todayStr, estimatedHours: 2, completed: true, type: 'assignment' }),
+        createItem({
+          id: 'completed-item',
+          title: 'Finished Lab',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: true,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.queryByText(/Move to another day:/i)).toBeNull();
@@ -261,7 +355,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       const onShiftDateMock = vi.fn();
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'prop-shift-item', title: 'Prop Shift Task', dueDate: todayStr, estimatedHours: 2, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'prop-shift-item',
+          title: 'Prop Shift Task',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items, { scheduleItems: items, onShiftDate: onShiftDateMock });
 
@@ -276,7 +377,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F7-1: completed task displays line-through title and completed checkbox', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'done-task', title: 'Completed Synthesis Notes', dueDate: todayStr, estimatedHours: 2, completed: true, type: 'reading' }),
+        createItem({
+          id: 'done-task',
+          title: 'Completed Synthesis Notes',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: true,
+          type: 'reading',
+        }),
       ];
       renderDashboard(items);
       const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
@@ -285,10 +393,19 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('F7-2: clicking checkbox on uncompleted task calls updateScheduleItem to complete it', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'pending-task', title: 'Pending Synthesis Notes', dueDate: todayStr, estimatedHours: 2, completed: false, type: 'reading' }),
+        createItem({
+          id: 'pending-task',
+          title: 'Pending Synthesis Notes',
+          dueDate: todayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'reading',
+        }),
       ];
       renderDashboard(items);
 
@@ -304,10 +421,19 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('F7-3: clicking checkbox on completed task calls updateScheduleItem to uncomplete it', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'uncomplete-task', title: 'Done Task', dueDate: todayStr, estimatedHours: 1, completed: true, type: 'quiz' }),
+        createItem({
+          id: 'uncomplete-task',
+          title: 'Done Task',
+          dueDate: todayStr,
+          estimatedHours: 1,
+          completed: true,
+          type: 'quiz',
+        }),
       ];
       renderDashboard(items);
 
@@ -323,7 +449,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F7-4: past completed tasks do not trigger rollover warning alert', () => {
       const pastStr = getRelativeDateStr(-2);
       const items: ScheduleItem[] = [
-        createItem({ id: 'past-done', title: 'Past Done Homework', dueDate: pastStr, estimatedHours: 2, completed: true, type: 'assignment' }),
+        createItem({
+          id: 'past-done',
+          title: 'Past Done Homework',
+          dueDate: pastStr,
+          estimatedHours: 2,
+          completed: true,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.queryByText(/Rollover Task/i)).toBeNull();
@@ -332,7 +465,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F7-5: completed task maintains estimated duration badge in task list', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'done-badge-task', title: 'Done Lab', dueDate: todayStr, estimatedHours: 2.5, completed: true, type: 'assignment' }),
+        createItem({
+          id: 'done-badge-task',
+          title: 'Done Lab',
+          dueDate: todayStr,
+          estimatedHours: 2.5,
+          completed: true,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('150m')).toBeDefined();
@@ -343,7 +483,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F8-1: uncompleted past task displays rollover alert badge in header', () => {
       const yesterdayStr = getRelativeDateStr(-1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'missed-1', title: 'Missed Chapter Reading', dueDate: yesterdayStr, estimatedHours: 2, completed: false, type: 'reading' }),
+        createItem({
+          id: 'missed-1',
+          title: 'Missed Chapter Reading',
+          dueDate: yesterdayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'reading',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText(/⚠️ 1 Rollover Task/i)).toBeDefined();
@@ -353,8 +500,22 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       const past1 = getRelativeDateStr(-1);
       const past2 = getRelativeDateStr(-2);
       const items: ScheduleItem[] = [
-        createItem({ id: 'm1', title: 'Missed 1', dueDate: past1, estimatedHours: 1, completed: false, type: 'quiz' }),
-        createItem({ id: 'm2', title: 'Missed 2', dueDate: past2, estimatedHours: 2, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'm1',
+          title: 'Missed 1',
+          dueDate: past1,
+          estimatedHours: 1,
+          completed: false,
+          type: 'quiz',
+        }),
+        createItem({
+          id: 'm2',
+          title: 'Missed 2',
+          dueDate: past2,
+          estimatedHours: 2,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText(/⚠️ 2 Rollover Tasks/i)).toBeDefined();
@@ -363,7 +524,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F8-3: rollover task appears in Today task list with "(Rollover)" appended', () => {
       const yesterdayStr = getRelativeDateStr(-1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'missed-lab', title: 'Physics Lab 1', dueDate: yesterdayStr, estimatedHours: 3, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'missed-lab',
+          title: 'Physics Lab 1',
+          dueDate: yesterdayStr,
+          estimatedHours: 3,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('Physics Lab 1 (Rollover)')).toBeDefined();
@@ -372,7 +540,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F8-4: rollover tasks display date shifter to allow rescheduling to future day', () => {
       const yesterdayStr = getRelativeDateStr(-1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'rollover-shift', title: 'Missed Vocab Quiz', dueDate: yesterdayStr, estimatedHours: 1, completed: false, type: 'quiz' }),
+        createItem({
+          id: 'rollover-shift',
+          title: 'Missed Vocab Quiz',
+          dueDate: yesterdayStr,
+          estimatedHours: 1,
+          completed: false,
+          type: 'quiz',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText(/Move to another day:/i)).toBeDefined();
@@ -381,7 +556,14 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('F8-5: uncompleted past tasks add to Today total hours calculation', () => {
       const yesterdayStr = getRelativeDateStr(-1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'missed-big', title: 'Missed Exam Review', dueDate: yesterdayStr, estimatedHours: 4, completed: false, type: 'exam' }),
+        createItem({
+          id: 'missed-big',
+          title: 'Missed Exam Review',
+          dueDate: yesterdayStr,
+          estimatedHours: 4,
+          completed: false,
+          type: 'exam',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('4.0 hrs')).toBeDefined();
@@ -402,7 +584,9 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
     it('B2: opens ProjectChunkerModal when clicking "Divide Project/Exam into Bite Chunks"', () => {
       renderDashboard([]);
-      const chunkBtn = screen.getByRole('button', { name: /Divide Project\/Exam into Bite Chunks/i });
+      const chunkBtn = screen.getByRole('button', {
+        name: /Divide Project\/Exam into Bite Chunks/i,
+      });
       fireEvent.click(chunkBtn);
       expect(screen.getByRole('dialog')).toBeDefined();
       expect(screen.getByText(/Study & Project Bite-Sized Chunker/i)).toBeDefined();
@@ -411,7 +595,13 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     it('B3: handles item with missing estimatedHours applying fallback', () => {
       const todayStr = getRelativeDateStr(0);
       const items: ScheduleItem[] = [
-        createItem({ id: 'no-hrs-item', title: 'Exam Without Hours', dueDate: todayStr, completed: false, type: 'exam' }),
+        createItem({
+          id: 'no-hrs-item',
+          title: 'Exam Without Hours',
+          dueDate: todayStr,
+          completed: false,
+          type: 'exam',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('2.0 hrs')).toBeDefined(); // 120m fallback for exam
@@ -428,7 +618,7 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
           estimatedHours: 0.5,
           completed: false,
           type: 'assignment',
-        })
+        }),
       );
       renderDashboard(items);
       expect(screen.getByText('7.5 hrs')).toBeDefined();
@@ -437,7 +627,13 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
     it('B5: handles item without dueDate gracefully without breaking forecast', () => {
       const items: ScheduleItem[] = [
-        createItem({ id: 'floating-task', title: 'Unscheduled Floating Task', dueDate: '', completed: false, type: 'assignment' }),
+        createItem({
+          id: 'floating-task',
+          title: 'Unscheduled Floating Task',
+          dueDate: '',
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
       expect(screen.getByText('0.0 hrs')).toBeDefined();
@@ -450,17 +646,26 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
   describe('Tier 3: Pairwise & Cross-Feature Interactions', () => {
     it('P1: Inspect Day 3 -> Shift Task to Day 5 -> Verified through updateScheduleItem', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const day3Str = getRelativeDateStr(3);
       const day5Str = getRelativeDateStr(5);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'd3-task', title: 'Day 3 Capstone Part', dueDate: day3Str, estimatedHours: 3, completed: false, type: 'project' }),
+        createItem({
+          id: 'd3-task',
+          title: 'Day 3 Capstone Part',
+          dueDate: day3Str,
+          estimatedHours: 3,
+          completed: false,
+          type: 'project',
+        }),
       ];
       renderDashboard(items);
 
       // Inspect Day 3
-      const buttons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('items'));
+      const buttons = getForecastDayButtons();
       fireEvent.click(buttons[3]);
 
       // Shift to Day 5
@@ -474,10 +679,19 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('P2: Rollover task toggled completed via checkbox', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const yesterdayStr = getRelativeDateStr(-1);
       const items: ScheduleItem[] = [
-        createItem({ id: 'rollover-toggle', title: 'Missed Coding HW', dueDate: yesterdayStr, estimatedHours: 2, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'rollover-toggle',
+          title: 'Missed Coding HW',
+          dueDate: yesterdayStr,
+          estimatedHours: 2,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
       renderDashboard(items);
 
@@ -492,7 +706,9 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
     it('P3: Open Chunker Modal -> Close Chunker Modal -> Dashboard remains interactive', () => {
       renderDashboard([]);
-      const chunkBtn = screen.getByRole('button', { name: /Divide Project\/Exam into Bite Chunks/i });
+      const chunkBtn = screen.getByRole('button', {
+        name: /Divide Project\/Exam into Bite Chunks/i,
+      });
       fireEvent.click(chunkBtn);
       expect(screen.getByRole('dialog')).toBeDefined();
 
@@ -514,9 +730,30 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       const day4Str = getRelativeDateStr(4);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'cs-exam-chunk', title: 'CS 310 Mock Exam', dueDate: todayStr, estimatedHours: 3, completed: false, type: 'exam' }),
-        createItem({ id: 'math-exam-chunk', title: 'Discrete Math Formula Drill', dueDate: day2Str, estimatedHours: 2.5, completed: false, type: 'exam' }),
-        createItem({ id: 'cs-project-chunk', title: 'Algorithms Project Code', dueDate: day4Str, estimatedHours: 4, completed: false, type: 'project' }),
+        createItem({
+          id: 'cs-exam-chunk',
+          title: 'CS 310 Mock Exam',
+          dueDate: todayStr,
+          estimatedHours: 3,
+          completed: false,
+          type: 'exam',
+        }),
+        createItem({
+          id: 'math-exam-chunk',
+          title: 'Discrete Math Formula Drill',
+          dueDate: day2Str,
+          estimatedHours: 2.5,
+          completed: false,
+          type: 'exam',
+        }),
+        createItem({
+          id: 'cs-project-chunk',
+          title: 'Algorithms Project Code',
+          dueDate: day4Str,
+          estimatedHours: 4,
+          completed: false,
+          type: 'project',
+        }),
       ];
 
       renderDashboard(items);
@@ -526,7 +763,7 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       expect(screen.getByText('CS 310 Mock Exam')).toBeDefined();
 
       // Inspect Day 2 (Discrete Math)
-      const buttons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('items'));
+      const buttons = getForecastDayButtons();
       fireEvent.click(buttons[2]);
       expect(screen.getByText('Discrete Math Formula Drill')).toBeDefined();
       expect(screen.getByText('2.5 hrs')).toBeDefined();
@@ -538,14 +775,30 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 2: Post-Illness Rollover Task Recovery and Date Shifting', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const dayMinus2 = getRelativeDateStr(-2);
       const dayMinus1 = getRelativeDateStr(-1);
       const dayPlus2 = getRelativeDateStr(2);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'sick-1', title: 'Missed Lecture Notes Review', dueDate: dayMinus2, estimatedHours: 2, completed: false, type: 'reading' }),
-        createItem({ id: 'sick-2', title: 'Missed Practice Problems', dueDate: dayMinus1, estimatedHours: 3, completed: false, type: 'assignment' }),
+        createItem({
+          id: 'sick-1',
+          title: 'Missed Lecture Notes Review',
+          dueDate: dayMinus2,
+          estimatedHours: 2,
+          completed: false,
+          type: 'reading',
+        }),
+        createItem({
+          id: 'sick-2',
+          title: 'Missed Practice Problems',
+          dueDate: dayMinus1,
+          estimatedHours: 3,
+          completed: false,
+          type: 'assignment',
+        }),
       ];
 
       renderDashboard(items);
@@ -564,9 +817,30 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
 
     it('Scenario 3: Senior Capstone Milestone Tracking Across 7-Day Window', () => {
       const items: ScheduleItem[] = [
-        createItem({ id: 'cap-1', title: 'Capstone: Research & Architecture', dueDate: getRelativeDateStr(0), estimatedHours: 3, completed: true, type: 'project' }),
-        createItem({ id: 'cap-2', title: 'Capstone: Core Feature Implementation', dueDate: getRelativeDateStr(2), estimatedHours: 5, completed: false, type: 'project' }),
-        createItem({ id: 'cap-3', title: 'Capstone: Testing & Bug Fixes', dueDate: getRelativeDateStr(5), estimatedHours: 4, completed: false, type: 'project' }),
+        createItem({
+          id: 'cap-1',
+          title: 'Capstone: Research & Architecture',
+          dueDate: getRelativeDateStr(0),
+          estimatedHours: 3,
+          completed: true,
+          type: 'project',
+        }),
+        createItem({
+          id: 'cap-2',
+          title: 'Capstone: Core Feature Implementation',
+          dueDate: getRelativeDateStr(2),
+          estimatedHours: 5,
+          completed: false,
+          type: 'project',
+        }),
+        createItem({
+          id: 'cap-3',
+          title: 'Capstone: Testing & Bug Fixes',
+          dueDate: getRelativeDateStr(5),
+          estimatedHours: 4,
+          completed: false,
+          type: 'project',
+        }),
       ];
 
       renderDashboard(items);
@@ -577,20 +851,36 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
       expect(checkbox.checked).toBe(true);
 
       // Inspect Day 2 (Core Feature - 5 hours)
-      const buttons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('items'));
+      const buttons = getForecastDayButtons();
       fireEvent.click(buttons[2]);
       expect(screen.getByText('Capstone: Core Feature Implementation')).toBeDefined();
       expect(screen.getByText('5.0 hrs')).toBeDefined();
     });
 
     it('Scenario 4: Rebalancing Heavy Peak Day to Avoid Burnout', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
       const tomorrowStr = getRelativeDateStr(1);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'heavy-1', title: 'Exam Cram 1', dueDate: todayStr, estimatedHours: 3.5, completed: false, type: 'exam' }),
-        createItem({ id: 'heavy-2', title: 'Exam Cram 2', dueDate: todayStr, estimatedHours: 3.0, completed: false, type: 'exam' }),
+        createItem({
+          id: 'heavy-1',
+          title: 'Exam Cram 1',
+          dueDate: todayStr,
+          estimatedHours: 3.5,
+          completed: false,
+          type: 'exam',
+        }),
+        createItem({
+          id: 'heavy-2',
+          title: 'Exam Cram 2',
+          dueDate: todayStr,
+          estimatedHours: 3.0,
+          completed: false,
+          type: 'exam',
+        }),
       ];
 
       renderDashboard(items);
@@ -609,12 +899,28 @@ describe('WorkloadOverviewDashboard Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 5: Complete Interactive Inspection and Task Completion Run', async () => {
-      const updateSpy = vi.spyOn(scheduleItemsLib, 'updateScheduleItem').mockResolvedValue(undefined);
+      const updateSpy = vi
+        .spyOn(scheduleItemsLib, 'updateScheduleItem')
+        .mockResolvedValue(undefined);
       const todayStr = getRelativeDateStr(0);
 
       const items: ScheduleItem[] = [
-        createItem({ id: 'run-1', title: 'Task A', dueDate: todayStr, estimatedHours: 1, completed: false, type: 'reading' }),
-        createItem({ id: 'run-2', title: 'Task B', dueDate: todayStr, estimatedHours: 1, completed: false, type: 'quiz' }),
+        createItem({
+          id: 'run-1',
+          title: 'Task A',
+          dueDate: todayStr,
+          estimatedHours: 1,
+          completed: false,
+          type: 'reading',
+        }),
+        createItem({
+          id: 'run-2',
+          title: 'Task B',
+          dueDate: todayStr,
+          estimatedHours: 1,
+          completed: false,
+          type: 'quiz',
+        }),
       ];
 
       renderDashboard(items);

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -7,10 +7,14 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Renders a brand accent marking this card as visually important.
    * `true` (or `"top"`) draws a gradient bar along the top edge; `"left"`
-   * draws a solid primary-colored border down the left edge instead - used
-   * to promote a single card as the dominant/primary one in a section.
+   * draws a solid primary-colored border down the left edge instead; `"glow"`
+   * draws the full-perimeter brand-gradient "Neon Edge" border + ambient
+   * glow (globals.css `.glow-edge-low`) - the calm, static everyday
+   * treatment. A card whose glow should escalate with real severity
+   * (medium/high/critical, breathing) uses WORKLOAD_GLOW_CLASS
+   * (lib/workload/uiClasses.ts) as `className` instead of this prop.
    */
-  accent?: boolean | 'top' | 'left';
+  accent?: boolean | 'top' | 'left' | 'glow';
 }
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>(
@@ -18,11 +22,15 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const isInteractive = interactive || hoverable;
     const accentTop = accent === true || accent === 'top';
     const accentLeft = accent === 'left';
+    const accentGlow = accent === 'glow';
     return (
       <div
         ref={ref}
         className={cn(
-          'relative rounded-glass border border-border bg-card/90 backdrop-blur-md shadow-card overflow-hidden',
+          'relative rounded-glass overflow-hidden',
+          accentGlow
+            ? 'glow-edge glow-edge-low'
+            : 'border border-border bg-card/90 backdrop-blur-md shadow-card',
           isInteractive &&
             'transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-card-hover',
           accentLeft && 'border-l-[3px] border-l-primary',
@@ -49,7 +57,11 @@ CardHeader.displayName = 'CardHeader';
 export type CardTitleProps = React.HTMLAttributes<HTMLHeadingElement>;
 export const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-h3 font-semibold text-foreground', className)} {...props} />
+    <h3
+      ref={ref}
+      className={cn('text-h3 font-extrabold tracking-tight text-foreground', className)}
+      {...props}
+    />
   ),
 );
 CardTitle.displayName = 'CardTitle';

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -5,16 +5,18 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   hoverable?: boolean;
   /**
-   * Renders a brand accent marking this card as visually important.
-   * `true` (or `"top"`) draws a gradient bar along the top edge; `"left"`
-   * draws a solid primary-colored border down the left edge instead; `"glow"`
-   * draws the full-perimeter brand-gradient "Neon Edge" border + ambient
-   * glow (globals.css `.glow-edge-low`) - the calm, static everyday
-   * treatment. A card whose glow should escalate with real severity
-   * (medium/high/critical, breathing) uses WORKLOAD_GLOW_CLASS
+   * Every card carries the brand-gradient "Neon Edge" border + ambient glow
+   * (globals.css `.glow-edge-low`) by default - the calm, static everyday
+   * treatment used sitewide. `true` (or `"top"`) instead draws a gradient
+   * bar along the top edge; `"left"` draws a solid primary-colored border
+   * down the left edge; `"none"` opts out back to a flat bordered card,
+   * reserved for cards whose border already carries other meaning (a
+   * destructive/error state, a dashed empty-state prompt) that a brand
+   * gradient would contradict. A card whose glow should escalate with real
+   * severity (medium/high/critical, breathing) uses WORKLOAD_GLOW_CLASS
    * (lib/workload/uiClasses.ts) as `className` instead of this prop.
    */
-  accent?: boolean | 'top' | 'left' | 'glow';
+  accent?: boolean | 'top' | 'left' | 'glow' | 'none';
 }
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>(
@@ -22,7 +24,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const isInteractive = interactive || hoverable;
     const accentTop = accent === true || accent === 'top';
     const accentLeft = accent === 'left';
-    const accentGlow = accent === 'glow';
+    const accentGlow = !accentTop && !accentLeft && accent !== 'none';
     return (
       <div
         ref={ref}

--- a/src/lib/__tests__/Card.test.tsx
+++ b/src/lib/__tests__/Card.test.tsx
@@ -69,7 +69,7 @@ describe('Card Component Suite', () => {
 
     const title = screen.getByText('Card Title Text');
     expect(title.className).toContain('title-custom');
-    expect(title.className).toContain('font-semibold');
+    expect(title.className).toContain('font-extrabold');
 
     const desc = screen.getByText('Card Description Text');
     expect(desc.className).toContain('desc-custom');

--- a/src/lib/workload/uiClasses.ts
+++ b/src/lib/workload/uiClasses.ts
@@ -72,6 +72,22 @@ export const WORKLOAD_SOLID_BADGE_CLASS: Record<WorkloadLevel, string> = {
 };
 
 /**
+ * Card border + ambient glow that escalates with real severity (globals.css
+ * defines the actual .glow-edge* rules) - 'low' stays the calm, static
+ * brand-gradient look used everywhere else a card just needs to look
+ * "important" (Card.tsx's accent="glow"); medium/high/critical progress
+ * through amber -> orange -> red and start breathing, so a genuinely
+ * urgent day is louder than a merely busy one instead of every non-quiet
+ * day getting the same fixed "urgent" treatment.
+ */
+export const WORKLOAD_GLOW_CLASS: Record<WorkloadLevel, string> = {
+  low: 'glow-edge glow-edge-low',
+  medium: 'glow-edge glow-edge-medium glow-edge-pulse',
+  high: 'glow-edge glow-edge-high glow-edge-pulse',
+  critical: 'glow-edge glow-edge-critical glow-edge-pulse',
+};
+
+/**
  * Unified badge helper returning consistent tokens across dashboard, planner, calendar, and task views.
  */
 export function getWorkloadBadgeTokens(


### PR DESCRIPTION
## Summary

Adds the "Neon Edge" card treatment that came out of a design-review round (mocked up across several Artifacts before touching code) and rebuilds the Tasks page's Workload Load / 7-Day Forecast cards to use it.

- **`Card.tsx`**: new `accent="glow"` option — the calm, static brand-gradient border + glow (built from the app's own `bg-gradient-brand` stops, no new colors) — for any card that just needs to look "important." `CardTitle` bumped to extrabold app-wide.
- **`globals.css`**: reusable `.glow-edge`/`.glow-edge-{low,medium,high,critical}` and `.spin-border` utilities, plus a registered `--spin-angle` custom property so the sweep animation tweens smoothly.
- **`lib/workload/uiClasses.ts`**: `WORKLOAD_GLOW_CLASS` maps real workload severity onto an escalating border+glow ladder — calm violet (low) → amber (medium) → orange (high) → red (critical), breathing on medium/high/critical — reusing the existing `load-medium/high/critical` tokens.
- **`WorkloadOverviewDashboard.tsx`**: both cards get real `CardHeader`/`CardTitle`/`CardDescription` headers with a divider (previously the title ran straight into the content with no separation); the 7-day forecast becomes one scannable row list instead of seven tiles; the Workload Load card's glow escalates with the inspected day's real severity, forced to critical when an item is overdue; fixed a layout bug where the card was too narrow at the `lg` breakpoint and its header badges looked cramped/randomly stacked (bumped the breakpoint to `xl`, merged the "Today" indicator into the subtitle line instead of a second floating pill).
- **`PomodoroTimer.tsx`**: the focus ring's stroke is now the brand gradient (was a flat color), and the widget picks up the `.spin-border` sweep only while a session is actively running — a real, frequently-visible home for the "something is happening right now" treatment.

## Verification

- `tsc --noEmit`, `next lint`, and the full `vitest` suite (567/567) all pass.
- Checked against the real Firebase emulator (not mock auth) logged in as `dev-test@syllabussense.dev`, with seeded data spanning light/moderate/heavy days, in both light and dark mode, and at both the stacked and two-column breakpoints (1024px/1280px/1366px) to confirm the width fix.
- The Pomodoro timer's gradient ring is implemented and code-reviewed but its running/spin-sweep state wasn't separately screenshotted in this pass (the workload-card verification took priority) — worth a quick manual check before merge if that matters to you.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` (567/567)
- [x] Manual verification against real Firebase emulator data, light + dark mode, multiple breakpoints
- [ ] Manual check of the Pomodoro timer's running/spin state (not yet screenshotted)
