### PR TITLE
feat: dismissible weekly workload briefing on the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,11 @@ All commits must be authored as `George-T83 <george.tannious@gmail.com>`, regard
 ## Verification standard
 
 This is a Next.js 14 + Firebase (Auth/Firestore/Storage) app. "Verified" means checked against the real Firebase Local Emulator Suite and a real browser session (Playwright) — not just that the code compiles or unit tests pass. For any change to a UI surface, actually navigate to it in a running browser and look at it before calling it done.
+
+## Merge approval
+
+Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking. Before requesting merge approval on any non-trivial change, produce a short review write-up (what changed, why, and evidence — screenshots against the real app for anything touching the UI) so the owner can review it the way a lead would review a teammate's PR, not just rubber-stamp a green check mark.
+
+## UI consistency
+
+Before adding or changing any "list card" pattern (a card with a header action button, an empty state, and a row-level edit/delete affordance — e.g. Contacts, Learning Objectives, Tasks on the course detail page), check how the other instances of that same pattern already look and match them exactly: same header button component (`CardActionButton`), same empty-state component (`EmptyState`), same button treatment for row-level actions (pill-style with a tinted background for primary/destructive actions, not a bare underlined text link). Do not invent a new one-off treatment for a single card — if an existing shared component already covers the need, use it. When two nearly-identical UI patterns exist in the same file, that is a bug worth fixing on sight, not something to leave for a later audit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,17 @@ This is a Next.js 14 + Firebase (Auth/Firestore/Storage) app. "Verified" means c
 
 ## Merge approval
 
-Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking. Before requesting merge approval on any non-trivial change, produce a short review write-up (what changed, why, and evidence — screenshots against the real app for anything touching the UI) so the owner can review it the way a lead would review a teammate's PR, not just rubber-stamp a green check mark.
+Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking.
+
+**Before asking for merge approval on every PR, with no exceptions** (not just "non-trivial" ones — there is no size threshold below which this step is skipped): publish a standalone review document as an Artifact and give the owner the link. This is a separate, required step every single time — it does not happen automatically, and it is easy to forget under time pressure, so treat "did I publish the review doc yet" as a checklist item on every PR, not a judgment call.
+
+The GitHub PR description does **not** satisfy this requirement by itself, no matter how thorough it is. The review doc must exist as its own artifact, and must contain:
+
+- What changed and why, broken out by logical change (not just a wall of diff).
+- Real evidence: actual screenshots from the running app (via the Firebase Local Emulator Suite + a live browser session) for anything touching the UI — before/after where a "before" is capturable, not just a description of what it used to look like.
+- The verification results (tsc, lint, tests, build, CI status).
+
+Only after that artifact is published and linked should merge approval be requested. If a PR is opened and merge approval is about to be asked for and no review doc has been published yet for it, stop and publish one before asking — this has been skipped before and should not happen again.
 
 ## UI consistency
 

--- a/src/components/contacts/ContactShareModal.tsx
+++ b/src/components/contacts/ContactShareModal.tsx
@@ -85,7 +85,7 @@ export function ContactShareModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
     >
       <div ref={dialogRef} tabIndex={-1} className="w-full max-w-lg outline-none">
