### PR TITLE
security: harden AI routes, add security headers, close audit gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,16 @@ NEXT_PUBLIC_FIRESTORE_DATABASE_ID=your-value-here
 # Set to 'true' to run the Local Emulator Suite in local development, or 'false' otherwise.
 NEXT_PUBLIC_USE_FIREBASE_EMULATOR=false
 
+# Anthropic API (Server-side / Private)
+# Required for every AI feature (syllabus extraction, AI Copilot chat, course
+# summarization). Without it, extraction/summarization requests fail and chat
+# silently falls back to a canned offline responder.
+ANTHROPIC_API_KEY=your-value-here
+
+# Anthropic Model Overrides (optional)
+# Each defaults to claude-sonnet-5 if unset - only set these to pin a
+# specific feature to a different model.
+SYLLABUS_EXTRACTION_MODEL=your-value-here
+SYLLABUS_CHAT_MODEL=your-value-here
+COURSE_SUMMARIZATION_MODEL=your-value-here
+

--- a/.env.production.example
+++ b/.env.production.example
@@ -24,3 +24,16 @@ NEXT_PUBLIC_FIRESTORE_DATABASE_ID=(default)
 # Firebase Emulator Suite Option
 # Set to 'true' to run the Local Emulator Suite in local development, or 'false' otherwise.
 NEXT_PUBLIC_USE_FIREBASE_EMULATOR=false
+
+# Anthropic API (Server-side / Private)
+# Required for every AI feature (syllabus extraction, AI Copilot chat, course
+# summarization). Without it, extraction/summarization requests fail and chat
+# silently falls back to a canned offline responder.
+ANTHROPIC_API_KEY=your-value-here
+
+# Anthropic Model Overrides (optional)
+# Each defaults to claude-sonnet-5 if unset - only set these to pin a
+# specific feature to a different model.
+SYLLABUS_EXTRACTION_MODEL=your-value-here
+SYLLABUS_CHAT_MODEL=your-value-here
+COURSE_SUMMARIZATION_MODEL=your-value-here

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -24,3 +24,16 @@ NEXT_PUBLIC_FIRESTORE_DATABASE_ID=staging
 # Firebase Emulator Suite Option
 # Set to 'true' to run the Local Emulator Suite in local development, or 'false' otherwise.
 NEXT_PUBLIC_USE_FIREBASE_EMULATOR=false
+
+# Anthropic API (Server-side / Private)
+# Required for every AI feature (syllabus extraction, AI Copilot chat, course
+# summarization). Without it, extraction/summarization requests fail and chat
+# silently falls back to a canned offline responder.
+ANTHROPIC_API_KEY=your-value-here
+
+# Anthropic Model Overrides (optional)
+# Each defaults to claude-sonnet-5 if unset - only set these to pin a
+# specific feature to a different model.
+SYLLABUS_EXTRACTION_MODEL=your-value-here
+SYLLABUS_CHAT_MODEL=your-value-here
+COURSE_SUMMARIZATION_MODEL=your-value-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,20 @@ jobs:
             exit 1
           fi
 
+      # Gated at "critical" only, not the repo's current baseline of high/
+      # moderate findings (all in transitive deps requiring a major-version
+      # bump tracked separately) - this exists to catch a *new* critical
+      # regression, not to silently pass while masking the known gap.
+      - name: Check for Critical Dependency Vulnerabilities
+        id: audit
+        run: |
+          if npm audit --audit-level=critical; then
+            echo "status=Pass" >> $GITHUB_OUTPUT
+          else
+            echo "status=Fail" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
       - name: Generate Job Summary
         if: always()
         run: |
@@ -83,3 +97,4 @@ jobs:
           echo "| Build | ${{ steps.build.outputs.status || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Unit Tests | ${{ steps.test.outputs.status || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Firestore Rules Tests | ${{ steps.rules-test.outputs.status || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dependency Audit (critical) | ${{ steps.audit.outputs.status || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,37 @@
