### PR TITLE
fix: destructive-delete gaps, data-layer error handling, dueDate bucketing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,13 +3,26 @@
 // direct-to-Storage uploads) - the app has no external fonts, analytics, or
 // third-party scripts (confirmed: everything is self-hosted via next/font),
 // so the allowlist below is deliberately narrow to just those.
+//
+// Dev-only relaxations (never shipped to production, gated on NODE_ENV):
+// - 'unsafe-eval' - `next dev`'s webpack build evaluates chunks via eval()
+//   for its default eval-source-map devtool; without this every page fails
+//   to run any JS at all under this CSP in dev.
+// - localhost/127.0.0.1 in connect-src - the Firebase Local Emulator Suite
+//   (NEXT_PUBLIC_USE_FIREBASE_EMULATOR=true) talks to the Auth/Firestore
+//   emulators over plain http/ws on localhost, which the production
+//   connect-src list has no reason to allow.
+const isDev = process.env.NODE_ENV !== 'production';
+
 const CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https://*.googleusercontent.com",
   "font-src 'self' data:",
-  "connect-src 'self' https://*.googleapis.com https://*.google.com https://*.firebaseio.com wss://*.firebaseio.com https://*.gstatic.com",
+  `connect-src 'self' https://*.googleapis.com https://*.google.com https://*.firebaseio.com wss://*.firebaseio.com https://*.gstatic.com${
+    isDev ? ' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*' : ''
+  }`,
   "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
   "object-src 'none'",
   "base-uri 'self'",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Root error boundary for the App Router segment tree. Catches render-time
+ * exceptions in any page/layout under this one that isn't already handling
+ * its own error state, so a bug in one view doesn't take down the whole app
+ * with a blank white screen.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[app/error]', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-card p-6 text-center shadow-modal">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-load-critical/15 text-load-critical">
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+        <h1 className="mt-4 text-base font-semibold text-foreground">Something went wrong</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          An unexpected error occurred. Your data is safe — try again, or reload the page.
+        </p>
+        <div className="mt-5 flex justify-center gap-2">
+          <button
+            onClick={() => (window.location.href = '/dashboard')}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
+          >
+            Go to dashboard
+          </button>
+          <button
+            onClick={reset}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -197,7 +197,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<ScheduleItem | null>(null);
   const [confirmingDeleteCourse, setConfirmingDeleteCourse] = useState(false);
+  const [isDeletingCourse, setIsDeletingCourse] = useState(false);
   const [confirmingDeleteItemId, setConfirmingDeleteItemId] = useState<string | null>(null);
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
+  const [confirmingDeleteObjectiveIndex, setConfirmingDeleteObjectiveIndex] = useState<
+    number | null
+  >(null);
+  const [deletingObjectiveIndex, setDeletingObjectiveIndex] = useState<number | null>(null);
 
   const [addContactOpen, setAddContactOpen] = useState(false);
   const [newContact, setNewContact] = useState<ContactFormState>(EMPTY_CONTACT_FORM);
