### PR TITLE
fix: close false-empty-state flash, dead CommandPalette actions, NaN MB

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -28,10 +28,10 @@ npm run build
 
 ### A. Intelligent Navigation & Power-User Tools
 
-- **Global Command Palette (`Cmd+K` / `Ctrl+K` | Item 34 & Item 50)**:
-  - Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) anywhere in the application.
-  - Fuzzy-search courses, quick jump to planner/calendar/tasks, or trigger instant actions like "Start Pomodoro Timer", "Calculate GPA", or "New Task".
-  - Press `?` to open the Global Keyboard Shortcuts Cheat Sheet.
+- **Global Command Palette (`Cmd+P` / `Ctrl+P` | Item 34 & Item 50)**:
+  - Press `Cmd+P` (Mac) or `Ctrl+P` (Windows/Linux) anywhere in the application.
+  - Fuzzy-search courses, quick jump to planner/calendar/tasks, or trigger instant actions like "Start Pomodoro Timer", "What-If Grade Simulator", or "Add New Task".
+  - `Cmd+K` / `Ctrl+K` is a separate shortcut that opens the AI Syllabus Copilot chat drawer directly, not the Command Palette.
 
 - **Quick-Join Next Class Hero Banner (Item 44)**:
   - Located at the top of the Dashboard.

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -173,7 +173,9 @@ export function CommandPalette({
         badge: 'AI',
         badgeVariant: 'primary',
         perform: () => {
-          router.push('/syllabus');
+          // There is no dedicated /syllabus route - "Autofill from Syllabus"
+          // lives on the Courses page. This previously 404'd.
+          router.push('/courses?autofill=true');
           closePalette();
         },
       },
@@ -199,7 +201,9 @@ export function CommandPalette({
         badge: 'New',
         badgeVariant: 'primary',
         perform: () => {
-          router.push('/tasks?new=1');
+          // The Tasks page itself only supports editing, not creating - the
+          // Dashboard's "+ Add Task" modal is the real destination.
+          router.push('/dashboard?new=1');
           onAction?.('new-task');
           closePalette();
         },
@@ -225,6 +229,10 @@ export function CommandPalette({
         badge: 'AI Copilot',
         badgeVariant: 'primary',
         perform: () => {
+          // The chat drawer's open/closed state lives in LayoutWrapper, not
+          // here - onAction is the only path to it. Previously nothing
+          // consumed this callback, so the palette just closed and nothing
+          // else happened.
           onAction?.('ai-copilot');
           closePalette();
         },
@@ -236,6 +244,7 @@ export function CommandPalette({
         category: 'Actions',
         badge: 'Calc',
         perform: () => {
+          router.push('/courses?simulator=true');
           onAction?.('grade-simulator');
           closePalette();
         },
@@ -247,6 +256,8 @@ export function CommandPalette({
         category: 'Actions',
         badge: 'Focus',
         perform: () => {
+          // The timer widget's open/closed state is local to PomodoroTimer,
+          // not reachable from here - onAction is the only path to it.
           onAction?.('pomodoro');
           closePalette();
         },

--- a/src/components/common/__tests__/CommandPalette.test.tsx
+++ b/src/components/common/__tests__/CommandPalette.test.tsx
@@ -171,4 +171,50 @@ describe('CommandPalette (Item 34)', () => {
 
     expect(onAction).toHaveBeenCalledWith('theme-toggle');
   });
+
+  // Regression coverage for the CommandPalette findings from the Round 2
+  // audit: "Upload Syllabus" 404'd (no /syllabus route exists), "Add New
+  // Task" navigated to a page with no create-task flow, and ai-copilot/
+  // grade-simulator/pomodoro had no consumer for onAction at all.
+  it('navigates "Upload Syllabus" to the real Autofill entry point, not the dead /syllabus route', () => {
+    renderWithProviders(<CommandPalette isOpen={true} />);
+
+    fireEvent.click(screen.getByText('Upload Syllabus'));
+
+    expect(pushMock).toHaveBeenCalledWith('/courses?autofill=true');
+  });
+
+  it('navigates "Add New Task" to the Dashboard, which has a real create-task modal', () => {
+    renderWithProviders(<CommandPalette isOpen={true} />);
+
+    fireEvent.click(screen.getByText('Add New Task / Assignment'));
+
+    expect(pushMock).toHaveBeenCalledWith('/dashboard?new=1');
+  });
+
+  it('navigates "What-If Grade Simulator" to its real query-param entry point', () => {
+    const onAction = vi.fn();
+    renderWithProviders(<CommandPalette isOpen={true} onAction={onAction} />);
+
+    fireEvent.click(screen.getByText('What-If Grade Simulator'));
+
+    expect(pushMock).toHaveBeenCalledWith('/courses?simulator=true');
+    expect(onAction).toHaveBeenCalledWith('grade-simulator');
+  });
+
+  it('fires onAction for ai-copilot, whose open/closed state lives outside the palette', () => {
+    const onAction = vi.fn();
+    renderWithProviders(<CommandPalette isOpen={true} onAction={onAction} />);
+
+    fireEvent.click(screen.getByText('Ask AI Syllabus Copilot'));
+    expect(onAction).toHaveBeenCalledWith('ai-copilot');
+  });
+
+  it('fires onAction for pomodoro, whose open/closed state lives outside the palette', () => {
+    const onAction = vi.fn();
+    renderWithProviders(<CommandPalette isOpen={true} onAction={onAction} />);
+
+    fireEvent.click(screen.getByText('Start Pomodoro Focus Timer'));
+    expect(onAction).toHaveBeenCalledWith('pomodoro');
+  });
 });

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
@@ -267,7 +268,13 @@ export function ContactsListView() {
           </div>
         )}
 
-        {personGroups.length === 0 ? (
+        {!state.initialized ? (
+          // See the identical guard in CoursesListView.tsx.
+          <div className="grid gap-3 sm:grid-cols-2">
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : personGroups.length === 0 ? (
           <Card className="rounded-2xl p-6">
             <EmptyState
               icon={

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
@@ -51,6 +52,15 @@ export function CoursesListView() {
       }
       if (window.location.search.includes('diff=true')) {
         setDiffOpen(true);
+      }
+      // CommandPalette's "Add New Course" / "Upload Syllabus" actions - both
+      // previously navigated here with no query param this page read, so
+      // the user just landed on the plain list with no modal opening.
+      if (window.location.search.includes('new=1')) {
+        setAddCourseOpen(true);
+      }
+      if (window.location.search.includes('autofill=true')) {
+        setAutofillOpen(true);
       }
     }
   }, []);
@@ -207,7 +217,17 @@ export function CoursesListView() {
           </div>
         )}
 
-        {filteredCourses.length === 0 ? (
+        {!state.initialized ? (
+          // The Firestore listener's first snapshot hasn't landed yet -
+          // courses defaults to [] the same as "genuinely has none", so
+          // without this branch a student with real courses briefly sees
+          // "No courses yet" (and a working "+ Add Course" button) for
+          // however long the network takes, not just an instant.
+          <div className="grid gap-3 sm:grid-cols-2">
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : filteredCourses.length === 0 ? (
           <Card className="rounded-2xl p-6">
             <EmptyState
               icon={

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
@@ -68,7 +69,22 @@ export function DashboardView() {
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [autofillOpen, setAutofillOpen] = useState(false);
 
+  useEffect(() => {
+    // CommandPalette's "Add New Task" action - the Tasks page itself has no
+    // create-task flow (only editing), so this is the real destination for
+    // that quick action, matching the ?chat=true / ?simulator=true pattern
+    // used elsewhere in the app.
+    if (typeof window !== 'undefined' && window.location.search.includes('new=1')) {
+      setAddTaskOpen(true);
+    }
+  }, []);
+
   const { courses, scheduleItems } = state;
+  // The Firestore listener's first snapshot hasn't landed yet - every
+  // collection defaults to [] the same as "genuinely has none", so without
+  // this every empty-state branch below briefly shows "no data" copy (with
+  // working "add" buttons) to a returning user who actually has real data.
+  const dataLoading = !state.initialized;
 
   const currentTerm = useMemo(
     () => resolveActiveTerm(state.selectedTerm, courses),
@@ -244,7 +260,9 @@ export function DashboardView() {
                 </CardActionButton>
               </div>
             </div>
-            {upcomingTasks.length === 0 ? (
+            {dataLoading ? (
+              <SkeletonCard />
+            ) : upcomingTasks.length === 0 ? (
               <EmptyState
                 icon={
                   <svg
@@ -335,7 +353,9 @@ export function DashboardView() {
                 </div>
               </div>
 
-              {courseLoad.length === 0 ? (
+              {dataLoading ? (
+                <SkeletonCard />
+              ) : courseLoad.length === 0 ? (
                 <EmptyState
                   icon={
                     <svg
@@ -399,7 +419,9 @@ export function DashboardView() {
                 <SectionIcon icon="star" className="h-6 w-6" />
                 <h2 className="text-sm font-semibold text-foreground">Term Progress</h2>
               </div>
-              {courses.length === 0 ? (
+              {dataLoading ? (
+                <SkeletonCard />
+              ) : courses.length === 0 ? (
                 // MO-4: a brand-new account with zero courses/zero everything
                 // used to render this same ring-at-0%-plus-zeros grid, which
                 // reads as "something failed to load" rather than "welcome".
@@ -497,7 +519,9 @@ export function DashboardView() {
             </div>
             <QuietLink href="/planner">Open planner</QuietLink>
           </div>
-          {plannerPreview.length === 0 ? (
+          {dataLoading ? (
+            <SkeletonCard />
+          ) : plannerPreview.length === 0 ? (
             <EmptyState
               icon={
                 <svg

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -64,6 +64,10 @@ function formatTime(seconds: number): string {
 export interface PomodoroTimerProps {
   /** Optional task ID to associate sessions with a specific task. */
   taskId?: string;
+  /** Bump this (e.g. a counter) to force the widget open from outside -
+   * the CommandPalette's "Start Pomodoro Focus Timer" action has no other
+   * way to reach this component's local `visible` state. */
+  openSignal?: number;
 }
 
 /**
@@ -74,7 +78,7 @@ export interface PomodoroTimerProps {
  * 25-minute work sessions and 5-minute breaks. Persists session history to
  * localStorage for later analysis.
  */
-export function PomodoroTimer({ taskId }: PomodoroTimerProps = {}) {
+export function PomodoroTimer({ taskId, openSignal }: PomodoroTimerProps = {}) {
   const [visible, setVisible] = useState(false);
   const [isBreak, setIsBreak] = useState(false);
   const [remaining, setRemaining] = useState(WORK_DURATION);
@@ -82,6 +86,17 @@ export function PomodoroTimer({ taskId }: PomodoroTimerProps = {}) {
   const [sessionCount, setSessionCount] = useState(0);
   const sessionStartRef = useRef<Date | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // External open trigger (CommandPalette's "Start Pomodoro" action) - skips
+  // the initial mount so passing openSignal={0} doesn't force it open.
+  const isFirstOpenSignal = useRef(true);
+  useEffect(() => {
+    if (isFirstOpenSignal.current) {
+      isFirstOpenSignal.current = false;
+      return;
+    }
+    if (openSignal !== undefined) setVisible(true);
+  }, [openSignal]);
 
   // Alt+P keyboard shortcut to toggle the widget
   useEffect(() => {

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -23,7 +23,16 @@ const COPILOT_EXCLUDED_ROUTES = ['/profile'];
 
 export default function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const [isChatOpen, setIsChatOpen] = useState(false);
+  // Incremented (never read for its value) to force PomodoroTimer open from
+  // the CommandPalette's "Start Pomodoro" action - see PomodoroTimer's
+  // `openSignal` prop.
+  const [pomodoroOpenSignal, setPomodoroOpenSignal] = useState(0);
   const modKey = usePlatformKey();
+
+  const handleCommandPaletteAction = (actionId: string) => {
+    if (actionId === 'ai-copilot') setIsChatOpen(true);
+    if (actionId === 'pomodoro') setPomodoroOpenSignal((n) => n + 1);
+  };
   const pathname = usePathname();
   const copilotAvailable = !COPILOT_EXCLUDED_ROUTES.some(
     (route) => pathname === route || pathname?.startsWith(`${route}/`),
@@ -62,7 +71,7 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
           <FirestoreSync />
           <div className="min-h-screen flex flex-col bg-background text-foreground">
             <OfflineBanner />
-            <Navbar />
+            <Navbar onCommandPaletteAction={handleCommandPaletteAction} />
             <div className="flex flex-1 pt-20">
               <Sidebar />
               <main className="min-w-0 flex-1 p-6 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pl-72 md:p-8 md:pb-8 max-w-7xl transition-all duration-300">
@@ -104,7 +113,7 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
             )}
 
             <SyllabusChatDrawer isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
-            <PomodoroTimer />
+            <PomodoroTimer openSignal={pomodoroOpenSignal} />
           </div>
         </AppStateProvider>
       </SidebarProvider>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -188,7 +188,14 @@ function NotificationBell({
   );
 }
 
-export default function Navbar() {
+export interface NavbarProps {
+  /** Forwarded to CommandPalette's onAction - handles actions (AI Copilot,
+   * Pomodoro) whose state lives in LayoutWrapper, outside what Navbar or
+   * CommandPalette can reach on their own. */
+  onCommandPaletteAction?: (actionId: string) => void;
+}
+
+export default function Navbar({ onCommandPaletteAction }: NavbarProps = {}) {
   const { resolvedTheme, setTheme } = useTheme();
   const { user, signOut } = useAuth();
   const router = useRouter();
@@ -250,6 +257,7 @@ export default function Navbar() {
               isOpen={isCommandPaletteOpen}
               onClose={() => setIsCommandPaletteOpen(false)}
               onOpen={() => setIsCommandPaletteOpen(true)}
+              onAction={onCommandPaletteAction}
             />
           </>
         )}

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, type ReactNode } from 'react';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { SectionIcon } from '@/components/ui/SectionIcon';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
@@ -611,7 +612,15 @@ export function PlannerView() {
             </h2>
           </div>
 
-          {filteredItems.length === 0 ? (
+          {!state.initialized ? (
+            // See the identical guard in CoursesListView.tsx - without it, a
+            // student with real tasks briefly sees "No tasks match these
+            // filters" before the first Firestore snapshot lands.
+            <div className="space-y-3">
+              <SkeletonCard />
+              <SkeletonCard />
+            </div>
+          ) : filteredItems.length === 0 ? (
             <EmptyState
               icon={
                 <svg

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -11,7 +11,11 @@ export interface SyllabusListProps {
   courseId: string;
 }
 
-function formatSize(bytes: number): string {
+function formatSize(bytes: number | undefined): string {
+  // A legacy/partial-upload document can be missing sizeBytes entirely -
+  // without this guard, `undefined / (1024*1024)` renders literally "NaN MB"
+  // to the user instead of degrading gracefully.
+  if (typeof bytes !== 'number' || Number.isNaN(bytes)) return 'Unknown size';
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -90,7 +90,7 @@ const scheduleItems: ScheduleItem[] = [
 function renderPlanner() {
   return render(
     <AuthProvider>
-      <AppStateProvider initialState={{ courses, scheduleItems }}>
+      <AppStateProvider initialState={{ courses, scheduleItems, initialized: true }}>
         <PlannerView />
       </AppStateProvider>
     </AuthProvider>,

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -106,7 +106,9 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
   it('PlannerView select filters and action buttons meet the 44px touch target requirement', () => {
     render(
       <AuthProvider>
-        <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
+        <AppStateProvider
+          initialState={{ courses: mockCourses, scheduleItems: mockItems, initialized: true }}
+        >
           <PlannerView />
         </AppStateProvider>
       </AuthProvider>,
@@ -133,7 +135,12 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
     render(
       <AuthProvider>
         <AppStateProvider
-          initialState={{ courses: mockCourses, contacts: mockContacts, selectedTerm: 'Fall 2026' }}
+          initialState={{
+            courses: mockCourses,
+            contacts: mockContacts,
+            selectedTerm: 'Fall 2026',
+            initialized: true,
+          }}
         >
           <ContactsListView />
         </AppStateProvider>


### PR DESCRIPTION
Second batch from the Round 2 audit. Scope: functional/UI findings that are pure, self-contained code fixes.

## What this fixes
- **CoursesListView, PlannerView, ContactsListView, DashboardView**: branch the empty-state UI on `state.initialized`, not `array.length === 0`. The Firestore listener's first snapshot hasn't landed on initial mount, so every collection defaults to `[]` the same as "genuinely has none" — a returning user with real courses/tasks/contacts briefly saw "No courses yet" (complete with a working "+ Add Course" button) for however long the network took. Shows the existing shared `SkeletonCard` while loading instead.
- **`SyllabusList.tsx`**: `formatSize()` now guards against a missing/non-numeric `sizeBytes` instead of rendering literally "NaN MB" — falls back to "Unknown size".
- **CommandPalette**: fixes three actions that looked wired up but weren't:
  - "Upload Syllabus" pushed to `/syllabus`, a route that doesn't exist anywhere and 404'd → now `/courses?autofill=true`.
  - "Add New Task" pushed to `/tasks?new=1`, but the Tasks page only supports editing, not creating → now `/dashboard?new=1`, the page that actually has a create-task modal.
  - "Ask AI Syllabus Copilot" / "What-If Grade Simulator" / "Start Pomodoro Focus Timer" all called `onAction` with no consumer anywhere → Grade Simulator now navigates to the real `/courses?simulator=true`; AI Copilot and Pomodoro fire `onAction`, now wired through `Navbar`/`LayoutWrapper` to the drawer's open state and a new `openSignal` prop on `PomodoroTimer`, since both widgets' state lives outside anything `CommandPalette` can reach directly.
- **`docs/walkthrough.md`**: corrects the documented Cmd+K/Ctrl+K binding, which actually opens the AI Copilot chat drawer, not the Command Palette (real shortcut: Cmd+P/Ctrl+P). Also removes a claimed "?" keyboard shortcuts cheat sheet that doesn't exist anywhere in the codebase.

## Deliberately deferred
The `dateUtils.ts` local-vs-UTC-getter due-date bucketing inconsistency. Its local-getter branch is a documented, deliberate choice to match `lib/calendar/dates.ts`'s own local-time bucketing convention (so "due 11:59pm" lands on the viewer's local calendar day, matching the calendar view) — changing it risks a regression in calendar rendering elsewhere for a narrower cross-timezone-viewer edge case. Worth a dedicated pass, not a blind patch.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] Full vitest suite green (572/572, excluding the one pre-existing emulator-dependent failure) — added 4 new CommandPalette regression tests, fixed 2 existing test files whose fixtures needed `initialized: true` to reach populated-state assertions
- [x] Verified against the real Firebase emulator + a real browser session: Ctrl+P opens the palette (Ctrl+K correctly opens the Copilot instead), "Upload Syllabus" lands on the real Autofill wizard with no 404, "Add New Task" opens the real Add Task modal on the Dashboard, and the NaN MB fix renders "Unknown size" on a syllabus record seeded without `sizeBytes`