-        <Card className="relative">
+        <Card accent="none" className="relative">
           <div className="max-h-[90vh] overflow-y-auto p-6 sm:p-7 space-y-5">
             {/* Header */}
             <div className="flex items-start justify-between border-b border-border pb-4">

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -356,13 +356,13 @@ export function ContactsListView() {
                               <>
                                 <button
                                   onClick={() => handleDelete(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-destructive hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-destructive/10 px-3 font-semibold text-destructive transition-colors hover:bg-destructive/20"
                                 >
                                   Confirm
                                 </button>
                                 <button
                                   onClick={() => setConfirmingDeleteId(null)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 text-muted-foreground hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 text-muted-foreground transition-colors hover:bg-accent"
                                 >
                                   Cancel
                                 </button>
@@ -371,25 +371,25 @@ export function ContactsListView() {
                               <>
                                 <button
                                   onClick={() => setDrafterContact(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   Draft Email
                                 </button>
                                 <button
                                   onClick={() => setShareContact(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   vCard/QR
                                 </button>
                                 <button
                                   onClick={() => openEdit(record)}
-                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   Edit
                                 </button>
                                 <button
                                   onClick={() => setConfirmingDeleteId(record.id)}
-                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 font-semibold text-destructive hover:underline"
+                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-3 font-semibold text-destructive transition-colors hover:bg-destructive/10"
                                 >
                                   Delete
                                 </button>
@@ -526,7 +526,7 @@ function ContactFormModal({
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="contact-form-title">
               {initialContact ? 'Edit Contact' : 'Add Contact'}

--- a/src/components/contacts/ProfessorEmailDrafterModal.tsx
+++ b/src/components/contacts/ProfessorEmailDrafterModal.tsx
@@ -113,7 +113,7 @@ export function ProfessorEmailDrafterModal({
         className="w-full max-w-lg outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border px-5 py-4">
             <div>

--- a/src/components/courses/AttendanceGauge.tsx
+++ b/src/components/courses/AttendanceGauge.tsx
@@ -373,7 +373,7 @@ export function AttendanceGauge({
           aria-labelledby="log-absence-title"
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
         >
-          <Card className="relative w-full max-w-md p-6 space-y-4">
+          <Card accent="none" className="relative w-full max-w-md p-6 space-y-4">
             <div className="flex items-center justify-between border-b border-border pb-3">
               <h3 id="log-absence-title" className="text-base font-bold text-foreground">
                 Log Course Absence

--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
@@ -143,13 +144,9 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
           </span>
           <h2 className="text-base font-semibold text-foreground">AI Summary</h2>
         </div>
-        <button
-          onClick={handleGenerate}
-          disabled={generating}
-          className="text-xs font-semibold text-primary hover:underline disabled:pointer-events-none disabled:opacity-50"
-        >
+        <CardActionButton variant="solid" onClick={handleGenerate} disabled={generating}>
           {generating ? 'Generating…' : summary ? 'Regenerate' : 'Generate'}
-        </button>
+        </CardActionButton>
       </div>
 
       {error && <p className="text-sm text-destructive">{error}</p>}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -644,15 +644,26 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
           </div>
 
           {courseContacts.length === 0 && !addContactOpen && (
-            <div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-border px-3 py-3">
-              <p className="text-sm text-muted-foreground">No contacts yet for this course.</p>
-              <button
-                onClick={() => setAddContactOpen(true)}
-                className="shrink-0 text-xs font-semibold text-primary hover:underline"
-              >
-                + Add
-              </button>
-            </div>
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+                  />
+                </svg>
+              }
+              title="No contacts yet for this course"
+              description="Add a professor or TA, or upload a syllabus above to extract contacts automatically."
+              action={{ label: '+ Add contact', onClick: () => setAddContactOpen(true) }}
+            />
           )}
 
           {courseContacts.length > 0 && (
@@ -705,7 +716,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         </div>
                         <button
                           onClick={() => handleStartEditContact(contact)}
-                          className="shrink-0 text-xs font-semibold text-primary hover:underline"
+                          className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                         >
                           Edit
                         </button>
@@ -788,20 +799,20 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
               )}
             </div>
             {!addingObjective && (
-              <button
-                onClick={() => setAddingObjective(true)}
-                className="shrink-0 text-xs font-semibold text-primary hover:underline"
-              >
-                + Add objective
-              </button>
+              <CardActionButton variant="solid" withPlus onClick={() => setAddingObjective(true)}>
+                Add objective
+              </CardActionButton>
             )}
           </div>
 
           {course.learningObjectives && course.learningObjectives.length > 0 ? (
-            <ul className="space-y-2.5">
+            <ul className="flex flex-col gap-2">
               {course.learningObjectives.map((objective, i) =>
                 editingObjectiveIndex === i ? (
-                  <li key={i} className="flex items-center gap-2">
+                  <li
+                    key={i}
+                    className="flex items-center gap-2 rounded-lg border border-border p-3"
+                  >
                     <input
                       type="text"
                       value={objectiveDraft}
@@ -857,7 +868,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                 ) : (
                   <li
                     key={i}
-                    className="group flex items-start justify-between gap-3 text-sm text-foreground"
+                    className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
                   >
                     <div className="flex items-start gap-2.5 min-w-0">
                       <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
@@ -865,34 +876,14 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         {renderInlineBold(objective)}
                       </span>
                     </div>
-                    <div className="flex items-center gap-1.5 shrink-0 opacity-80 group-hover:opacity-100 transition-opacity">
-                      <button
-                        type="button"
-                        onClick={() => handleStartEditObjective(i)}
-                        className="rounded p-1 text-muted-foreground hover:text-primary transition-colors"
-                        aria-label="Edit objective"
-                      >
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
-                          />
-                        </svg>
-                      </button>
+                    <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                       {confirmingDeleteObjectiveIndex === i ? (
                         <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
                           <button
                             type="button"
                             onClick={() => handleDeleteObjective(i)}
                             disabled={deletingObjectiveIndex === i}
-                            className="font-semibold text-destructive hover:underline disabled:opacity-50"
+                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                           >
                             {deletingObjectiveIndex === i ? 'Deleting…' : 'Confirm'}
                           </button>
@@ -900,32 +891,54 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                             type="button"
                             onClick={() => setConfirmingDeleteObjectiveIndex(null)}
                             disabled={deletingObjectiveIndex === i}
-                            className="text-muted-foreground hover:underline disabled:opacity-50"
+                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
                           >
                             Cancel
                           </button>
                         </div>
                       ) : (
-                        <button
-                          type="button"
-                          onClick={() => setConfirmingDeleteObjectiveIndex(i)}
-                          className="rounded p-1 text-muted-foreground hover:text-destructive transition-colors"
-                          aria-label="Delete objective"
-                        >
-                          <svg
-                            className="h-3.5 w-3.5"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleStartEditObjective(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                            aria-label="Edit objective"
                           >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteObjectiveIndex(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                            aria-label="Delete objective"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                              />
+                            </svg>
+                          </button>
+                        </>
                       )}
                     </div>
                   </li>
@@ -934,7 +947,26 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
             </ul>
           ) : (
             !addingObjective && (
-              <p className="text-sm text-muted-foreground">No learning objectives yet.</p>
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                }
+                title="No learning objectives yet"
+                description="Add one, or upload a syllabus above to extract objectives automatically."
+                action={{ label: '+ Add objective', onClick: () => setAddingObjective(true) }}
+              />
             )
           )}
 
@@ -1051,18 +1083,18 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                           Edit
                         </button>
                         {confirmingDeleteItemId === item.id ? (
-                          <div className="flex items-center gap-2 text-xs">
+                          <div className="flex items-center gap-1.5 text-xs">
                             <button
                               onClick={() => handleDeleteTask(item)}
                               disabled={deletingItemId === item.id}
-                              className="font-semibold text-destructive hover:underline disabled:opacity-50"
+                              className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                             >
                               {deletingItemId === item.id ? 'Deleting…' : 'Confirm'}
                             </button>
                             <button
                               onClick={() => setConfirmingDeleteItemId(null)}
                               disabled={deletingItemId === item.id}
-                              className="text-muted-foreground hover:underline disabled:opacity-50"
+                              className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
                             >
                               Cancel
                             </button>
@@ -1070,7 +1102,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         ) : (
                           <button
                             onClick={() => setConfirmingDeleteItemId(item.id)}
-                            className="text-xs font-semibold text-destructive hover:underline"
+                            className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
                           >
                             Delete
                           </button>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -218,6 +218,15 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [addingObjective, setAddingObjective] = useState(false);
   const [newObjectiveDraft, setNewObjectiveDraft] = useState('');
 
+  const [confirmingDeleteMaterialIndex, setConfirmingDeleteMaterialIndex] = useState<number | null>(
+    null,
+  );
+  const [deletingMaterialIndex, setDeletingMaterialIndex] = useState<number | null>(null);
+  const [editingMaterialIndex, setEditingMaterialIndex] = useState<number | null>(null);
+  const [materialDraft, setMaterialDraft] = useState('');
+  const [addingMaterial, setAddingMaterial] = useState(false);
+  const [newMaterialDraft, setNewMaterialDraft] = useState('');
+
   const course = state.courses.find((c) => c.id === courseId);
   const items = state.scheduleItems
     .filter((item) => item.courseId === courseId)
@@ -251,6 +260,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       color: values.color,
       icon: values.icon,
       meetingTimes: values.meetingTimes ?? [],
+      skipDates: values.skipDates ?? [],
       ...(values.instructor ? { instructor: values.instructor } : {}),
       ...(values.modality ? { modality: values.modality } : {}),
     };
@@ -471,6 +481,50 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     );
     setNewObjectiveDraft('');
     setAddingObjective(false);
+  };
+
+  const handleStartEditMaterial = (index: number) => {
+    setMaterialDraft(course.materials?.[index] ?? '');
+    setEditingMaterialIndex(index);
+  };
+
+  const handleCommitMaterialEdit = async (index: number) => {
+    if (!user) return;
+    const current = [...(course.materials ?? [])];
+    const trimmed = materialDraft.trim();
+    if (trimmed) {
+      current[index] = trimmed;
+    } else {
+      current.splice(index, 1);
+    }
+    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+    setEditingMaterialIndex(null);
+  };
+
+  const handleDeleteMaterial = async (index: number) => {
+    if (!user) return;
+    setDeletingMaterialIndex(index);
+    try {
+      const current = [...(course.materials ?? [])];
+      current.splice(index, 1);
+      await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+      setConfirmingDeleteMaterialIndex(null);
+    } finally {
+      setDeletingMaterialIndex(null);
+    }
+  };
+
+  const handleAddMaterial = async () => {
+    if (!user) return;
+    const trimmed = newMaterialDraft.trim();
+    if (!trimmed) {
+      setAddingMaterial(false);
+      return;
+    }
+    const current = [...(course.materials ?? []), trimmed];
+    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+    setNewMaterialDraft('');
+    setAddingMaterial(false);
   };
 
   const handleExportICS = () => {
@@ -1028,6 +1082,214 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                   type="button"
                   onClick={handleAddObjective}
                   disabled={!newObjectiveDraft.trim()}
+                  className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <Card className="rounded-2xl p-6 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-base font-semibold text-foreground">Materials</h2>
+            {!addingMaterial && (
+              <CardActionButton variant="solid" withPlus onClick={() => setAddingMaterial(true)}>
+                Add material
+              </CardActionButton>
+            )}
+          </div>
+
+          {course.materials && course.materials.length > 0 ? (
+            <ul className="flex flex-col gap-2">
+              {course.materials.map((material, i) =>
+                editingMaterialIndex === i ? (
+                  <li
+                    key={i}
+                    className="flex items-center gap-2 rounded-lg border border-border p-3"
+                  >
+                    <input
+                      type="text"
+                      value={materialDraft}
+                      onChange={(e) => setMaterialDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleCommitMaterialEdit(i);
+                        if (e.key === 'Escape') setEditingMaterialIndex(null);
+                      }}
+                      className="flex-1 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleCommitMaterialEdit(i)}
+                      className="rounded p-1 text-primary hover:bg-primary/10"
+                      aria-label="Save this material"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M4.5 12.75l6 6 9-13.5"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingMaterialIndex(null)}
+                      className="rounded p-1 text-muted-foreground hover:bg-muted"
+                      aria-label="Cancel editing"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                ) : (
+                  <li
+                    key={i}
+                    className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
+                  >
+                    <div className="min-w-0">
+                      <span className="leading-relaxed break-words">{material}</span>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
+                      {confirmingDeleteMaterialIndex === i ? (
+                        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteMaterial(i)}
+                            disabled={deletingMaterialIndex === i}
+                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                          >
+                            {deletingMaterialIndex === i ? 'Deleting…' : 'Confirm'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteMaterialIndex(null)}
+                            disabled={deletingMaterialIndex === i}
+                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleStartEditMaterial(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                            aria-label="Edit material"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteMaterialIndex(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                            aria-label="Delete material"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                              />
+                            </svg>
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </li>
+                ),
+              )}
+            </ul>
+          ) : (
+            !addingMaterial && (
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                    />
+                  </svg>
+                }
+                title="No materials yet"
+                description="Add a textbook, calculator, or other required supply, or upload a syllabus above to extract them automatically."
+                action={{ label: '+ Add material', onClick: () => setAddingMaterial(true) }}
+              />
+            )
+          )}
+
+          {addingMaterial && (
+            <div className="space-y-2 rounded-lg border border-border p-3">
+              <input
+                type="text"
+                value={newMaterialDraft}
+                onChange={(e) => setNewMaterialDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAddMaterial();
+                  if (e.key === 'Escape') setAddingMaterial(false);
+                }}
+                placeholder="e.g. Introduction to Algorithms, 3rd Edition"
+                className="w-full rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">Press Enter to save.</p>
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setAddingMaterial(false)}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAddMaterial}
+                  disabled={!newMaterialDraft.trim()}
                   className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
                   Add

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -16,7 +16,7 @@ import {
   updateScheduleItem,
   deleteScheduleItem,
 } from '@/lib/firestore/scheduleItems';
-import { createContact, updateContact } from '@/lib/firestore/contacts';
+import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
@@ -206,6 +206,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [deletingObjectiveIndex, setDeletingObjectiveIndex] = useState<number | null>(null);
 
   const [addContactOpen, setAddContactOpen] = useState(false);
+  const [confirmingDeleteContactId, setConfirmingDeleteContactId] = useState<string | null>(null);
+  const [deletingContactId, setDeletingContactId] = useState<string | null>(null);
   const [newContact, setNewContact] = useState<ContactFormState>(EMPTY_CONTACT_FORM);
   const [savingContact, setSavingContact] = useState(false);
   const [editingContactId, setEditingContactId] = useState<string | null>(null);
@@ -395,6 +397,17 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       dispatch,
     );
     setEditingContactId(null);
+  };
+
+  const handleDeleteContact = async (contact: Contact) => {
+    if (!user) return;
+    setDeletingContactId(contact.id);
+    try {
+      await deleteContact(user.uid, contact, dispatch);
+      setConfirmingDeleteContactId(null);
+    } finally {
+      setDeletingContactId(null);
+    }
   };
 
   const handleStartEditObjective = (index: number) => {
@@ -714,12 +727,39 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                             <span className="text-xs text-muted-foreground">{contact.title}</span>
                           )}
                         </div>
-                        <button
-                          onClick={() => handleStartEditContact(contact)}
-                          className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
-                        >
-                          Edit
-                        </button>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <button
+                            onClick={() => handleStartEditContact(contact)}
+                            className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                          >
+                            Edit
+                          </button>
+                          {confirmingDeleteContactId === contact.id ? (
+                            <div className="flex items-center gap-1.5 text-xs">
+                              <button
+                                onClick={() => handleDeleteContact(contact)}
+                                disabled={deletingContactId === contact.id}
+                                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                              >
+                                {deletingContactId === contact.id ? 'Deleting…' : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmingDeleteContactId(null)}
+                                disabled={deletingContactId === contact.id}
+                                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmingDeleteContactId(contact.id)}
+                              className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+                            >
+                              Delete
+                            </button>
+                          )}
+                        </div>
                       </div>
                       {contact.howToAddress && (
                         <p className="text-xs text-muted-foreground">

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -288,6 +288,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );
@@ -308,6 +310,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -783,21 +783,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
         <Card className="rounded-2xl p-6 space-y-4">
           <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2.5">
-              <h2 className="text-base font-semibold text-foreground">Learning Objectives</h2>
-              {course.learningObjectives && course.learningObjectives.length > 0 && (
-                <span
-                  className={cn(
-                    'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
-                    course.learningObjectivesApproved
-                      ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-                      : 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
-                  )}
-                >
-                  {course.learningObjectivesApproved ? 'Approved' : 'Needs review'}
-                </span>
-              )}
-            </div>
+            <h2 className="text-base font-semibold text-foreground">Learning Objectives</h2>
             {!addingObjective && (
               <CardActionButton variant="solid" withPlus onClick={() => setAddingObjective(true)}>
                 Add objective
@@ -870,8 +856,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     key={i}
                     className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
                   >
-                    <div className="flex items-start gap-2.5 min-w-0">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                    <div className="min-w-0">
                       <span className="leading-relaxed break-words">
                         {renderInlineBold(objective)}
                       </span>

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -14,6 +14,7 @@ import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course
 import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 import { useAppState } from '@/context/AppStateContext';
 import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
 import { COURSE_ICON_PRESETS, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
@@ -67,6 +68,7 @@ const emptyValues: CourseFormValues = {
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
   const { state } = useAppState();
   const [values, setValues] = useState<CourseFormValues>(emptyValues);
+  const [baseline, setBaseline] = useState<CourseFormValues>(emptyValues);
   const [errors, setErrors] = useState<Partial<Record<keyof CourseFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -80,29 +82,34 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
 
   useEffect(() => {
     if (!open) return;
-    setValues(
-      initialCourse
-        ? {
-            code: initialCourse.code,
-            title: initialCourse.title,
-            instructor: initialCourse.instructor ?? '',
-            term: initialCourse.term ?? '',
-            color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
-            icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
-            modality: initialCourse.modality,
-            meetingTimes: initialCourse.meetingTimes ?? [],
-            skipDates: initialCourse.skipDates ?? [],
-          }
-        : // A fresh course defaults to whichever preset is least represented
-          // among the user's existing courses, so a student with 8+ courses
-          // doesn't land on the same blue every time.
-          { ...emptyValues, color: pickNextCourseColor(coursesRef.current) },
-    );
+    const initial: CourseFormValues = initialCourse
+      ? {
+          code: initialCourse.code,
+          title: initialCourse.title,
+          instructor: initialCourse.instructor ?? '',
+          term: initialCourse.term ?? '',
+          color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
+          icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
+          modality: initialCourse.modality,
+          meetingTimes: initialCourse.meetingTimes ?? [],
+          skipDates: initialCourse.skipDates ?? [],
+        }
+      : // A fresh course defaults to whichever preset is least represented
+        // among the user's existing courses, so a student with 8+ courses
+        // doesn't land on the same blue every time.
+        { ...emptyValues, color: pickNextCourseColor(coursesRef.current) };
+    setValues(initial);
+    setBaseline(initial);
     setErrors({});
     setSubmitError(null);
   }, [open, initialCourse]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -195,14 +202,40 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
       role="dialog"
       aria-modal="true"
       aria-labelledby="course-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this course that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="course-form-title">
@@ -498,7 +531,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             <CardFooter className="justify-end gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
               >
                 Cancel

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -9,6 +9,7 @@ import {
   CardContent,
   CardFooter,
 } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course';
 import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
@@ -173,7 +174,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="course-form-title">
               {initialCourse ? 'Edit Course' : 'Add Course'}
@@ -333,13 +334,9 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-foreground">Weekly meetings</span>
-                  <button
-                    type="button"
-                    onClick={addMeetingTime}
-                    className="text-xs font-semibold text-primary hover:underline"
-                  >
-                    + Add meeting time
-                  </button>
+                  <CardActionButton variant="solid" withPlus onClick={addMeetingTime}>
+                    Add meeting time
+                  </CardActionButton>
                 </div>
                 {meetingTimes.length === 0 ? (
                   <p className="text-xs text-muted-foreground">

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -61,6 +61,7 @@ const emptyValues: CourseFormValues = {
   icon: DEFAULT_COURSE_ICON,
   modality: undefined,
   meetingTimes: [],
+  skipDates: [],
 };
 
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
@@ -90,6 +91,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
             modality: initialCourse.modality,
             meetingTimes: initialCourse.meetingTimes ?? [],
+            skipDates: initialCourse.skipDates ?? [],
           }
         : // A fresh course defaults to whichever preset is least represented
           // among the user's existing courses, so a student with 8+ courses
@@ -133,9 +135,36 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
     setErrors((e) => (e.meetingTimes ? { ...e, meetingTimes: undefined } : e));
   };
 
+  const skipDates = values.skipDates ?? [];
+
+  const addSkipDate = () => {
+    setValues((s) => ({ ...s, skipDates: [...(s.skipDates ?? []), ''] }));
+  };
+
+  const removeSkipDate = (index: number) => {
+    setValues((s) => ({
+      ...s,
+      skipDates: (s.skipDates ?? []).filter((_, i) => i !== index),
+    }));
+  };
+
+  const updateSkipDate = (index: number, value: string) => {
+    setValues((s) => ({
+      ...s,
+      skipDates: (s.skipDates ?? []).map((d, i) => (i === index ? value : d)),
+    }));
+    setErrors((e) => (e.skipDates ? { ...e, skipDates: undefined } : e));
+  };
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const result = courseFormSchema.safeParse(values);
+    // A skip-date row the user added but hasn't picked a date for yet
+    // shouldn't block submission - drop empty rows rather than fail
+    // validation on a placeholder.
+    const result = courseFormSchema.safeParse({
+      ...values,
+      skipDates: (values.skipDates ?? []).filter((d) => d.trim().length > 0),
+    });
     if (!result.success) {
       const fieldErrors: Partial<Record<keyof CourseFormValues, string>> = {};
       for (const issue of result.error.issues) {
@@ -422,6 +451,48 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
                 {errors.meetingTimes && (
                   <p className="text-xs text-destructive">{errors.meetingTimes}</p>
                 )}
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-foreground">
+                    Skip dates (holidays &amp; breaks)
+                  </span>
+                  <CardActionButton variant="solid" withPlus onClick={addSkipDate}>
+                    Add skip date
+                  </CardActionButton>
+                </div>
+                {skipDates.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No skipped dates yet — add one to hide a weekly meeting on a holiday or break.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {skipDates.map((date, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-2 rounded-lg border border-border p-2"
+                      >
+                        <input
+                          aria-label={`Skip date ${index + 1}`}
+                          type="date"
+                          value={date}
+                          onChange={(e) => updateSkipDate(index, e.target.value)}
+                          className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeSkipDate(index)}
+                          aria-label={`Remove skip date ${index + 1}`}
+                          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {errors.skipDates && <p className="text-xs text-destructive">{errors.skipDates}</p>}
               </div>
             </CardContent>
             <CardFooter className="justify-end gap-2">

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -119,6 +119,7 @@ export function CoursesListView() {
         ...(values.term ? { term: values.term } : {}),
         ...(values.modality ? { modality: values.modality } : {}),
         ...(values.meetingTimes?.length ? { meetingTimes: values.meetingTimes } : {}),
+        ...(values.skipDates?.length ? { skipDates: values.skipDates } : {}),
       },
       dispatch,
     );

--- a/src/components/courses/GradeCalculatorModal.tsx
+++ b/src/components/courses/GradeCalculatorModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useAppState } from '@/context/AppStateContext';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
+import { useModalA11y } from '@/hooks/useModalA11y';
 import {
   GradeCategory,
   calculateCurrentWeightedGrade,
@@ -45,16 +46,7 @@ export function GradeCalculatorModal({
     }
   }, [initialCourseId, state.courses, selectedCourseId]);
 
-  // Handle Escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   // Math Calculations
   const currentGrade = useMemo(() => {
@@ -132,7 +124,11 @@ export function GradeCalculatorModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <Card accent="none" className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
+      <Card
+        ref={dialogRef}
+        accent="none"
+        className="relative w-full max-w-2xl overflow-hidden transition-all my-8"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border/40 px-5 py-4 bg-muted/20">
           <div className="flex items-center gap-3">

--- a/src/components/courses/GradeCalculatorModal.tsx
+++ b/src/components/courses/GradeCalculatorModal.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useAppState } from '@/context/AppStateContext';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import {
   GradeCategory,
   calculateCurrentWeightedGrade,
@@ -131,7 +132,7 @@ export function GradeCalculatorModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <Card className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
+      <Card accent="none" className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border/40 px-5 py-4 bg-muted/20">
           <div className="flex items-center gap-3">
@@ -326,12 +327,9 @@ export function GradeCalculatorModal({
                     >
                       Total Weight: {totalWeight}% {totalWeight !== 100 && '(Adjust to 100%)'}
                     </span>
-                    <button
-                      onClick={handleAddCategory}
-                      className="rounded-md bg-muted px-2 py-1 text-xs font-semibold text-foreground hover:bg-accent transition-colors"
-                    >
-                      + Add Category
-                    </button>
+                    <CardActionButton variant="solid" withPlus onClick={handleAddCategory}>
+                      Add Category
+                    </CardActionButton>
                   </div>
                 </div>
 

--- a/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
+++ b/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
@@ -107,7 +107,7 @@ describe('GradeCalculatorModal (Item 36)', () => {
     const onClose = vi.fn();
     renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={onClose} />);
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
+++ b/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
@@ -35,7 +35,7 @@ function renderWithProviders(ui: React.ReactElement, stateOverrides: Partial<App
   return render(
     <ThemeProvider>
       <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
-    </ThemeProvider>
+    </ThemeProvider>,
   );
 }
 
@@ -58,7 +58,9 @@ describe('GradeCalculatorModal (Item 36)', () => {
   });
 
   it('renders nothing when isOpen is false', () => {
-    const { container } = renderWithProviders(<GradeCalculatorModal isOpen={false} onClose={vi.fn()} />);
+    const { container } = renderWithProviders(
+      <GradeCalculatorModal isOpen={false} onClose={vi.fn()} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
@@ -95,7 +97,7 @@ describe('GradeCalculatorModal (Item 36)', () => {
   it('allows adding and updating categories dynamically', () => {
     renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={vi.fn()} />);
 
-    const addBtn = screen.getByText('+ Add Category');
+    const addBtn = screen.getByText('Add Category');
     fireEvent.click(addBtn);
 
     expect(screen.getByLabelText('Category 4 Name')).toBeDefined();

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -155,8 +155,11 @@ export function DashboardView() {
         title: values.title,
         color: values.color,
         icon: values.icon,
+        meetingTimes: values.meetingTimes ?? [],
+        skipDates: values.skipDates ?? [],
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
+        ...(values.modality ? { modality: values.modality } : {}),
       },
       dispatch,
     );

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -431,13 +431,14 @@ export function DashboardView() {
                   <p className="text-xs text-muted-foreground">
                     Add your first course to start tracking assignments and workload.
                   </p>
-                  <button
-                    type="button"
+                  <CardActionButton
+                    variant="solid"
+                    withPlus
                     onClick={() => setAddCourseOpen(true)}
-                    className="mt-1 rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                    className="mt-1"
                   >
-                    + Add Course
-                  </button>
+                    Add Course
+                  </CardActionButton>
                 </div>
               ) : (
                 <div className="flex items-center gap-4">

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -178,6 +178,8 @@ export function DashboardView() {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -16,6 +16,7 @@ import { createScheduleItem, updateScheduleItem } from '@/lib/firestore/schedule
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
+import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
@@ -238,6 +239,8 @@ export function DashboardView() {
             </button>
           </div>
         </div>
+
+        <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
 
         <div className="space-y-4">
           <Card accent="left" className="rounded-2xl p-6">

--- a/src/components/dashboard/WeeklyBriefingCard.tsx
+++ b/src/components/dashboard/WeeklyBriefingCard.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useAuth } from '@/context/AuthContext';
+import { calculateWorkloadBreakdown } from '@/lib/planner/projectChunker';
+import type { ScheduleItem } from '@/types/schedule';
+
+/** Monday of the calendar week containing `date`, as a YYYY-MM-DD key - used
+ * to dismiss the briefing "for the week" regardless of which day the
+ * student first opens the dashboard on. */
+function weekStartKey(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay(); // 0 = Sunday
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diffToMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+function dismissedStorageKey(uid: string, weekKey: string): string {
+  return `weekly-briefing-dismissed:${uid}:${weekKey}`;
+}
+
+export interface WeeklyBriefingCardProps {
+  scheduleItems: ScheduleItem[];
+}
+
+/** A once-a-week "here's what's ahead" summary, generated entirely from data
+ * the workload engine already computes - no notification backend required.
+ * Dismissing it hides it until the following week's Monday. */
+export function WeeklyBriefingCard({ scheduleItems }: WeeklyBriefingCardProps) {
+  const { user } = useAuth();
+  const weekKey = useMemo(() => weekStartKey(new Date()), []);
+  const [dismissed, setDismissed] = useState(() => {
+    if (!user || typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(dismissedStorageKey(user.uid, weekKey)) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const breakdown = useMemo(() => calculateWorkloadBreakdown(scheduleItems), [scheduleItems]);
+
+  const { thisWeek } = breakdown;
+  const pendingDays = thisWeek.days.map((day) => ({
+    ...day,
+    items: day.items.filter((item) => !item.completed),
+  }));
+  const pendingItemCount = pendingDays.reduce((sum, day) => sum + day.items.length, 0);
+  const examCount = pendingDays.reduce(
+    (sum, day) => sum + day.items.filter((item) => item.type === 'exam').length,
+    0,
+  );
+  const heaviestDay = pendingDays.reduce(
+    (max, day) => (day.totalMinutes > max.totalMinutes ? day : max),
+    pendingDays[0],
+  );
+
+  if (dismissed || pendingItemCount === 0 || !heaviestDay || heaviestDay.totalMinutes === 0) {
+    return null;
+  }
+
+  const totalHours = Math.round((thisWeek.totalMinutes / 60) * 10) / 10;
+  const heaviestTitles = heaviestDay.items
+    .slice(0, 2)
+    .map((item) => item.title)
+    .join(', ');
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (!user) return;
+    try {
+      window.localStorage.setItem(dismissedStorageKey(user.uid, weekKey), 'true');
+    } catch {
+      // Non-fatal: worst case the briefing reappears next visit this week.
+    }
+  };
+
+  return (
+    <Card accent="none" className="rounded-2xl border-primary/20 bg-primary/5 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-bold text-primary">
+            This week: {totalHours}h
+            {examCount > 0 ? `, ${examCount} exam${examCount > 1 ? 's' : ''}` : ''}
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Heaviest day: {heaviestDay.dayName} ({heaviestTitles}
+            {heaviestDay.items.length > 2 ? `, +${heaviestDay.items.length - 2} more` : ''})
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss this week's briefing"
+          className="shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/layout/TermSwitcher.tsx
+++ b/src/components/layout/TermSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { inferCurrentTerm, useAppState } from '@/context/AppStateContext';
 import { cn } from '@/lib/utils';
 
@@ -40,6 +40,24 @@ function sortTermsChronologically(terms: string[]): string[] {
 export function TermSwitcher() {
   const { state, dispatch } = useAppState();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const close = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
 
   const terms = useMemo(
     () =>
@@ -59,12 +77,13 @@ export function TermSwitcher() {
 
   const select = (term: string) => {
     dispatch({ type: 'SELECT_TERM', payload: term });
-    setOpen(false);
+    close();
   };
 
   return (
     <div className="relative">
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
@@ -89,11 +108,7 @@ export function TermSwitcher() {
       </button>
       {open && (
         <>
-          <div
-            className="fixed inset-0 z-[60] bg-transparent"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
+          <div className="fixed inset-0 z-[60] bg-transparent" onClick={close} aria-hidden="true" />
           <div
             role="listbox"
             aria-label="Select term"

--- a/src/components/planner/ProjectChunkerModal.tsx
+++ b/src/components/planner/ProjectChunkerModal.tsx
@@ -217,7 +217,7 @@ export function ProjectChunkerModal({
       aria-modal="true"
       aria-labelledby="project-chunker-title"
     >
-      <Card ref={dialogRef} className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+      <Card ref={dialogRef} accent="none" className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <CardHeader className="flex-row items-center justify-between space-y-0 border-b border-border pb-4">
           <div className="flex items-center gap-2.5">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">

--- a/src/components/planner/ProjectChunkerModal.tsx
+++ b/src/components/planner/ProjectChunkerModal.tsx
@@ -135,6 +135,7 @@ export function ProjectChunkerModal({
   const [selectedCourseId, setSelectedCourseId] = useState<string>('');
   const [saving, setSaving] = useState(false);
   const [savedSuccess, setSavedSuccess] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const dialogRef = useModalA11y<HTMLDivElement>(isModalOpen, onClose);
   const availableCourses = courses || state.courses;
@@ -164,6 +165,7 @@ export function ProjectChunkerModal({
   const handlePersistChunks = async () => {
     if (!user || previewChunks.length === 0) return;
     setSaving(true);
+    setSaveError(null);
     try {
       if (onSaveChunks) {
         await onSaveChunks(previewChunks);
@@ -205,6 +207,9 @@ export function ProjectChunkerModal({
       }, 1200);
     } catch (err) {
       console.error('Failed to save study chunks:', err);
+      setSaveError(
+        "Couldn't save these chunks - some may have been added before the failure. Check your planner, then try again.",
+      );
     } finally {
       setSaving(false);
     }
@@ -391,6 +396,11 @@ export function ProjectChunkerModal({
         </CardContent>
 
         <CardFooter className="flex-wrap items-center justify-between gap-3">
+          {saveError && (
+            <p className="w-full rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-xs text-load-critical">
+              {saveError}
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">
             Total Work: <span className="font-bold text-foreground">{totalHours} hrs</span> spread
             across{' '}

--- a/src/components/planner/WorkloadOverviewDashboard.tsx
+++ b/src/components/planner/WorkloadOverviewDashboard.tsx
@@ -190,7 +190,7 @@ export function WorkloadOverviewDashboard({
             breathe), so a genuinely heavy or overdue day is visibly louder
             than a merely busy one instead of every non-quiet day getting
             an identical fixed "urgent" treatment. */}
-        <Card className={cn('xl:col-span-1 p-5', WORKLOAD_GLOW_CLASS[glowLevel])}>
+        <Card accent="glow" className={cn('xl:col-span-1 p-5', WORKLOAD_GLOW_CLASS[glowLevel])}>
           <CardHeader className="flex-row items-start justify-between gap-3 space-y-0 border-b border-border p-0 pb-5">
             <div>
               <CardTitle>Workload Load</CardTitle>

--- a/src/components/planner/WorkloadOverviewDashboard.tsx
+++ b/src/components/planner/WorkloadOverviewDashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { ProjectChunkerModal } from './ProjectChunkerModal';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
 import { cn } from '@/lib/utils';
 import { toLocalDateStr } from '@/lib/planner/projectChunker';
 import {
@@ -51,6 +52,7 @@ export function WorkloadOverviewDashboard({
 }: WorkloadOverviewDashboardProps = {}) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const [chunkerOpen, setChunkerOpen] = useState(false);
   const [selectedDayDate, setSelectedDayDate] = useState<string | null>(selectedDate ?? null);
 
@@ -109,6 +111,7 @@ export function WorkloadOverviewDashboard({
       await updateScheduleItem(user.uid, task, updatedItem, dispatch);
     } catch (err) {
       console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
     }
   };
 
@@ -126,6 +129,7 @@ export function WorkloadOverviewDashboard({
       await updateScheduleItem(user.uid, task, updatedItem, dispatch);
     } catch (err) {
       console.error('Failed to shift task date:', err);
+      showError("Couldn't reschedule that task. Try again in a moment.");
     }
   };
 

--- a/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
+++ b/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { WorkloadOverviewDashboard } from '../WorkloadOverviewDashboard';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import { toLocalDateStr } from '@/lib/planner/projectChunker';
 import * as scheduleItemsLib from '@/lib/firestore/scheduleItems';
 import type { ScheduleItem, AssignmentType, Course } from '@/types/schedule';
@@ -96,9 +97,11 @@ function renderDashboard(
 ) {
   return render(
     <AuthProvider>
-      <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: items }}>
-        <WorkloadOverviewDashboard {...props} />
-      </AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: items }}>
+          <WorkloadOverviewDashboard {...props} />
+        </AppStateProvider>
+      </ToastProvider>
     </AuthProvider>,
   );
 }

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -275,7 +275,7 @@ export function ProfileView() {
             {!editing && (
               <button
                 onClick={() => setEditing(true)}
-                className="text-xs font-semibold text-primary hover:underline"
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
               >
                 Edit
               </button>
@@ -312,7 +312,7 @@ export function ProfileView() {
               <button
                 type="submit"
                 disabled={saving}
-                className="text-xs font-semibold text-primary hover:underline disabled:opacity-50"
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
               >
                 {saving ? 'Saving...' : 'Save'}
               </button>
@@ -323,7 +323,7 @@ export function ProfileView() {
                   setName(user.displayName ?? '');
                   clearError();
                 }}
-                className="text-xs font-medium text-muted-foreground hover:underline"
+                className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel
               </button>
@@ -551,7 +551,7 @@ export function ProfileView() {
                       setPasswordFormError(null);
                       clearError();
                     }}
-                    className="text-xs font-semibold text-primary hover:underline"
+                    className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                   >
                     Change password
                   </button>
@@ -642,7 +642,7 @@ export function ProfileView() {
                         setPasswordFormError(null);
                         clearError();
                       }}
-                      className="text-xs font-medium text-muted-foreground hover:underline"
+                      className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
                     >
                       Cancel
                     </button>
@@ -753,7 +753,7 @@ export function ProfileView() {
                     setDeletePassword('');
                     clearError();
                   }}
-                  className="text-xs font-medium text-muted-foreground hover:underline"
+                  className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
                 >
                   Cancel
                 </button>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -2,12 +2,16 @@
 
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import { collection, getDocs } from 'firebase/firestore';
 import { Card } from '@/components/ui/Card';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
+import { db } from '@/lib/firebase/client';
 import { updateUserPreferences, type UserPreferences } from '@/lib/firestore/preferences';
+import type { SyllabusUpload } from '@/types/syllabus';
 import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import { GpaGoalRadial } from './GpaGoalRadial';
@@ -112,6 +116,7 @@ export function ProfileView() {
   const { user, error, updateDisplayName, changePassword, deleteAccount, signOut, clearError } =
     useAuth();
   const { state, dispatch } = useAppState();
+  const { showError } = useToast();
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(user?.displayName ?? '');
@@ -129,6 +134,9 @@ export function ProfileView() {
   const [passwordSaving, setPasswordSaving] = useState(false);
   const [passwordSuccess, setPasswordSuccess] = useState(false);
   const [passwordFormError, setPasswordFormError] = useState<string | null>(null);
+
+  // --- Account & Data: data export ---
+  const [downloadingData, setDownloadingData] = useState(false);
 
   // --- Account & Data: delete account ---
   const [deleting, setDeleting] = useState(false);
@@ -212,26 +220,47 @@ export function ProfileView() {
     }
   };
 
-  const handleDownloadData = () => {
-    const payload = {
-      exportedAt: new Date().toISOString(),
-      account: {
-        email: user.email,
-        displayName: user.displayName,
-        memberSince: user.metadata.creationTime ?? null,
-      },
-      courses: state.courses,
-      scheduleItems: state.scheduleItems,
-    };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `syllabus-sense-data-${user.uid}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+  const handleDownloadData = async () => {
+    const firestore = db;
+    if (!firestore) return;
+    setDownloadingData(true);
+    try {
+      const syllabiByCourse = await Promise.all(
+        state.courses.map((course) =>
+          getDocs(collection(firestore, 'users', user.uid, 'courses', course.id, 'syllabi')),
+        ),
+      );
+      const syllabi: SyllabusUpload[] = syllabiByCourse.flatMap((snapshot) =>
+        snapshot.docs.map((doc) => doc.data() as SyllabusUpload),
+      );
+
+      const payload = {
+        exportedAt: new Date().toISOString(),
+        account: {
+          email: user.email,
+          displayName: user.displayName,
+          memberSince: user.metadata.creationTime ?? null,
+        },
+        courses: state.courses,
+        scheduleItems: state.scheduleItems,
+        contacts: state.contacts,
+        preferences: state.preferences,
+        syllabi,
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `syllabus-sense-data-${user.uid}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch {
+      showError("Couldn't put together your data export. Try again in a moment.");
+    } finally {
+      setDownloadingData(false);
+    }
   };
 
   const deleteReady =
@@ -663,14 +692,16 @@ export function ProfileView() {
           <h3 className="text-sm font-semibold text-foreground">Your data</h3>
           <div className="mt-2 flex items-center justify-between gap-4">
             <p className="text-sm text-muted-foreground">
-              Download every course and task in your account as a JSON file.
+              Download every course, task, contact, syllabus, and preference in your account as a
+              JSON file.
             </p>
             <button
               type="button"
               onClick={handleDownloadData}
-              className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:bg-accent"
+              disabled={downloadingData}
+              className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Download my data
+              {downloadingData ? 'Preparing...' : 'Download my data'}
             </button>
           </div>
         </div>

--- a/src/components/schedule/ExtracurricularView.tsx
+++ b/src/components/schedule/ExtracurricularView.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { EmptyState } from '@/components/ui/EmptyState';
 
 export type ActivityCategory = 'club' | 'research' | 'internship' | 'athletics' | 'volunteering';
 
@@ -366,22 +368,14 @@ export function ExtracurricularView({
             Balance leadership, lab research, and career milestones alongside your coursework.
           </p>
         </div>
-        <button
+        <CardActionButton
+          variant="solid"
+          withPlus
           onClick={openCreateModal}
           data-testid="add-activity-btn"
-          className="inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-primary hover:opacity-90 text-primary-foreground text-sm font-medium transition-all shadow-lg shadow-primary/20 active:scale-95 cursor-pointer min-h-[44px]"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
           Add Activity
-        </button>
+        </CardActionButton>
       </div>
 
       {/* Commitment Capacity Meter Card */}
@@ -571,32 +565,32 @@ export function ExtracurricularView({
           </h2>
 
           {filteredActivities.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-border p-8 text-center bg-muted/30">
-              <svg
-                className="w-10 h-10 text-muted-foreground mx-auto mb-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
-              <p className="text-muted-foreground font-medium">No activities match your filters</p>
-              <button
-                onClick={() => {
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              }
+              title="No activities match your filters"
+              action={{
+                label: 'Clear all filters',
+                onClick: () => {
                   setSelectedCategory('all');
                   setStatusFilter('all');
                   setSearchQuery('');
-                }}
-                className="mt-3 text-xs text-primary hover:underline cursor-pointer"
-              >
-                Clear all filters
-              </button>
-            </div>
+                },
+              }}
+            />
           ) : (
             filteredActivities.map((act) => {
               const cfg = CATEGORY_CONFIG[act.category];
@@ -905,7 +899,10 @@ export function ExtracurricularView({
           aria-labelledby="activity-modal-title"
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
         >
-          <Card className="relative w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+          <Card
+            accent="none"
+            className="relative w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto"
+          >
             <div className="flex items-center justify-between border-b border-border pb-3">
               <h3 id="activity-modal-title" className="text-lg font-bold text-foreground">
                 {editingActivity ? 'Edit Activity' : 'Add Extracurricular Activity'}

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -455,16 +455,16 @@ export function PlannerView() {
                 Edit
               </button>
               {isConfirmingThisDelete ? (
-                <div className="flex items-center gap-2 text-xs">
+                <div className="flex items-center gap-1.5 text-xs">
                   <button
                     onClick={() => handleDeleteTask(item)}
-                    className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-foreground hover:underline"
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground/10 px-2.5 font-semibold text-foreground transition-colors hover:bg-foreground/15"
                   >
                     Confirm
                   </button>
                   <button
                     onClick={() => setConfirmingDeleteId(null)}
-                    className="inline-flex min-h-[44px] items-center justify-center px-2 text-muted-foreground hover:underline"
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-full px-2.5 text-muted-foreground transition-colors hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -475,7 +475,7 @@ export function PlannerView() {
                 // doesn't compete with the one badge that should stand out.
                 <button
                   onClick={() => setConfirmingDeleteId(item.id)}
-                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-2.5 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 >
                   Delete
                 </button>

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -388,6 +388,8 @@ export function PlannerView() {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardFooter } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { EmptyState } from '@/components/ui/EmptyState';
 import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
 import { createCourseWithScheduleItems } from '@/lib/firestore/courses';
 import { createContacts, updateContact } from '@/lib/firestore/contacts';
@@ -49,6 +51,45 @@ const STEPS: { key: Step; label: string }[] = [
   { key: 'review', label: 'Review' },
   { key: 'saving', label: 'Save' },
 ];
+
+interface CourseDraft {
+  code: string;
+  title: string;
+  instructor: string;
+  term: string;
+  color: string;
+  icon: string;
+  modality: CourseModality | undefined;
+  meetingTimes: MeetingTime[];
+  materials: string[];
+  skipDates: string[];
+  notes: string;
+}
+
+/** The review-screen state worth protecting against a closed tab or an
+ * accidentally-dismissed modal - everything Claude extracted plus whatever
+ * the student has already hand-corrected. Deliberately excludes the
+ * uploaded `File` itself (not serializable, and not needed to resume - the
+ * expensive part to lose is the human review, not the raw upload) and
+ * `savedCourseId` (a course that's already in Firestore has nothing left to
+ * resume). Persisted to localStorage rather than Firestore since this is a
+ * same-device recovery net, not cross-device sync. */
+interface PersistedAutofillDraft {
+  savedAt: string;
+  fileName: string;
+  course: CourseDraft;
+  items: DraftItem[];
+  unresolved: string[];
+  learningObjectivesText: string;
+  learningObjectivesApproved: boolean;
+  contactDrafts: DraftContact[];
+}
+
+const AUTOFILL_DRAFT_STORAGE_PREFIX = 'syllabus-autofill-draft';
+
+function autofillDraftStorageKey(userId: string): string {
+  return `${AUTOFILL_DRAFT_STORAGE_PREFIX}:${userId}`;
+}
 
 interface DraftItem extends ExtractedScheduleItem {
   /** Local id for React keys/editing - not persisted as-is. */
@@ -342,19 +383,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * gets a confirmation instead of losing that work silently (SY-5). */
   const initialDraftRef = useRef<string | null>(null);
 
-  const [course, setCourse] = useState<{
-    code: string;
-    title: string;
-    instructor: string;
-    term: string;
-    color: string;
-    icon: string;
-    modality: CourseModality | undefined;
-    meetingTimes: MeetingTime[];
-    materials: string[];
-    skipDates: string[];
-    notes: string;
-  } | null>(null);
+  const [course, setCourse] = useState<CourseDraft | null>(null);
   const [items, setItems] = useState<DraftItem[]>([]);
   const [unresolved, setUnresolved] = useState<string[]>([]);
   /** Claude's suggested syllabus file name, freely editable - not just a
@@ -366,11 +395,6 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * array so a student can restructure freely, split back into lines at
    * render/save time. */
   const [learningObjectivesText, setLearningObjectivesText] = useState('');
-  /** Whether the objectives section renders at all - set once at extraction
-   * time from whether Claude found any, independent of later edits (mirrors
-   * the "Claude also caught" notes/skipDates section, which stays visible
-   * once populated even as its content is edited). */
-  const [hasLearningObjectives, setHasLearningObjectives] = useState(false);
   const [learningObjectivesApproved, setLearningObjectivesApproved] = useState(true);
   /** Index into `learningObjectivesLines` currently open for editing, or
    * null when every objective is just static text with a pencil button. */
@@ -382,6 +406,96 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * failure without letting a second Confirm click create a duplicate
    * course. Cleared on full success/close and on reset. */
   const [savedCourseId, setSavedCourseId] = useState<string | null>(null);
+  /** A draft found in localStorage from a previous session that closed
+   * (tab closed, modal dismissed) before the student confirmed - offered as
+   * a resume/discard choice on the upload screen rather than silently
+   * dropped or silently auto-loaded over a fresh upload. */
+  const [pendingDraft, setPendingDraft] = useState<PersistedAutofillDraft | null>(null);
+
+  const clearPersistedDraft = () => {
+    if (!user) return;
+    try {
+      localStorage.removeItem(autofillDraftStorageKey(user.uid));
+    } catch {
+      // Best-effort - a failure here just means a stale draft lingers,
+      // which the next open will still offer to discard.
+    }
+  };
+
+  // Offer to resume a draft left over from a closed tab/dismissed modal,
+  // checked once per modal open rather than continuously.
+  useEffect(() => {
+    if (!open || !user) return;
+    try {
+      const raw = localStorage.getItem(autofillDraftStorageKey(user.uid));
+      if (raw) setPendingDraft(JSON.parse(raw) as PersistedAutofillDraft);
+    } catch {
+      // Corrupt or inaccessible storage - treat as "no draft to resume".
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, user]);
+
+  // Autosaves the review-screen draft on every edit so a closed tab or a
+  // dismissed modal doesn't lose the student's work - cleared once the
+  // course is actually saved (see handleConfirm) or explicitly discarded.
+  useEffect(() => {
+    if (!user || step !== 'review' || !course) return;
+    try {
+      const draft: PersistedAutofillDraft = {
+        savedAt: new Date().toISOString(),
+        fileName,
+        course,
+        items,
+        unresolved,
+        learningObjectivesText,
+        learningObjectivesApproved,
+        contactDrafts,
+      };
+      localStorage.setItem(autofillDraftStorageKey(user.uid), JSON.stringify(draft));
+    } catch {
+      // Quota exceeded or storage disabled (e.g. private browsing) - the
+      // review screen itself still works, it just loses the safety net.
+    }
+  }, [
+    user,
+    step,
+    course,
+    items,
+    unresolved,
+    fileName,
+    learningObjectivesText,
+    learningObjectivesApproved,
+    contactDrafts,
+  ]);
+
+  const resumeDraft = () => {
+    if (!pendingDraft) return;
+    setCourse(pendingDraft.course);
+    setItems(pendingDraft.items);
+    setUnresolved(pendingDraft.unresolved);
+    setFileName(pendingDraft.fileName);
+    setLearningObjectivesText(pendingDraft.learningObjectivesText);
+    setLearningObjectivesApproved(pendingDraft.learningObjectivesApproved);
+    setContactDrafts(pendingDraft.contactDrafts);
+    // Baseline the SY-5 dirty-check against the resumed draft itself, not a
+    // fresh extraction - re-running Claude from here should compare against
+    // what's actually on screen.
+    initialDraftRef.current = JSON.stringify({
+      course: pendingDraft.course,
+      items: pendingDraft.items.map(omitDraftKey),
+      unresolved: pendingDraft.unresolved,
+      learningObjectivesText: pendingDraft.learningObjectivesText,
+      learningObjectivesApproved: pendingDraft.learningObjectivesApproved,
+      contactDrafts: pendingDraft.contactDrafts.map(omitContactDraftKey),
+    });
+    setStep('review');
+    setPendingDraft(null);
+  };
+
+  const discardDraft = () => {
+    clearPersistedDraft();
+    setPendingDraft(null);
+  };
 
   const reset = () => {
     setStep('upload');
@@ -392,7 +506,6 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setUnresolved([]);
     setFileName('');
     setLearningObjectivesText('');
-    setHasLearningObjectives(false);
     setLearningObjectivesApproved(true);
     setContactDrafts([]);
     setSavedCourseId(null);
@@ -401,6 +514,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     initialDraftRef.current = null;
   };
 
+  // Deliberately does NOT clear the persisted draft - closing the modal
+  // (tab close, Cancel, the X button) is exactly the case this feature
+  // protects against, so the in-progress review survives to be resumed
+  // next time the modal opens. Only a successful save or an explicit
+  // "Discard" clears it.
   const handleClose = () => {
     reset();
     onClose();
@@ -468,14 +586,12 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       }));
       const nextUnresolved = result.unresolved ?? [];
       const nextLearningObjectivesText = result.course.learningObjectives.join('\n');
-      const nextHasLearningObjectives = result.course.learningObjectives.length > 0;
       const nextContactDrafts = buildContactDrafts(result.course.contacts, state.contacts);
 
       setCourse(nextCourse);
       setItems(nextItems);
       setUnresolved(nextUnresolved);
       setLearningObjectivesText(nextLearningObjectivesText);
-      setHasLearningObjectives(nextHasLearningObjectives);
       setLearningObjectivesApproved(true);
       setContactDrafts(nextContactDrafts);
       setFileName(
@@ -641,18 +757,36 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setEditingObjectiveIndex(index);
   };
 
+  // `editingObjectiveIndex === learningObjectivesLines.length` (one past the
+  // last real line) is the "adding a new objective" state - reuses the same
+  // edit-row UI instead of a separate add form.
+  const startAddingObjective = () => {
+    setObjectiveDraft('');
+    setEditingObjectiveIndex(learningObjectivesLines.length);
+  };
+
   // A blank commit removes that objective rather than saving an empty
-  // bullet - editing down to nothing is how a student deletes one.
+  // bullet - editing an existing one down to nothing is still a valid way
+  // to delete it, alongside the explicit trash button below.
   const commitObjectiveEdit = (index: number) => {
     const nextLines = [...learningObjectivesLines];
     const trimmed = objectiveDraft.trim();
-    if (trimmed) {
+    if (index >= nextLines.length) {
+      if (trimmed) nextLines.push(trimmed);
+    } else if (trimmed) {
       nextLines[index] = trimmed;
     } else {
       nextLines.splice(index, 1);
     }
     setLearningObjectivesText(nextLines.join('\n'));
     setEditingObjectiveIndex(null);
+  };
+
+  const removeObjective = (index: number) => {
+    const nextLines = [...learningObjectivesLines];
+    nextLines.splice(index, 1);
+    setLearningObjectivesText(nextLines.join('\n'));
+    if (editingObjectiveIndex === index) setEditingObjectiveIndex(null);
   };
 
   const approvedCount = items.filter((i) => i.approved).length;
@@ -739,6 +873,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       // together or not at all, instead of the course succeeding while a
       // mid-loop failure leaves some assignments missing.
       await createCourseWithScheduleItems(user.uid, newCourse, scheduleItems, dispatch);
+      // The course now exists in Firestore - resuming the localStorage draft
+      // from here on would recreate it as a duplicate, so the recovery net
+      // is no longer needed regardless of what happens next (syllabus file,
+      // contacts).
+      clearPersistedDraft();
 
       if (file) {
         try {
@@ -800,7 +939,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         className="max-h-full w-full max-w-3xl overflow-y-auto outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
+        <Card accent="none" className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
           <div className="bg-gradient-brand px-6 py-6 text-white sm:px-8">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
               Syllabus Autofill
@@ -838,6 +977,51 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   />
                 </svg>
                 <span>{error}</span>
+              </div>
+            )}
+
+            {step === 'upload' && !file && pendingDraft && (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary/30 bg-primary/5 px-4 py-3">
+                <div className="flex items-start gap-2.5">
+                  <svg
+                    className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      Resume your unfinished review
+                      {pendingDraft.course.code ? ` for ${pendingDraft.course.code}` : ''}?
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      You closed this before confirming - your edits are still here.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={discardDraft}
+                    className="rounded-full px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resumeDraft}
+                    className="rounded-full bg-primary px-3.5 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                  >
+                    Resume
+                  </button>
+                </div>
               </div>
             )}
 
@@ -1318,28 +1502,28 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   </section>
                 )}
 
-                {hasLearningObjectives && (
-                  <section
-                    className="review-reveal space-y-2.5 rounded-xl border border-primary/20 bg-primary/5 p-3 sm:p-4"
-                    style={{ animationDelay: '165ms' }}
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <h3 className="flex items-center gap-1.5 text-xs font-semibold text-primary">
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s4.332.477 5.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                          />
-                        </svg>
-                        Learning Objectives
-                      </h3>
+                <section
+                  className="review-reveal space-y-2.5 rounded-xl border border-primary/20 bg-primary/5 p-3 sm:p-4"
+                  style={{ animationDelay: '165ms' }}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="flex items-center gap-1.5 text-xs font-semibold text-primary">
+                      <svg
+                        className="h-3.5 w-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s4.332.477 5.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                        />
+                      </svg>
+                      Learning Objectives
+                    </h3>
+                    <div className="flex items-center gap-3">
                       <label className="flex items-center gap-1.5 text-xs font-medium text-foreground">
                         <input
                           type="checkbox"
@@ -1349,79 +1533,118 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                         />
                         Save to course
                       </label>
+                      {editingObjectiveIndex !== learningObjectivesLines.length && (
+                        <CardActionButton variant="solid" withPlus onClick={startAddingObjective}>
+                          Add objective
+                        </CardActionButton>
+                      )}
                     </div>
-                    {learningObjectivesLines.length > 0 && (
-                      <ul className="space-y-1 text-xs text-foreground">
-                        {learningObjectivesLines.map((line, i) =>
-                          editingObjectiveIndex === i ? (
-                            <li key={i} className="flex items-start gap-1.5">
-                              <span className="mt-1 text-primary">&bull;</span>
-                              <textarea
-                                autoFocus
-                                value={objectiveDraft}
-                                onChange={(e) => setObjectiveDraft(e.target.value)}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter' && !e.shiftKey) {
-                                    e.preventDefault();
-                                    commitObjectiveEdit(i);
-                                  } else if (e.key === 'Escape') {
-                                    setEditingObjectiveIndex(null);
-                                  }
-                                }}
-                                rows={2}
-                                className="max-h-32 flex-1 resize-y overflow-y-auto rounded-lg border border-primary bg-card px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                              />
-                              <div className="flex shrink-0 flex-col gap-1">
-                                <button
-                                  type="button"
-                                  onClick={() => commitObjectiveEdit(i)}
-                                  className="rounded p-0.5 text-primary hover:bg-primary/10"
-                                  aria-label="Save this objective"
+                  </div>
+                  {learningObjectivesLines.length === 0 &&
+                  editingObjectiveIndex !== learningObjectivesLines.length ? (
+                    <EmptyState
+                      icon={
+                        <svg
+                          className="h-5 w-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                      }
+                      title="No learning objectives yet"
+                      description="Claude didn't find any in this syllabus - add one, or skip this section."
+                      action={{ label: '+ Add objective', onClick: startAddingObjective }}
+                    />
+                  ) : (
+                    <ul className="space-y-1.5 text-xs text-foreground">
+                      {[
+                        ...learningObjectivesLines,
+                        ...(editingObjectiveIndex === learningObjectivesLines.length ? [''] : []),
+                      ].map((line, i) =>
+                        editingObjectiveIndex === i ? (
+                          <li
+                            key={i}
+                            className="flex items-start gap-1.5 rounded-lg border border-primary/30 p-2"
+                          >
+                            <textarea
+                              autoFocus
+                              value={objectiveDraft}
+                              onChange={(e) => setObjectiveDraft(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                  e.preventDefault();
+                                  commitObjectiveEdit(i);
+                                } else if (e.key === 'Escape') {
+                                  setEditingObjectiveIndex(null);
+                                }
+                              }}
+                              rows={2}
+                              placeholder="e.g. Design multi-tier web applications"
+                              className="max-h-32 flex-1 resize-y overflow-y-auto rounded-lg border border-primary bg-card px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                            />
+                            <div className="flex shrink-0 flex-col gap-1">
+                              <button
+                                type="button"
+                                onClick={() => commitObjectiveEdit(i)}
+                                className="rounded p-1 text-primary hover:bg-primary/10"
+                                aria-label="Save this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
                                 >
-                                  <svg
-                                    className="h-3.5 w-3.5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M4.5 12.75l6 6 9-13.5"
-                                    />
-                                  </svg>
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => setEditingObjectiveIndex(null)}
-                                  className="rounded p-0.5 text-muted-foreground hover:bg-muted"
-                                  aria-label="Cancel editing this objective"
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M4.5 12.75l6 6 9-13.5"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setEditingObjectiveIndex(null)}
+                                className="rounded p-1 text-muted-foreground hover:bg-muted"
+                                aria-label="Cancel editing this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
                                 >
-                                  <svg
-                                    className="h-3.5 w-3.5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M6 18L18 6M6 6l12 12"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </li>
-                          ) : (
-                            <li key={i} className="flex items-start gap-1.5">
-                              <span className="text-primary">&bull;</span>
-                              <span className="flex-1">{renderInlineMarkdown(line)}</span>
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </li>
+                        ) : (
+                          <li
+                            key={i}
+                            className="group flex items-start justify-between gap-1.5 rounded-lg border border-border p-2 transition-colors hover:border-primary/30"
+                          >
+                            <span className="flex-1 leading-relaxed">
+                              {renderInlineMarkdown(line)}
+                            </span>
+                            <div className="flex items-center gap-0.5 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                               <button
                                 type="button"
                                 onClick={() => startEditingObjective(i)}
-                                className="shrink-0 text-muted-foreground transition-colors hover:text-primary"
+                                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
                                 aria-label="Edit this objective"
                               >
                                 <svg
@@ -1438,18 +1661,39 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                                   />
                                 </svg>
                               </button>
-                            </li>
-                          ),
-                        )}
-                      </ul>
-                    )}
+                              <button
+                                type="button"
+                                onClick={() => removeObjective(i)}
+                                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                                aria-label="Remove this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  )}
+                  {learningObjectivesLines.length > 0 && (
                     <p className="text-xs text-muted-foreground">
-                      Click the pencil to edit an objective, or clear its text to remove it. Uncheck
-                      &quot;Save to course&quot; to skip saving these for now without losing what
-                      Claude found.
+                      Uncheck &quot;Save to course&quot; to skip saving these for now without losing
+                      what Claude found.
                     </p>
-                  </section>
-                )}
+                  )}
+                </section>
 
                 {contactDrafts.length > 0 && (
                   <section className="space-y-3">

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -5,6 +5,7 @@ import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import type { Course, AssignmentType } from '@/types/schedule';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { useModalA11y } from '@/hooks/useModalA11y';
 
 export interface SuggestedChunk {
   title: string;
@@ -97,16 +98,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isLoading]);
 
-  // Handle Escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   const selectedCourse: Course | undefined = state.courses.find((c) => c.id === selectedCourseId);
 
@@ -231,7 +223,10 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
       }}
     >
       <div className="fixed inset-y-0 right-0 flex max-w-full pl-6 sm:pl-10">
-        <aside className="w-screen max-w-md md:max-w-lg border-l border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl flex flex-col justify-between">
+        <aside
+          ref={dialogRef}
+          className="w-screen max-w-md md:max-w-lg border-l border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl flex flex-col justify-between"
+        >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border/40 px-4 py-3.5 bg-muted/20">
             <div className="flex items-center gap-2.5">

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import type { Course, AssignmentType } from '@/types/schedule';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useToast } from '@/components/ui/Toast';
 
 export interface SuggestedChunk {
   title: string;
@@ -41,6 +42,7 @@ const STARTER_PROMPTS = [
 export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: SyllabusChatDrawerProps) {
   const { state } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const [selectedCourseId, setSelectedCourseId] = useState<string>(initialCourseId || '');
   const [inputQuery, setInputQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +72,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
       setUploadedFile({ name: file.name, base64 });
     } catch (err) {
       console.error('Failed to read upload file:', err);
+      showError("Couldn't read that file. Try a different one.");
     } finally {
       setFileUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -503,6 +506,7 @@ function SuggestedChunksCard({
 }) {
   const { user } = useAuth();
   const { dispatch } = useAppState();
+  const { showError } = useToast();
   const [loading, setLoading] = useState(false);
   const [applied, setApplied] = useState(false);
 
@@ -530,6 +534,9 @@ function SuggestedChunksCard({
       setApplied(true);
     } catch (err) {
       console.error('Failed to apply suggested chunks:', err);
+      showError(
+        "Couldn't add these to your planner - some may have been added before the failure. Check your task list, then try again.",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/components/syllabus/SyllabusDiffModal.tsx
+++ b/src/components/syllabus/SyllabusDiffModal.tsx
@@ -86,7 +86,10 @@ export function SyllabusDiffModal({
       aria-labelledby="syllabus-diff-title"
       className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4 bg-black/40 backdrop-blur-sm"
     >
-      <Card className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col">
+      <Card
+        accent="none"
+        className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col"
+      >
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-border pb-4 shrink-0">
           <div>

--- a/src/components/syllabus/SyllabusDiffModal.tsx
+++ b/src/components/syllabus/SyllabusDiffModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import { analyzeSyllabusRevision, PolicyChange, PolicyDiffReport } from '@/lib/syllabus/diffEngine';
+import { useModalA11y } from '@/hooks/useModalA11y';
 
 export interface SyllabusDiffModalProps {
   courseCode?: string;
@@ -38,6 +39,8 @@ export function SyllabusDiffModal({
       setSelectedChangeIds(new Set(report.changes.map((c) => c.id)));
     }
   }, [report]);
+
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   if (!isOpen) return null;
 
@@ -87,6 +90,7 @@ export function SyllabusDiffModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4 bg-black/40 backdrop-blur-sm"
     >
       <Card
+        ref={dialogRef}
         accent="none"
         className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col"
       >

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -55,19 +55,19 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
             <span className="text-xs text-muted-foreground">{formatSize(syllabus.sizeBytes)}</span>
           </div>
           {confirmingDeleteId === syllabus.id ? (
-            <div className="flex items-center gap-2 text-xs shrink-0">
+            <div className="flex items-center gap-1.5 text-xs shrink-0">
               <button
                 onClick={() => {
                   if (userId) deleteSyllabusUpload(userId, syllabus);
                   setConfirmingDeleteId(null);
                 }}
-                className="font-semibold text-destructive hover:underline"
+                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20"
               >
                 Confirm
               </button>
               <button
                 onClick={() => setConfirmingDeleteId(null)}
-                className="text-muted-foreground hover:underline"
+                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel
               </button>
@@ -75,7 +75,7 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
           ) : (
             <button
               onClick={() => setConfirmingDeleteId(syllabus.id)}
-              className="text-xs font-semibold text-destructive hover:underline shrink-0"
+              className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
             >
               Delete
             </button>

--- a/src/components/syllabus/SyllabusUploader.tsx
+++ b/src/components/syllabus/SyllabusUploader.tsx
@@ -97,17 +97,26 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
               style={{ width: `${progress}%` }}
             />
           </div>
-          <div className="flex gap-3 text-xs font-semibold">
+          <div className="flex gap-1.5 text-xs font-semibold">
             {status === 'uploading' ? (
-              <button onClick={pause} className="text-primary hover:underline">
+              <button
+                onClick={pause}
+                className="rounded-full px-2.5 py-1 text-primary transition-colors hover:bg-primary/10"
+              >
                 Pause
               </button>
             ) : (
-              <button onClick={resume} className="text-primary hover:underline">
+              <button
+                onClick={resume}
+                className="rounded-full px-2.5 py-1 text-primary transition-colors hover:bg-primary/10"
+              >
                 Resume
               </button>
             )}
-            <button onClick={cancel} className="text-destructive hover:underline">
+            <button
+              onClick={cancel}
+              className="rounded-full px-2.5 py-1 text-destructive transition-colors hover:bg-destructive/10"
+            >
               Cancel
             </button>
           </div>
@@ -117,7 +126,10 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
       {status === 'success' && (
         <div className="flex items-center justify-between rounded-xl border border-border p-4 text-sm">
           <span className="text-foreground">Upload complete.</span>
-          <button onClick={reset} className="text-xs font-semibold text-primary hover:underline">
+          <button
+            onClick={reset}
+            className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+          >
             Upload another
           </button>
         </div>

--- a/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
@@ -148,7 +148,7 @@ describe('SyllabusChatDrawer (Item 35)', () => {
     const onClose = vi.fn();
     renderWithProviders(<SyllabusChatDrawer isOpen={true} onClose={onClose} />);
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SyllabusChatDrawer } from '../SyllabusChatDrawer';
 import { AppStateProvider, AppState } from '@/context/AppStateContext';
 import { ThemeProvider } from '@/context/ThemeProvider';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Course } from '@/types/schedule';
 
 vi.mock('@/context/AuthContext', () => ({
@@ -51,7 +52,9 @@ function renderWithProviders(ui: React.ReactElement, stateOverrides: Partial<App
 
   return render(
     <ThemeProvider>
-      <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+      </ToastProvider>
     </ThemeProvider>,
   );
 }

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -282,6 +282,8 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -133,7 +133,7 @@ export function TaskFormModal({
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
             <CardDescription>

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -13,6 +13,7 @@ import { scheduleItemFormSchema, type ScheduleItemFormValues } from '@/lib/valid
 import type { Course, ScheduleItem, AssignmentType, Priority } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 
 const TYPE_OPTIONS: { value: AssignmentType; label: string }[] = [
   { value: 'assignment', label: 'Assignment' },
@@ -60,33 +61,41 @@ export function TaskFormModal({
   initialItem,
 }: TaskFormModalProps) {
   const [values, setValues] = useState<ScheduleItemFormValues>(emptyValues(courses[0]?.id ?? ''));
+  const [baseline, setBaseline] = useState<ScheduleItemFormValues>(
+    emptyValues(courses[0]?.id ?? ''),
+  );
   const [errors, setErrors] = useState<Partial<Record<keyof ScheduleItemFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    setValues(
-      initialItem
-        ? {
-            title: initialItem.title,
-            type: initialItem.type,
-            courseId: initialItem.courseId,
-            dueDate: initialItem.dueDate.slice(0, 10),
-            estimatedHours: initialItem.estimatedHours?.toString() ?? '',
-            priority: initialItem.priority ?? 'medium',
-            notes: initialItem.notes ?? '',
-            progress: initialItem.progress?.toString() ?? '',
-            gradeWeight: initialItem.gradeWeight?.toString() ?? '',
-            gradeCategory: initialItem.gradeCategory ?? '',
-          }
-        : emptyValues(courses[0]?.id ?? ''),
-    );
+    const initial: ScheduleItemFormValues = initialItem
+      ? {
+          title: initialItem.title,
+          type: initialItem.type,
+          courseId: initialItem.courseId,
+          dueDate: initialItem.dueDate.slice(0, 10),
+          estimatedHours: initialItem.estimatedHours?.toString() ?? '',
+          priority: initialItem.priority ?? 'medium',
+          notes: initialItem.notes ?? '',
+          progress: initialItem.progress?.toString() ?? '',
+          gradeWeight: initialItem.gradeWeight?.toString() ?? '',
+          gradeCategory: initialItem.gradeCategory ?? '',
+        }
+      : emptyValues(courses[0]?.id ?? '');
+    setValues(initial);
+    setBaseline(initial);
     setErrors({});
     setSubmitError(null);
   }, [open, initialItem, courses]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -129,14 +138,40 @@ export function TaskFormModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="task-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this task that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
@@ -308,7 +343,7 @@ export function TaskFormModal({
             <CardFooter className="justify-end gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
               >
                 Cancel

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -47,6 +47,8 @@ function emptyValues(defaultCourseId: string): ScheduleItemFormValues {
     priority: 'medium',
     notes: '',
     progress: '',
+    gradeWeight: '',
+    gradeCategory: '',
   };
 }
 
@@ -75,6 +77,8 @@ export function TaskFormModal({
             priority: initialItem.priority ?? 'medium',
             notes: initialItem.notes ?? '',
             progress: initialItem.progress?.toString() ?? '',
+            gradeWeight: initialItem.gradeWeight?.toString() ?? '',
+            gradeCategory: initialItem.gradeCategory ?? '',
           }
         : emptyValues(courses[0]?.id ?? ''),
     );
@@ -269,6 +273,26 @@ export function TaskFormModal({
                       )}
                     </div>
                   )}
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field
+                      id="gradeWeight"
+                      label="Grade Weight (%)"
+                      type="number"
+                      value={values.gradeWeight ?? ''}
+                      error={errors.gradeWeight}
+                      onChange={(v) => updateField('gradeWeight', v)}
+                      placeholder="Optional"
+                    />
+                    <Field
+                      id="gradeCategory"
+                      label="Grade Category"
+                      value={values.gradeCategory ?? ''}
+                      error={errors.gradeCategory}
+                      onChange={(v) => updateField('gradeCategory', v)}
+                      placeholder="e.g. Homework"
+                    />
+                  </div>
 
                   <Field
                     id="notes"

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -5,16 +5,17 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   hoverable?: boolean;
   /**
-   * Every card carries the brand-gradient "Neon Edge" border + ambient glow
-   * (globals.css `.glow-edge-low`) by default - the calm, static everyday
-   * treatment used sitewide. `true` (or `"top"`) instead draws a gradient
-   * bar along the top edge; `"left"` draws a solid primary-colored border
-   * down the left edge; `"none"` opts out back to a flat bordered card,
-   * reserved for cards whose border already carries other meaning (a
-   * destructive/error state, a dashed empty-state prompt) that a brand
-   * gradient would contradict. A card whose glow should escalate with real
-   * severity (medium/high/critical, breathing) uses WORKLOAD_GLOW_CLASS
-   * (lib/workload/uiClasses.ts) as `className` instead of this prop.
+   * Every card is a plain flat bordered card by default - a modal dialog is
+   * already the sole focus of attention behind its own backdrop, and an
+   * in-page card sitting in normal page flow doesn't need a decorative
+   * border to earn a look, so the default costs nothing extra to opt out
+   * of. `"glow"` opts in to the brand-gradient "Neon Edge" border + ambient
+   * glow (globals.css `.glow-edge-low`) for a card that should genuinely
+   * stand out; `true` (or `"top"`) instead draws a gradient bar along the
+   * top edge; `"left"` draws a solid primary-colored border down the left
+   * edge. A card whose glow should escalate with real severity
+   * (medium/high/critical, breathing) passes `accent="glow"` and layers
+   * WORKLOAD_GLOW_CLASS (lib/workload/uiClasses.ts) on top via `className`.
    */
   accent?: boolean | 'top' | 'left' | 'glow' | 'none';
 }
@@ -24,7 +25,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const isInteractive = interactive || hoverable;
     const accentTop = accent === true || accent === 'top';
     const accentLeft = accent === 'left';
-    const accentGlow = !accentTop && !accentLeft && accent !== 'none';
+    const accentGlow = accent === 'glow';
     return (
       <div
         ref={ref}

--- a/src/components/ui/CardAction.tsx
+++ b/src/components/ui/CardAction.tsx
@@ -78,25 +78,22 @@ export function CardActionLink({
 }
 
 export function CardActionButton({
-  onClick,
   children,
   variant = 'ghost',
   withPlus,
   withChevron,
   className,
-  disabled,
   type = 'button',
-}: SharedProps & {
-  onClick?: () => void;
-  disabled?: boolean;
-  type?: 'button' | 'submit';
-}) {
+  ...rest
+}: SharedProps & { type?: 'button' | 'submit' } & Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    'type' | 'className' | 'children'
+  >) {
   return (
     <button
       type={type}
-      onClick={onClick}
-      disabled={disabled}
       className={cn(baseClass, variantClass[variant], 'disabled:opacity-50', className)}
+      {...rest}
     >
       {withPlus && <PlusIcon />}
       {children}

--- a/src/hooks/useDirtyClose.ts
+++ b/src/hooks/useDirtyClose.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Guards a form modal's close path (backdrop click, Escape, a Cancel button)
+ * behind a "discard unsaved changes?" confirmation whenever the current
+ * values have actually diverged from the snapshot taken when the form
+ * opened. Closing after a successful submit should call the modal's own
+ * `onClose` directly, bypassing this - a save is never a discard.
+ */
+export function useDirtyClose<T>(current: T, baseline: T, onClose: () => void) {
+  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
+  const isDirty = JSON.stringify(current) !== JSON.stringify(baseline);
+
+  const requestClose = () => {
+    if (isDirty) {
+      setConfirmingDiscard(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const confirmDiscard = () => {
+    setConfirmingDiscard(false);
+    onClose();
+  };
+
+  const cancelDiscard = () => setConfirmingDiscard(false);
+
+  return { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard, isDirty };
+}

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { PlannerView } from '@/components/schedule/PlannerView';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Course, ScheduleItem } from '@/types/schedule';
 
 vi.hoisted(() => {
@@ -90,9 +91,11 @@ const scheduleItems: ScheduleItem[] = [
 function renderPlanner() {
   return render(
     <AuthProvider>
-      <AppStateProvider initialState={{ courses, scheduleItems, initialized: true }}>
-        <PlannerView />
-      </AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={{ courses, scheduleItems, initialized: true }}>
+          <PlannerView />
+        </AppStateProvider>
+      </ToastProvider>
     </AuthProvider>,
   );
 }

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -9,6 +9,7 @@ import { MonthCalendar } from '@/components/calendar/MonthCalendar';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { ThemeProvider } from '@/context/ThemeProvider';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
 
 vi.hoisted(() => {
@@ -106,11 +107,13 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
   it('PlannerView select filters and action buttons meet the 44px touch target requirement', () => {
     render(
       <AuthProvider>
-        <AppStateProvider
-          initialState={{ courses: mockCourses, scheduleItems: mockItems, initialized: true }}
-        >
-          <PlannerView />
-        </AppStateProvider>
+        <ToastProvider>
+          <AppStateProvider
+            initialState={{ courses: mockCourses, scheduleItems: mockItems, initialized: true }}
+          >
+            <PlannerView />
+          </AppStateProvider>
+        </ToastProvider>
       </AuthProvider>,
     );
 

--- a/src/lib/validation/course.ts
+++ b/src/lib/validation/course.ts
@@ -27,6 +27,7 @@ export const courseFormSchema = z.object({
   icon: z.string().min(1),
   modality: z.union([z.literal('in-person'), z.literal('online'), z.literal('hybrid')]).optional(),
   meetingTimes: z.array(meetingTimeSchema).optional(),
+  skipDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use YYYY-MM-DD')).optional(),
 });
 
 export type CourseFormValues = z.infer<typeof courseFormSchema>;

--- a/src/lib/validation/scheduleItem.ts
+++ b/src/lib/validation/scheduleItem.ts
@@ -18,6 +18,14 @@ export const scheduleItemFormSchema = z.object({
       (v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0 && Number(v) <= 100),
       'Enter 0-100',
     ),
+  gradeWeight: z
+    .string()
+    .optional()
+    .refine(
+      (v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0 && Number(v) <= 100),
+      'Enter 0-100',
+    ),
+  gradeCategory: z.string().max(60, 'Keep it under 60 characters').optional(),
 });
 
 export type ScheduleItemFormValues = z.infer<typeof scheduleItemFormSchema>;


### PR DESCRIPTION
## What changed

This is the first feature out of a fresh audit (published separately as a Phase 2 review-doc Artifact — see the linked feature audit) aimed at genuinely new capabilities for busy students, not bug fixes. This one is feature #4 from that audit: **Monday Briefing**, Design Option A.

The Profile page's notification settings (daily digest, deadline reminders) are honestly labeled "coming soon" — they need an email-sending backend that doesn't exist. In the meantime there's no glance-able answer anywhere in the app to "what does my week actually look like."

## Fix

Added `WeeklyBriefingCard`, shown at the top of the Dashboard: total hours due in the next 7 days, an exam count when relevant, and the single heaviest day with its top task titles. All of it is computed from `calculateWorkloadBreakdown`, the same workload engine already powering the Planner and Workload dashboard — no new backend, no new data model beyond a small localStorage dismissal flag.

- Only renders when there's actually something due this week (an empty week means nothing to brief).
- Dismissible with an ✕; the dismissal is scoped to the current calendar week (Monday-start) and to the signed-in user, so it reappears the following week rather than being gone forever after one click.
- Styled with the app's existing tinted-card treatment (`bg-primary/5`, `border-primary/20`), matching the "Got a syllabus?" hero card immediately above it rather than inventing a new visual language.

## Verification

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `vitest run` — 624 / 624
- Verified live against the Firebase Local Emulator Suite + a real browser (Playwright):
  - Fresh account, no tasks yet → confirmed the briefing does **not** render (nothing to brief)
  - Created a course with an exam 5 days out and an assignment 3 days out → confirmed the card shows "This week: 3h, 1 exam" and "Heaviest day: Tue (Midterm Exam)"
  - Clicked the dismiss button → card disappears immediately
  - Reloaded the page → card stays dismissed for the rest of this week, confirming the localStorage-backed per-week dismissal actually persists across a real page load

## Note on branch stacking

This branch stacks on `fix/silent-error-swallowing` (#216), which stacks on #215 → #214 → #213 → #212 → #211 → #210 → #209 → #208 → #207, none of which have merged yet. Diff will look larger than its own incremental change until those merge; this PR's own files are `DashboardView.tsx` and the new `WeeklyBriefingCard.tsx`.

**Not merging without explicit go-ahead**, per standing project instructions.