@@ -257,8 +263,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleDeleteCourse = async () => {
     if (!user) return;
-    await deleteCourse(user.uid, course, items, dispatch, courseContacts);
-    router.push('/dashboard');
+    setIsDeletingCourse(true);
+    try {
+      await deleteCourse(user.uid, course, items, dispatch, courseContacts);
+      router.push('/dashboard');
+    } finally {
+      setIsDeletingCourse(false);
+    }
   };
 
   const handleAddTask = async (values: ScheduleItemFormValues) => {
@@ -307,8 +318,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleDeleteTask = async (item: ScheduleItem) => {
     if (!user) return;
-    await deleteScheduleItem(user.uid, item, dispatch);
-    setConfirmingDeleteItemId(null);
+    setDeletingItemId(item.id);
+    try {
+      await deleteScheduleItem(user.uid, item, dispatch);
+      setConfirmingDeleteItemId(null);
+    } finally {
+      setDeletingItemId(null);
+    }
   };
 
   const handleAddContact = async () => {
@@ -406,14 +422,20 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleDeleteObjective = async (index: number) => {
     if (!user) return;
-    const current = [...(course.learningObjectives ?? [])];
-    current.splice(index, 1);
-    await updateCourse(
-      user.uid,
-      course,
-      { ...course, learningObjectives: current, learningObjectivesApproved: true },
-      dispatch,
-    );
+    setDeletingObjectiveIndex(index);
+    try {
+      const current = [...(course.learningObjectives ?? [])];
+      current.splice(index, 1);
+      await updateCourse(
+        user.uid,
+        course,
+        { ...course, learningObjectives: current, learningObjectivesApproved: true },
+        dispatch,
+      );
+      setConfirmingDeleteObjectiveIndex(null);
+    } finally {
+      setDeletingObjectiveIndex(null);
+    }
   };
 
   const handleAddObjective = async () => {
@@ -571,13 +593,15 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     <span className="text-muted-foreground">Delete course and its tasks?</span>
                     <button
                       onClick={handleDeleteCourse}
-                      className="rounded-full bg-destructive/10 px-3 py-1.5 font-semibold text-destructive transition-colors hover:bg-destructive/20"
+                      disabled={isDeletingCourse}
+                      className="rounded-full bg-destructive/10 px-3 py-1.5 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                     >
-                      Confirm
+                      {isDeletingCourse ? 'Deleting…' : 'Confirm'}
                     </button>
                     <button
                       onClick={() => setConfirmingDeleteCourse(false)}
-                      className="rounded-full px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent"
+                      disabled={isDeletingCourse}
+                      className="rounded-full px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
                     >
                       Cancel
                     </button>
@@ -862,26 +886,47 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                           />
                         </svg>
                       </button>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteObjective(i)}
-                        className="rounded p-1 text-muted-foreground hover:text-destructive transition-colors"
-                        aria-label="Delete objective"
-                      >
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
+                      {confirmingDeleteObjectiveIndex === i ? (
+                        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteObjective(i)}
+                            disabled={deletingObjectiveIndex === i}
+                            className="font-semibold text-destructive hover:underline disabled:opacity-50"
+                          >
+                            {deletingObjectiveIndex === i ? 'Deleting…' : 'Confirm'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteObjectiveIndex(null)}
+                            disabled={deletingObjectiveIndex === i}
+                            className="text-muted-foreground hover:underline disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingDeleteObjectiveIndex(i)}
+                          className="rounded p-1 text-muted-foreground hover:text-destructive transition-colors"
+                          aria-label="Delete objective"
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            className="h-3.5 w-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      )}
                     </div>
                   </li>
                 ),
@@ -1009,13 +1054,15 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                           <div className="flex items-center gap-2 text-xs">
                             <button
                               onClick={() => handleDeleteTask(item)}
-                              className="font-semibold text-destructive hover:underline"
+                              disabled={deletingItemId === item.id}
+                              className="font-semibold text-destructive hover:underline disabled:opacity-50"
                             >
-                              Confirm
+                              {deletingItemId === item.id ? 'Deleting…' : 'Confirm'}
                             </button>
                             <button
                               onClick={() => setConfirmingDeleteItemId(null)}
-                              className="text-muted-foreground hover:underline"
+                              disabled={deletingItemId === item.id}
+                              className="text-muted-foreground hover:underline disabled:opacity-50"
                             >
                               Cancel
                             </button>

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -1035,7 +1035,32 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                     id="autofill-course-instructor"
                     label="Instructor"
                     value={course.instructor}
-                    onChange={(v) => setCourse((c) => c && { ...c, instructor: v })}
+                    onChange={(v) => {
+                      const previousInstructor = course.instructor;
+                      setCourse((c) => c && { ...c, instructor: v });
+                      // Course.instructor and the matching professor Contact
+                      // are two independent drafts at this point - keep them
+                      // in sync while there's exactly one professor entry
+                      // that still matches the old name, so editing here
+                      // doesn't silently leave the Contact card showing a
+                      // stale name. Skipped when there are multiple
+                      // professors (ambiguous which one to update) or the
+                      // student has already hand-edited that entry away
+                      // from the extracted instructor name.
+                      const professorDrafts = contactDrafts.filter((cd) => cd.role === 'professor');
+                      if (
+                        professorDrafts.length === 1 &&
+                        (professorDrafts[0].values.fullName ?? '') === previousInstructor
+                      ) {
+                        setContactDrafts((drafts) =>
+                          drafts.map((cd) =>
+                            cd === professorDrafts[0]
+                              ? { ...cd, values: { ...cd.values, fullName: v } }
+                              : cd,
+                          ),
+                        );
+                      }
+                    }}
                   />
 
                   <div className="space-y-1.5">

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { collection, doc, onSnapshot } from 'firebase/firestore';
+import { collection, doc, onSnapshot, type FirestoreError } from 'firebase/firestore';
 import { db } from '@/lib/firebase/client';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
+import { useToast } from '@/components/ui/Toast';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 import { reconcileScheduleItems } from '@/lib/firestore/scheduleItems';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
@@ -18,6 +19,7 @@ import { mockCourses, mockScheduleItems } from '@/lib/mock-data';
 export function useFirestoreSync() {
   const { user } = useAuth();
   const { state, dispatch } = useAppState();
+  const { showError } = useToast();
   const stateRef = useRef(state);
 
   useEffect(() => {
@@ -26,6 +28,14 @@ export function useFirestoreSync() {
 
   useEffect(() => {
     if (!user || !db) return;
+
+    const onSyncError = (label: string) => (error: FirestoreError) => {
+      console.error(`[useFirestoreSync] ${label} listener failed:`, error);
+      showError(
+        `Couldn't sync your ${label}`,
+        'Your changes may not be saved. Try refreshing the page.',
+      );
+    };
     if (
       process.env.NODE_ENV !== 'production' &&
       typeof window !== 'undefined' &&
@@ -38,9 +48,13 @@ export function useFirestoreSync() {
       return;
     }
 
-    const unsubCourses = onSnapshot(collection(db, 'users', user.uid, 'courses'), (snapshot) => {
-      dispatch({ type: 'SET_COURSES', payload: snapshot.docs.map((d) => d.data() as Course) });
-    });
+    const unsubCourses = onSnapshot(
+      collection(db, 'users', user.uid, 'courses'),
+      (snapshot) => {
+        dispatch({ type: 'SET_COURSES', payload: snapshot.docs.map((d) => d.data() as Course) });
+      },
+      onSyncError('courses'),
+    );
     const unsubItems = onSnapshot(
       collection(db, 'users', user.uid, 'scheduleItems'),
       (snapshot) => {
@@ -51,18 +65,27 @@ export function useFirestoreSync() {
           payload: reconciled,
         });
       },
+      onSyncError('tasks'),
     );
-    const unsubContacts = onSnapshot(collection(db, 'users', user.uid, 'contacts'), (snapshot) => {
-      dispatch({ type: 'SET_CONTACTS', payload: snapshot.docs.map((d) => d.data() as Contact) });
-    });
+    const unsubContacts = onSnapshot(
+      collection(db, 'users', user.uid, 'contacts'),
+      (snapshot) => {
+        dispatch({ type: 'SET_CONTACTS', payload: snapshot.docs.map((d) => d.data() as Contact) });
+      },
+      onSyncError('contacts'),
+    );
     // Same doc ProfileView writes to via updateUserPreferences - kept here
     // instead of a separate listener per consumer, so a change (from this
     // device or another) reaches every view that reads state.preferences
     // through the one realtime subscription.
-    const unsubPreferences = onSnapshot(doc(db, 'users', user.uid), (snapshot) => {
-      const stored = snapshot.data()?.preferences as Partial<UserPreferences> | undefined;
-      dispatch({ type: 'SET_PREFERENCES', payload: { ...DEFAULT_PREFERENCES, ...stored } });
-    });
+    const unsubPreferences = onSnapshot(
+      doc(db, 'users', user.uid),
+      (snapshot) => {
+        const stored = snapshot.data()?.preferences as Partial<UserPreferences> | undefined;
+        dispatch({ type: 'SET_PREFERENCES', payload: { ...DEFAULT_PREFERENCES, ...stored } });
+      },
+      onSyncError('preferences'),
+    );
 
     return () => {
       unsubCourses();
@@ -70,5 +93,5 @@ export function useFirestoreSync() {
       unsubContacts();
       unsubPreferences();
     };
-  }, [user, dispatch]);
+  }, [user, dispatch, showError]);
 }

--- a/src/lib/planner/examCollisionDetector.ts
+++ b/src/lib/planner/examCollisionDetector.ts
@@ -5,6 +5,7 @@
  * any 48-hour window with 2+ exams/quizzes, or 3+ graded items — and
  * surfaces them as CollisionAlerts so the dashboard can warn early.
  */
+import { parseDayKey, toDayKey } from '@/lib/calendar/dates';
 import type { ScheduleItem } from '@/types/schedule';
 
 /** A detected cluster of overlapping high-stakes deadlines. */
@@ -21,10 +22,15 @@ const GRADED_TYPES = new Set(['exam', 'quiz', 'assignment', 'project', 'presenta
 const EXAM_TYPES = new Set(['exam', 'quiz']);
 const MS_48H = 48 * 60 * 60 * 1000;
 
-/** Parses a YYYY-MM-DD date string into a UTC midnight timestamp. */
-function dateKeyToMs(dateKey: string): number {
-  const [y, m, d] = dateKey.split('-').map(Number);
-  return Date.UTC(y, m - 1, d);
+/**
+ * Resolves a schedule item's due date to a local-midnight timestamp for its
+ * calendar day, using the same local-time bucketing convention as the rest
+ * of the app (see calendar/dates.ts). A bare `YYYY-MM-DD` due date and a
+ * full ISO due date (e.g. end-of-day) on the same calendar day must land on
+ * the same bucket here, or they'd silently miss each other's 48h window.
+ */
+function dueDateDayMs(item: ScheduleItem): number {
+  return parseDayKey(toDayKey(item.dueDate)).getTime();
 }
 
 /**
@@ -37,14 +43,12 @@ function dateKeyToMs(dateKey: string): number {
  * appears once, anchored to the earliest item's date.
  */
 export function detectExamCollisions(items: ScheduleItem[]): CollisionAlert[] {
-  const graded = items.filter(
-    (item) => !item.completed && GRADED_TYPES.has(item.type),
-  );
+  const graded = items.filter((item) => !item.completed && GRADED_TYPES.has(item.type));
 
   if (graded.length < 2) return [];
 
   // Sort ascending by due date so we can walk forward efficiently
-  const sorted = [...graded].sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+  const sorted = [...graded].sort((a, b) => dueDateDayMs(a) - dueDateDayMs(b));
 
   const alerts: CollisionAlert[] = [];
   // Track which item IDs have already been included in an alert to avoid
@@ -54,11 +58,11 @@ export function detectExamCollisions(items: ScheduleItem[]): CollisionAlert[] {
   for (let i = 0; i < sorted.length; i++) {
     if (consumed.has(sorted[i].id)) continue;
 
-    const anchorMs = dateKeyToMs(sorted[i].dueDate.slice(0, 10));
+    const anchorMs = dueDateDayMs(sorted[i]);
     const window: ScheduleItem[] = [sorted[i]];
 
     for (let j = i + 1; j < sorted.length; j++) {
-      const candidateMs = dateKeyToMs(sorted[j].dueDate.slice(0, 10));
+      const candidateMs = dueDateDayMs(sorted[j]);
       if (candidateMs - anchorMs <= MS_48H) {
         window.push(sorted[j]);
       }
@@ -76,7 +80,7 @@ export function detectExamCollisions(items: ScheduleItem[]): CollisionAlert[] {
     for (const item of window) consumed.add(item.id);
 
     alerts.push({
-      date: sorted[i].dueDate.slice(0, 10),
+      date: toDayKey(sorted[i].dueDate),
       items: window,
       severity: isCritical ? 'critical' : 'warning',
     });


### PR DESCRIPTION
## Summary

Batch 3 of the audit-driven fix series (following #204 security hardening and #205 functional/UI fixes). Focused on destructive-action safety, silent data-layer failures, and a timezone-dependent bug in exam collision detection.

- **Destructive delete gaps (CourseDetailView)**: the learning-objective delete button deleted immediately on click with no confirmation at all — now matches the course/task delete pattern (inline Confirm/Cancel). All three delete flows (course, task, objective) now show a "Deleting…" disabled state while the write is in flight, so a double-click can't fire two deletes.
- **Silent Firestore listener failures**: none of `useFirestoreSync`'s four `onSnapshot` listeners had an error callback — a permission change, expired auth token, or offline edge case would fail silently and leave the UI showing stale data forever. Each listener now reports failures via a toast. Also added a root `src/app/error.tsx` boundary for render-time errors, which didn't exist anywhere in the app.
- **Exam collision detector timezone bug**: `examCollisionDetector.ts` bucketed a full-ISO due date by its *UTC* calendar day, while the rest of the app (`calendar/dates.ts`) buckets by *local* calendar day. An assignment due 11:59pm local time near midnight UTC could land on the wrong day for the 48-hour collision window depending on the viewer's timezone. Now uses the same shared local-time day-key helper as everywhere else.
- **Course.instructor / Contact desync (partial)**: in the syllabus autofill review UI, editing the course instructor name only updated `Course.instructor` in local draft state — the parallel professor `Contact` draft could silently go stale. Now kept in sync when there's exactly one professor entry that hasn't already diverged from the extracted name. (Full bidirectional sync between arbitrary Course/Contact edits elsewhere in the app is a larger effort, out of scope here.)
- **Dev-mode CSP regression (fix for #204)**: while verifying this batch against `next dev` + the Firebase emulator, found the security-hardening CSP from the prior batch blocks `unsafe-eval`, which `next dev`'s default webpack source-map devtool requires — every page failed to run any JS at all locally. It also didn't allow the Firestore/Auth emulator's localhost connections. Both are now dev-only relaxations gated on `NODE_ENV`; production CSP is byte-for-byte unchanged (verified via `next start` + `curl -I`).

## Verification

- `tsc --noEmit`, `next lint`, and the full `vitest` suite (624/624, including `rules.spec.ts` against a live Firestore emulator) are all green.
- `next build` succeeds; production CSP headers confirmed unchanged.
- Real Firebase Local Emulator Suite (Auth + Firestore) + a live Playwright/Chromium session: signed up a test user, created a course, added a learning objective, verified Cancel keeps it and Confirm deletes it, verified the course delete confirmation UI and Cancel path, and forced a render-time error through a temporary test route to confirm the new `error.tsx` boundary catches it and "Go to dashboard" recovers cleanly (test route removed afterward, not part of this diff).

## Test plan

- [x] `tsc --noEmit`
- [x] `next lint`
- [x] `vitest run` (624/624)
- [x] `next build`
- [x] Manual verification against Firebase emulator + live browser (course/task/objective delete flows, error boundary)