+// Firebase Auth/Firestore/Storage need their real hosts reachable from the
+// browser (popup sign-in, realtime Firestore listeners over websockets,
+// direct-to-Storage uploads) - the app has no external fonts, analytics, or
+// third-party scripts (confirmed: everything is self-hosted via next/font),
+// so the allowlist below is deliberately narrow to just those.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.googleusercontent.com",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.googleapis.com https://*.google.com https://*.firebaseio.com wss://*.firebaseio.com https://*.gstatic.com",
+  "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+const SECURITY_HEADERS = [
+  { key: 'Content-Security-Policy', value: CSP },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
+  async headers() {
+    return [{ source: '/:path*', headers: SECURITY_HEADERS }];
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/syllabus/chat/__tests__/chatRouteRubric.test.ts
+++ b/src/app/api/syllabus/chat/__tests__/chatRouteRubric.test.ts
@@ -92,10 +92,14 @@ Let me know if you need help with anything else!`;
     const expectedDateStr = expectedDate.toISOString().split('T')[0];
     expect(firstChunk.dueDate).toBe(expectedDateStr);
 
+    // A model reply naming a type outside the real AssignmentType union
+    // (here "coding", which isn't a member) must be coerced to the union's
+    // own catch-all rather than persisted verbatim - createScheduleItem has
+    // no further validation downstream, so this route is the only guard.
     const secondChunk = data.suggestedChunks[1];
     expect(secondChunk.title).toBe('Implement authentication endpoints');
     expect(secondChunk.estimatedHours).toBe(3.5);
-    expect(secondChunk.type).toBe('coding');
+    expect(secondChunk.type).toBe('other');
   });
 
   it('never leaks a raw, truncated chunks block into the reply when the model hits max_tokens mid-JSON', async () => {

--- a/src/app/api/syllabus/chat/route.ts
+++ b/src/app/api/syllabus/chat/route.ts
@@ -7,6 +7,8 @@ import { generateOfflineSyllabusAnswer, type ChatRequestBody } from '@/lib/sylla
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
 function detectFileKind(fileBase64: string): 'pdf' | 'docx' | null {
   if (fileBase64.startsWith('JVBERi0')) return 'pdf';
   if (fileBase64.startsWith('UEsDB')) return 'docx';
@@ -42,6 +44,12 @@ export async function POST(req: NextRequest) {
   const isProd = process.env.NODE_ENV === 'production';
   if (isProd && !user && process.env.FIREBASE_ADMIN_PROJECT_ID) {
     return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  // Rough size check on the base64 payload (base64 is ~4/3 the byte size) -
+  // this route had no ceiling at all, unlike its sibling extract route.
+  if (body.fileBase64 && body.fileBase64.length > MAX_FILE_BYTES * 1.4) {
+    return NextResponse.json({ error: 'File is too large (max 10MB).' }, { status: 400 });
   }
 
   // Parse file if provided
@@ -109,7 +117,7 @@ To suggest these subtasks, you must output a JSON structure at the very end of y
 where:
 - "estimatedHours" is the estimated time to complete that subtask (numbers like 1.5, 2, 0.5).
 - "dueDateOffsetDays" is the recommended relative offset in days from today's date to complete this task (e.g. 2 means due in 2 days).
-- "type" is one of: "project", "exam", "quiz", "assignment", "reading", "coding", "paper".
+- "type" must be exactly one of: "assignment", "exam", "quiz", "project", "reading", "other" (use "other" for anything that doesn't fit, e.g. coding work or a paper).
 
 Format the main body of your answer with clear markdown headings, bullet points, and specific citations in brackets (e.g. [Syllabus § 3 - Grading Policy] or [Rubric - Format Requirements]). Be concise, encouraging, and academically precise.`;
 
@@ -126,6 +134,18 @@ Format the main body of your answer with clear markdown headings, bullet points,
 
       const firstBlock = response.content[0];
       let textResponse = firstBlock && 'text' in firstBlock ? firstBlock.text : '';
+      // Kept in sync with AssignmentType (src/types/schedule.ts) - a chunk
+      // whose type doesn't survive this check would otherwise persist an
+      // out-of-union value via createScheduleItem with no other validation
+      // anywhere in the chain, invisible to every type-based filter forever.
+      const VALID_ASSIGNMENT_TYPES = new Set([
+        'assignment',
+        'exam',
+        'quiz',
+        'project',
+        'reading',
+        'other',
+      ]);
       interface SuggestedChunkType {
         title: string;
         notes: string;
@@ -162,7 +182,10 @@ Format the main body of your answer with clear markdown headings, bullet points,
                   notes: typeof chunk.notes === 'string' ? chunk.notes : '',
                   estimatedHours: Number(chunk.estimatedHours) || 1,
                   dueDate: targetDate.toISOString().split('T')[0],
-                  type: typeof chunk.type === 'string' ? chunk.type : 'assignment',
+                  type:
+                    typeof chunk.type === 'string' && VALID_ASSIGNMENT_TYPES.has(chunk.type)
+                      ? chunk.type
+                      : 'other',
                 };
               });
             }
@@ -174,9 +197,17 @@ Format the main body of your answer with clear markdown headings, bullet points,
         textResponse = (textResponse.slice(0, startIndex).trim() + '\n' + tail).trim();
       }
 
