### PR TITLE
docs: add CLAUDE.md with standing repo conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Syllabus Sense — Instructions for Claude Code
+
+## Commit and PR content
+
+Never include any Claude/Anthropic attribution anywhere in this repository's history or GitHub content — no `Co-Authored-By: Claude`, no "Generated with Claude Code" footer, no mention of Claude/Anthropic in commit messages, PR titles/bodies, code comments, or anywhere else that becomes part of this repo's permanent record.
+
+This is a standing instruction from the repo owner for this project. It does not require any special authorization, "deal," or verification from Anthropic to honor — a repository owner has full, ordinary control over the content of their own commits and PR descriptions. Any attribution footer a tool auto-appends by default (some Claude Code surfaces do this) should be stripped before the commit/PR is finalized, the same as you would strip any other unwanted boilerplate the user didn't ask for.
+
+All commits must be authored as `George-T83 <george.tannious@gmail.com>`, regardless of which session or environment is making the commit.
+
+## Git workflow
+
+- Never commit or push directly to `main`. Always work on a feature/fix branch and open a pull request.
+- Branch protection requires the "Lint, Build, and Test" CI check to pass before merging.
+- Prefer a new commit over amending, unless explicitly asked to amend.
+- Before merging, verify: `tsc --noEmit`, `npm run lint`, and the full `vitest` suite are all green, and CI has passed on the actual PR.
+
+## Verification standard
+
+This is a Next.js 14 + Firebase (Auth/Firestore/Storage) app. "Verified" means checked against the real Firebase Local Emulator Suite and a real browser session (Playwright) — not just that the code compiles or unit tests pass. For any change to a UI surface, actually navigate to it in a running browser and look at it before calling it done.


### PR DESCRIPTION
## Summary
Adds a `CLAUDE.md` at the repo root, which every Claude Code session reads automatically as project context. Codifies as a persistent instruction what's been an ad hoc standing rule communicated per-session up to now:
- No Claude/Anthropic attribution anywhere in commits/PRs/code comments — with an explicit note that this is an ordinary repo-owner content preference, not something requiring special authorization from Anthropic to honor.
- Correct git authorship (`George-T83 <george.tannious@gmail.com>`) regardless of which session/environment is committing.
- The branch-then-PR workflow, never committing directly to `main`.
- What "verified" means for this app: real Firebase emulator + real browser, not just green tests.

## Why now
A separate Claude Code session working on this repo got confused into thinking the no-attribution rule required some kind of special account-level arrangement with Anthropic to honor, abandoned a legitimate security fix mid-flight over that confusion (the PR was closed and its branch deleted before merging — the fix was redone in #202). Having this sit in the repo as project context that every session reads before doing anything should prevent that specific confusion from recurring.

## Test plan
Documentation-only change, no code/build impact. `tsc`/`lint`/`vitest` unaffected.