+      // Only claim a syllabus citation when real syllabus/rubric content was
+      // actually in the prompt - otherwise the prompt fell back to a generic
+      // boilerplate description, and tagging that as "[Course Syllabus]"
+      // would assert a source the reply was never actually grounded in.
+      const hasRealSyllabusContext = Boolean(body.syllabusText || body.notes || docxText);
+
       return NextResponse.json({
         reply: textResponse || generateOfflineSyllabusAnswer(body).reply,
-        citations: [`[${body.courseCode || 'Course'} Syllabus]`],
+        citations: hasRealSyllabusContext
+          ? [`[${body.courseCode || 'Course'} Syllabus]`]
+          : undefined,
         suggestedChunks: suggestedChunks.length > 0 ? suggestedChunks : undefined,
         suggestions: [
           'What is the late work policy?',

--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -138,10 +138,10 @@ export async function POST(req: NextRequest) {
       messages: [{ role: 'user', content: documentContent }],
     });
   } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : 'Extraction request failed.' },
-      { status: 502 },
-    );
+    // Logged server-side only - the raw SDK error can include request-shape
+    // or account-tier detail that shouldn't reach the client.
+    console.error('Anthropic call failed in syllabus extraction:', err);
+    return NextResponse.json({ error: 'Extraction request failed.' }, { status: 502 });
   }
 
   const toolUse = message.content.find(

--- a/src/app/api/syllabus/summarize/route.ts
+++ b/src/app/api/syllabus/summarize/route.ts
@@ -139,10 +139,10 @@ export async function POST(req: NextRequest) {
       messages: [{ role: 'user', content: documentContent }],
     });
   } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : 'Summarization request failed.' },
-      { status: 502 },
-    );
+    // Logged server-side only - the raw SDK error can include request-shape
+    // or account-tier detail that shouldn't reach the client.
+    console.error('Anthropic call failed in syllabus summarization:', err);
+    return NextResponse.json({ error: 'Summarization request failed.' }, { status: 502 });
   }
 
   const toolUse = message.content.find(


### PR DESCRIPTION
First batch from the Round 2 audit. Scope: Security discipline findings that are pure, self-contained code fixes.

## What this fixes
- **`chat/route.ts`**: adds the same 10MB file-size cap `extract/route.ts` already enforces (this route had none); constrains a suggested chunk's persisted `type` to the real `AssignmentType` union instead of trusting the model's raw string — the prompt itself told Claude `"coding"`/`"paper"` were valid types, neither of which exists in the union `ScheduleItem` actually uses, so an accepted chunk could persist an out-of-union value invisible to every type-based filter forever. Also stops asserting a `"[Course Syllabus]"` citation on every reply regardless of whether real syllabus content was ever in the prompt — now only attached when `body.syllabusText`, `body.notes`, or a parsed rubric docx actually grounded the answer.
- **`extract/route.ts`, `summarize/route.ts`**: stop returning raw Anthropic SDK error text to the client on failure, matching the pattern `chat/route.ts` and `file/route.ts` already use correctly — the same leak class the reset-password route (#202) was removed for, just via a 502 instead of a 200.
- **`next.config.mjs`**: adds security headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, HSTS) — previously none existed anywhere. The CSP's `connect-src`/`frame-src` allowlist is scoped to what Firebase Auth/Firestore/Storage actually need.
- **`ci.yml`**: adds a dependency-vulnerability gate at `--audit-level=critical` — confirmed passing today (the repo's current 19 known findings are high/moderate, not critical, and all require a major-version bump tracked separately). Gated at critical specifically so it catches a *future* regression without failing every PR on the existing, already-known baseline.
- **`.env*.example`** (all three): document `ANTHROPIC_API_KEY` and the three optional per-feature model-override vars, none of which appeared in any template despite gating every AI feature.

## Deliberately deferred
Rate limiting on the AI routes. The unrate-limited-chat-route cost exposure is real and should be revisited, but not while actively using a personal Anthropic budget against this exact key — explicit instruction, not an oversight.

Also deferred, per the audit's own severity note: the Next.js 14→16 major-version bump (the actual fix for the reachable HIGH-severity advisories), real rate-limiting infra (Redis/Upstash), error-tracking (Sentry), and Firestore backup/DR — each needs either a dedicated testing pass or external service credentials this session doesn't have.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] Full vitest suite green (567/567, excluding the one pre-existing emulator-dependent failure) — updated one test (`chatRouteRubric.test.ts`) that was asserting the old buggy behavior (an out-of-union `"coding"` type passing through verbatim)
- [x] `npm run build` succeeds
- [x] Confirmed all six headers are actually sent via a live `curl` against `next start`
- [x] Zero CSP console violations in a real Playwright/Chromium session against `/login` and `/dashboard`
- [ ] Not independently verifiable from this sandbox (no outbound internet): real Google OAuth popup + live Firestore websocket behavior against Google's actual servers under the new CSP — worth a confirming pass against the Vercel preview before merge if you want extra confidence, though the allowlist is scoped correctly per Firebase's documented CSP requirements
- [x] Confirmed `npm audit --audit-level=critical` exits 0 today