### PR TITLE
Add AI-generated practice quizzes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,11 @@ All commits must be authored as `George-T83 <george.tannious@gmail.com>`, regard
 ## Verification standard
 
 This is a Next.js 14 + Firebase (Auth/Firestore/Storage) app. "Verified" means checked against the real Firebase Local Emulator Suite and a real browser session (Playwright) — not just that the code compiles or unit tests pass. For any change to a UI surface, actually navigate to it in a running browser and look at it before calling it done.
+
+## Merge approval
+
+Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking. Before requesting merge approval on any non-trivial change, produce a short review write-up (what changed, why, and evidence — screenshots against the real app for anything touching the UI) so the owner can review it the way a lead would review a teammate's PR, not just rubber-stamp a green check mark.
+
+## UI consistency
+
+Before adding or changing any "list card" pattern (a card with a header action button, an empty state, and a row-level edit/delete affordance — e.g. Contacts, Learning Objectives, Tasks on the course detail page), check how the other instances of that same pattern already look and match them exactly: same header button component (`CardActionButton`), same empty-state component (`EmptyState`), same button treatment for row-level actions (pill-style with a tinted background for primary/destructive actions, not a bare underlined text link). Do not invent a new one-off treatment for a single card — if an existing shared component already covers the need, use it. When two nearly-identical UI patterns exist in the same file, that is a bug worth fixing on sight, not something to leave for a later audit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,17 @@ This is a Next.js 14 + Firebase (Auth/Firestore/Storage) app. "Verified" means c
 
 ## Merge approval
 
-Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking. Before requesting merge approval on any non-trivial change, produce a short review write-up (what changed, why, and evidence — screenshots against the real app for anything touching the UI) so the owner can review it the way a lead would review a teammate's PR, not just rubber-stamp a green check mark.
+Never merge a PR without the repo owner's explicit go-ahead in the conversation, even when CI is green and the branch is mergeable. "Drive this PR to green" is not the same instruction as "merge it" — green CI is a precondition for asking, not a substitute for asking.
+
+**Before asking for merge approval on every PR, with no exceptions** (not just "non-trivial" ones — there is no size threshold below which this step is skipped): publish a standalone review document as an Artifact and give the owner the link. This is a separate, required step every single time — it does not happen automatically, and it is easy to forget under time pressure, so treat "did I publish the review doc yet" as a checklist item on every PR, not a judgment call.
+
+The GitHub PR description does **not** satisfy this requirement by itself, no matter how thorough it is. The review doc must exist as its own artifact, and must contain:
+
+- What changed and why, broken out by logical change (not just a wall of diff).
+- Real evidence: actual screenshots from the running app (via the Firebase Local Emulator Suite + a live browser session) for anything touching the UI — before/after where a "before" is capturable, not just a description of what it used to look like.
+- The verification results (tsc, lint, tests, build, CI status).
+
+Only after that artifact is published and linked should merge approval be requested. If a PR is opened and merge approval is about to be asked for and no review doc has been published yet for it, stop and publish one before asking — this has been skipped before and should not happen again.
 
 ## UI consistency
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,6 +23,10 @@ service cloud.firestore {
       match /sources/{sourceId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /flashcards/{flashcardId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,10 @@ service cloud.firestore {
       match /contacts/{contactId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /sources/{sourceId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -27,6 +27,14 @@ service cloud.firestore {
       match /flashcards/{flashcardId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /quizzes/{quizId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      match /quizAttempts/{attemptId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/src/app/(app)/flashcards/page.tsx
+++ b/src/app/(app)/flashcards/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { FlashcardsView } from '@/components/flashcards/FlashcardsView';
+
+export const metadata: Metadata = {
+  title: 'Flashcards | Syllabus Sense',
+  description: 'AI-generated flashcards with spaced-repetition review.',
+};
+
+export default function FlashcardsPage() {
+  return <FlashcardsView />;
+}

--- a/src/app/(app)/quizzes/page.tsx
+++ b/src/app/(app)/quizzes/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { QuizzesView } from '@/components/quizzes/QuizzesView';
+
+export const metadata: Metadata = {
+  title: 'Practice Quizzes | Syllabus Sense',
+  description: 'AI-generated multiple-choice practice quizzes from your syllabi.',
+};
+
+export default function QuizzesPage() {
+  return <QuizzesView />;
+}

--- a/src/app/api/syllabus/flashcards/route.ts
+++ b/src/app/api/syllabus/flashcards/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type Anthropic from '@anthropic-ai/sdk';
+import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
+import { adminStorage } from '@/lib/firebase/adminStorage';
+import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import { FLASHCARDS_SYSTEM_PROMPT, FLASHCARDS_TOOL } from '@/lib/ai/flashcardsTool';
+import { generatedFlashcardsSchema } from '@/types/flashcard';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+async function requireUser(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+  if (!token || !projectId) return null;
+  try {
+    return await verifyFirebaseIdToken(token, projectId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generates study flashcards from an already-uploaded syllabus. Same trust
+ * model and file-handling shape as /api/syllabus/summarize: the client
+ * supplies the file's own storage path, checked against the caller's own
+ * `users/{uid}/...` prefix so a client-supplied path can't read anyone
+ * else's file.
+ */
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: { storagePath?: string; fileName?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const { storagePath, fileName } = body;
+  if (!storagePath || !fileName) {
+    return NextResponse.json({ error: 'Missing storagePath or fileName.' }, { status: 400 });
+  }
+  if (!storagePath.startsWith(`users/${user.uid}/`)) {
+    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+  }
+
+  const fileKind = fileName.toLowerCase().endsWith('.pdf')
+    ? 'pdf'
+    : fileName.toLowerCase().endsWith('.docx')
+      ? 'docx'
+      : null;
+  if (!fileKind) {
+    return NextResponse.json(
+      { error: 'Only PDF and .docx syllabi can generate flashcards.' },
+      { status: 400 },
+    );
+  }
+
+  if (!adminStorage) {
+    return NextResponse.json(
+      { error: 'Storage is not configured on the server.' },
+      { status: 500 },
+    );
+  }
+
+  let fileBase64: string;
+  try {
+    const file = adminStorage.bucket().file(storagePath);
+    const [bytes] = await file.download();
+    fileBase64 = bytes.toString('base64');
+  } catch {
+    return NextResponse.json({ error: "Couldn't read that file." }, { status: 404 });
+  }
+
+  let docxText: string | null = null;
+  if (fileKind === 'docx') {
+    try {
+      const mammoth = await import('mammoth');
+      const buffer = Buffer.from(fileBase64, 'base64');
+      const result = await mammoth.extractRawText({ buffer });
+      docxText = result.value.trim();
+    } catch {
+      return NextResponse.json(
+        { error: "Couldn't read that Word document. Try re-saving it and uploading again." },
+        { status: 400 },
+      );
+    }
+    if (!docxText) {
+      return NextResponse.json({ error: 'That document appears to be empty.' }, { status: 400 });
+    }
+  }
+
+  let anthropic;
+  try {
+    anthropic = getAnthropicClient();
+  } catch {
+    return NextResponse.json(
+      { error: 'Flashcard generation is not configured on the server.' },
+      { status: 503 },
+    );
+  }
+
+  const documentContent: Anthropic.MessageParam['content'] =
+    fileKind === 'pdf'
+      ? [
+          {
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
+            title: fileName,
+          },
+          { type: 'text', text: 'Generate flashcards from this syllabus using record_flashcards.' },
+        ]
+      : [
+          {
+            type: 'text',
+            text: `Syllabus document (${fileName}), extracted from a Word file:\n\n${docxText}`,
+          },
+          { type: 'text', text: 'Generate flashcards from this syllabus using record_flashcards.' },
+        ];
+
+  let message;
+  try {
+    message = await anthropic.messages.create({
+      model: SYLLABUS_EXTRACTION_MODEL,
+      max_tokens: 4000,
+      system: FLASHCARDS_SYSTEM_PROMPT,
+      tools: [FLASHCARDS_TOOL],
+      tool_choice: { type: 'tool', name: FLASHCARDS_TOOL.name },
+      messages: [{ role: 'user', content: documentContent }],
+    });
+  } catch (err) {
+    console.error('Anthropic call failed in flashcard generation:', err);
+    return NextResponse.json({ error: 'Flashcard generation request failed.' }, { status: 502 });
+  }
+
+  const toolUse = message.content.find(
+    (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+  );
+  if (!toolUse) {
+    return NextResponse.json(
+      { error: 'The model did not return structured data. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  const input = toolUse.input as { cards?: unknown };
+  const parsed = generatedFlashcardsSchema.safeParse(input.cards);
+  if (!parsed.success) {
+    console.error('Flashcard validation failed:', parsed.error.issues);
+    return NextResponse.json(
+      { error: 'The generated flashcards were malformed. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ cards: parsed.data });
+}

--- a/src/app/api/syllabus/quiz/route.ts
+++ b/src/app/api/syllabus/quiz/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type Anthropic from '@anthropic-ai/sdk';
+import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
+import { adminStorage } from '@/lib/firebase/adminStorage';
+import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import { QUIZ_SYSTEM_PROMPT, QUIZ_TOOL } from '@/lib/ai/quizTool';
+import { generatedQuizQuestionsSchema } from '@/types/quiz';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+async function requireUser(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+  if (!token || !projectId) return null;
+  try {
+    return await verifyFirebaseIdToken(token, projectId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generates a practice quiz from an already-uploaded syllabus. Same trust
+ * model and file-handling shape as /api/syllabus/summarize and
+ * /api/syllabus/flashcards: the client supplies the file's own storage
+ * path, checked against the caller's own `users/{uid}/...` prefix so a
+ * client-supplied path can't read anyone else's file.
+ */
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: { storagePath?: string; fileName?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const { storagePath, fileName } = body;
+  if (!storagePath || !fileName) {
+    return NextResponse.json({ error: 'Missing storagePath or fileName.' }, { status: 400 });
+  }
+  if (!storagePath.startsWith(`users/${user.uid}/`)) {
+    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+  }
+
+  const fileKind = fileName.toLowerCase().endsWith('.pdf')
+    ? 'pdf'
+    : fileName.toLowerCase().endsWith('.docx')
+      ? 'docx'
+      : null;
+  if (!fileKind) {
+    return NextResponse.json(
+      { error: 'Only PDF and .docx syllabi can generate a quiz.' },
+      { status: 400 },
+    );
+  }
+
+  if (!adminStorage) {
+    return NextResponse.json(
+      { error: 'Storage is not configured on the server.' },
+      { status: 500 },
+    );
+  }
+
+  let fileBase64: string;
+  try {
+    const file = adminStorage.bucket().file(storagePath);
+    const [bytes] = await file.download();
+    fileBase64 = bytes.toString('base64');
+  } catch {
+    return NextResponse.json({ error: "Couldn't read that file." }, { status: 404 });
+  }
+
+  let docxText: string | null = null;
+  if (fileKind === 'docx') {
+    try {
+      const mammoth = await import('mammoth');
+      const buffer = Buffer.from(fileBase64, 'base64');
+      const result = await mammoth.extractRawText({ buffer });
+      docxText = result.value.trim();
+    } catch {
+      return NextResponse.json(
+        { error: "Couldn't read that Word document. Try re-saving it and uploading again." },
+        { status: 400 },
+      );
+    }
+    if (!docxText) {
+      return NextResponse.json({ error: 'That document appears to be empty.' }, { status: 400 });
+    }
+  }
+
+  let anthropic;
+  try {
+    anthropic = getAnthropicClient();
+  } catch {
+    return NextResponse.json(
+      { error: 'Quiz generation is not configured on the server.' },
+      { status: 503 },
+    );
+  }
+
+  const documentContent: Anthropic.MessageParam['content'] =
+    fileKind === 'pdf'
+      ? [
+          {
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf', data: fileBase64 },
+            title: fileName,
+          },
+          { type: 'text', text: 'Generate a practice quiz from this syllabus using record_quiz.' },
+        ]
+      : [
+          {
+            type: 'text',
+            text: `Syllabus document (${fileName}), extracted from a Word file:\n\n${docxText}`,
+          },
+          { type: 'text', text: 'Generate a practice quiz from this syllabus using record_quiz.' },
+        ];
+
+  let message;
+  try {
+    message = await anthropic.messages.create({
+      model: SYLLABUS_EXTRACTION_MODEL,
+      max_tokens: 4000,
+      system: QUIZ_SYSTEM_PROMPT,
+      tools: [QUIZ_TOOL],
+      tool_choice: { type: 'tool', name: QUIZ_TOOL.name },
+      messages: [{ role: 'user', content: documentContent }],
+    });
+  } catch (err) {
+    console.error('Anthropic call failed in quiz generation:', err);
+    return NextResponse.json({ error: 'Quiz generation request failed.' }, { status: 502 });
+  }
+
+  const toolUse = message.content.find(
+    (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+  );
+  if (!toolUse) {
+    return NextResponse.json(
+      { error: 'The model did not return structured data. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  const input = toolUse.input as { questions?: unknown };
+  const parsed = generatedQuizQuestionsSchema.safeParse(input.questions);
+  if (!parsed.success) {
+    console.error('Quiz validation failed:', parsed.error.issues);
+    return NextResponse.json(
+      { error: 'The generated quiz was malformed. Try again.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ questions: parsed.data });
+}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -975,6 +975,7 @@ export function MonthCalendar() {
                           completed={item.completed}
                           progress={item.progress}
                           priority={item.priority}
+                          assignedTo={item.assignedTo}
                           onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                         />
                       );
@@ -1158,6 +1159,7 @@ function DayDetailCard({
                       completed={item.completed}
                       progress={item.progress}
                       priority={item.priority}
+                      assignedTo={item.assignedTo}
                       onToggleComplete={onToggleComplete ? () => onToggleComplete(item) : undefined}
                       trailing={
                         <div className="flex items-center gap-1">

--- a/src/components/calendar/__tests__/MonthCalendarAriaGrid.test.tsx
+++ b/src/components/calendar/__tests__/MonthCalendarAriaGrid.test.tsx
@@ -31,6 +31,7 @@ vi.mock('firebase/auth', () => ({
 }));
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(),
   setDoc: vi.fn(),
   deleteDoc: vi.fn(),

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAppState } from '@/context/AppStateContext';
 import { useTheme } from '@/context/ThemeProvider';
 import { usePlatformKey } from '@/hooks/usePlatformKey';
+import { isCardDue } from '@/lib/flashcards/sm2';
 
 export interface CommandPaletteProps {
   isOpen?: boolean;
@@ -131,6 +132,17 @@ export function CommandPalette({
         badge: `${state.scheduleItems.filter((t) => !t.completed).length} pending`,
         perform: () => {
           router.push('/tasks');
+          closePalette();
+        },
+      },
+      {
+        id: 'nav-flashcards',
+        title: 'Flashcards',
+        subtitle: 'AI-generated study decks with spaced-repetition review',
+        category: 'Navigation',
+        badge: `${state.flashcards.filter((c) => isCardDue(c)).length} due`,
+        perform: () => {
+          router.push('/flashcards');
           closePalette();
         },
       },
@@ -311,6 +323,7 @@ export function CommandPalette({
     state.courses,
     state.scheduleItems,
     state.contacts,
+    state.flashcards,
     resolvedTheme,
     setTheme,
     router,

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -147,6 +147,17 @@ export function CommandPalette({
         },
       },
       {
+        id: 'nav-quizzes',
+        title: 'Practice Quizzes',
+        subtitle: 'AI-generated multiple-choice quizzes from your syllabi',
+        category: 'Navigation',
+        badge: `${state.quizzes.length}`,
+        perform: () => {
+          router.push('/quizzes');
+          closePalette();
+        },
+      },
+      {
         id: 'nav-calendar',
         title: 'Calendar',
         subtitle: 'Month & week views, class schedules, and deadlines',
@@ -324,6 +335,7 @@ export function CommandPalette({
     state.scheduleItems,
     state.contacts,
     state.flashcards,
+    state.quizzes,
     resolvedTheme,
     setTheme,
     router,

--- a/src/components/contacts/ContactShareModal.tsx
+++ b/src/components/contacts/ContactShareModal.tsx
@@ -85,7 +85,7 @@ export function ContactShareModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
     >
       <div ref={dialogRef} tabIndex={-1} className="w-full max-w-lg outline-none">
-        <Card className="relative">
+        <Card accent="none" className="relative">
           <div className="max-h-[90vh] overflow-y-auto p-6 sm:p-7 space-y-5">
             {/* Header */}
             <div className="flex items-start justify-between border-b border-border pb-4">

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -12,9 +12,11 @@ import {
 import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { SkeletonCard } from '@/components/ui/Skeleton';
+import { useToast } from '@/components/ui/Toast';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
+import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import type { Contact, ContactRole, Course } from '@/types/schedule';
 import { cn, normalizeContactName } from '@/lib/utils';
@@ -55,10 +57,12 @@ function courseLabel(course: Course | undefined): string {
 
 import { ProfessorEmailDrafterModal } from '@/components/contacts/ProfessorEmailDrafterModal';
 import { ContactShareModal } from '@/components/contacts/ContactShareModal';
+import { ScheduleOfficeVisitModal } from '@/components/contacts/ScheduleOfficeVisitModal';
 
 export function ContactsListView() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showSuccess, showError } = useToast();
   const { contacts, courses } = state;
 
   const [search, setSearch] = useState('');
@@ -68,6 +72,7 @@ export function ContactsListView() {
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
   const [drafterContact, setDrafterContact] = useState<Contact | null>(null);
   const [shareContact, setShareContact] = useState<Contact | null>(null);
+  const [schedulingContact, setSchedulingContact] = useState<Contact | null>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && contacts.length > 0) {
@@ -203,6 +208,39 @@ export function ContactsListView() {
     if (!user) return;
     await deleteContact(user.uid, contact, dispatch);
     setConfirmingDeleteId(null);
+  };
+
+  const handleScheduleVisit = async (contact: Contact, dateKey: string) => {
+    if (!user) throw new Error('You must be signed in to schedule a visit.');
+    try {
+      await createScheduleItem(
+        user.uid,
+        {
+          id: crypto.randomUUID(),
+          courseId: contact.courseId,
+          title: `Office hours — ${contact.howToAddress || contact.fullName}`,
+          type: 'other',
+          dueDate: new Date(`${dateKey}T23:59:00`).toISOString(),
+          completed: false,
+          source: 'manual',
+          ...(contact.officeHours || contact.officeLocation
+            ? {
+                notes: [
+                  contact.officeHours ? `Regular hours: ${contact.officeHours}` : '',
+                  contact.officeLocation ? `Location: ${contact.officeLocation}` : '',
+                ]
+                  .filter(Boolean)
+                  .join(' · '),
+              }
+            : {}),
+        },
+        dispatch,
+      );
+      showSuccess('Visit scheduled', `Added to your tasks for ${dateKey}.`);
+    } catch (err) {
+      showError('Could not schedule the visit', err instanceof Error ? err.message : undefined);
+      throw err;
+    }
   };
 
   const selectClass =
@@ -369,6 +407,14 @@ export function ContactsListView() {
                               </>
                             ) : (
                               <>
+                                {record.officeHours && (
+                                  <button
+                                    onClick={() => setSchedulingContact(record)}
+                                    className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
+                                  >
+                                    Schedule Visit
+                                  </button>
+                                )}
                                 <button
                                   onClick={() => setDrafterContact(record)}
                                   className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
@@ -433,6 +479,11 @@ export function ContactsListView() {
           onClose={() => setShareContact(null)}
         />
       )}
+      <ScheduleOfficeVisitModal
+        contact={schedulingContact}
+        onClose={() => setSchedulingContact(null)}
+        onSchedule={handleScheduleVisit}
+      />
     </>
   );
 }

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -356,13 +356,13 @@ export function ContactsListView() {
                               <>
                                 <button
                                   onClick={() => handleDelete(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-destructive hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-destructive/10 px-3 font-semibold text-destructive transition-colors hover:bg-destructive/20"
                                 >
                                   Confirm
                                 </button>
                                 <button
                                   onClick={() => setConfirmingDeleteId(null)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 text-muted-foreground hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 text-muted-foreground transition-colors hover:bg-accent"
                                 >
                                   Cancel
                                 </button>
@@ -371,25 +371,25 @@ export function ContactsListView() {
                               <>
                                 <button
                                   onClick={() => setDrafterContact(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   Draft Email
                                 </button>
                                 <button
                                   onClick={() => setShareContact(record)}
-                                  className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   vCard/QR
                                 </button>
                                 <button
                                   onClick={() => openEdit(record)}
-                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 font-semibold text-primary hover:underline"
+                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                 >
                                   Edit
                                 </button>
                                 <button
                                   onClick={() => setConfirmingDeleteId(record.id)}
-                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 font-semibold text-destructive hover:underline"
+                                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-3 font-semibold text-destructive transition-colors hover:bg-destructive/10"
                                 >
                                   Delete
                                 </button>
@@ -526,7 +526,7 @@ function ContactFormModal({
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="contact-form-title">
               {initialContact ? 'Edit Contact' : 'Add Contact'}

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -24,6 +24,7 @@ import { cn, normalizeContactName } from '@/lib/utils';
 const ROLE_LABEL: Record<ContactRole, string> = {
   professor: 'Professor',
   ta: 'TA',
+  classmate: 'Classmate',
 };
 
 interface ContactFormValues {
@@ -211,14 +212,17 @@ export function ContactsListView() {
   };
 
   const handleScheduleVisit = async (contact: Contact, dateKey: string) => {
-    if (!user) throw new Error('You must be signed in to schedule a visit.');
+    if (!user) throw new Error('You must be signed in to schedule this.');
+    const isClassmate = contact.role === 'classmate';
     try {
       await createScheduleItem(
         user.uid,
         {
           id: crypto.randomUUID(),
           courseId: contact.courseId,
-          title: `Office hours — ${contact.howToAddress || contact.fullName}`,
+          title: isClassmate
+            ? `Study session with ${contact.howToAddress || contact.fullName}`
+            : `Office hours — ${contact.howToAddress || contact.fullName}`,
           type: 'other',
           dueDate: new Date(`${dateKey}T23:59:00`).toISOString(),
           completed: false,
@@ -236,9 +240,12 @@ export function ContactsListView() {
         },
         dispatch,
       );
-      showSuccess('Visit scheduled', `Added to your tasks for ${dateKey}.`);
+      showSuccess(
+        isClassmate ? 'Study session scheduled' : 'Visit scheduled',
+        `Added to your tasks for ${dateKey}.`,
+      );
     } catch (err) {
-      showError('Could not schedule the visit', err instanceof Error ? err.message : undefined);
+      showError('Could not schedule this', err instanceof Error ? err.message : undefined);
       throw err;
     }
   };
@@ -407,12 +414,14 @@ export function ContactsListView() {
                               </>
                             ) : (
                               <>
-                                {record.officeHours && (
+                                {(record.officeHours || record.role === 'classmate') && (
                                   <button
                                     onClick={() => setSchedulingContact(record)}
                                     className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 font-semibold text-primary transition-colors hover:bg-primary/10"
                                   >
-                                    Schedule Visit
+                                    {record.role === 'classmate'
+                                      ? 'Schedule Study Session'
+                                      : 'Schedule Visit'}
                                   </button>
                                 )}
                                 <button
@@ -631,7 +640,7 @@ function ContactFormModal({
               <div className="space-y-1.5">
                 <span className="text-sm font-medium text-foreground">Role</span>
                 <div className="flex gap-2">
-                  {(['professor', 'ta'] as ContactRole[]).map((role) => (
+                  {(['professor', 'ta', 'classmate'] as ContactRole[]).map((role) => (
                     <button
                       key={role}
                       type="button"

--- a/src/components/contacts/ProfessorEmailDrafterModal.tsx
+++ b/src/components/contacts/ProfessorEmailDrafterModal.tsx
@@ -113,7 +113,7 @@ export function ProfessorEmailDrafterModal({
         className="w-full max-w-lg outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border px-5 py-4">
             <div>

--- a/src/components/contacts/ScheduleOfficeVisitModal.tsx
+++ b/src/components/contacts/ScheduleOfficeVisitModal.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
+import { useModalA11y } from '@/hooks/useModalA11y';
+import { toDayKey } from '@/lib/calendar/dates';
+import type { Contact } from '@/types/schedule';
+
+export interface ScheduleOfficeVisitModalProps {
+  contact: Contact | null;
+  onClose: () => void;
+  onSchedule: (contact: Contact, dateKey: string) => Promise<void>;
+}
+
+export function ScheduleOfficeVisitModal({
+  contact,
+  onClose,
+  onSchedule,
+}: ScheduleOfficeVisitModalProps) {
+  const today = toDayKey(new Date());
+  const [date, setDate] = useState(today);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const open = !!contact;
+  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+
+  useEffect(() => {
+    if (!open) return;
+    setDate(today);
+    setSubmitError(null);
+    // `today` intentionally excluded - it should only reset when a new
+    // contact opens the modal, not tick over if the modal is left open
+    // across midnight.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, contact]);
+
+  if (!contact) return null;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await onSchedule(contact, date);
+      onClose();
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : 'Failed to schedule the visit. Please try again.',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="schedule-visit-title"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-md outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card accent="none">
+          <CardHeader>
+            <CardTitle id="schedule-visit-title">Schedule a Visit</CardTitle>
+            <CardDescription>Adds a reminder task to your Tasks list.</CardDescription>
+          </CardHeader>
+          <form onSubmit={handleSubmit}>
+            <CardContent className="space-y-4">
+              {submitError && (
+                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                  {submitError}
+                </div>
+              )}
+
+              <div className="rounded-xl border border-border bg-muted/50 p-3 text-sm">
+                <div className="font-semibold text-foreground">{contact.fullName}</div>
+                {contact.officeHours && (
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    Office hours: {contact.officeHours}
+                  </div>
+                )}
+                {contact.officeLocation && (
+                  <div className="text-xs text-muted-foreground">{contact.officeLocation}</div>
+                )}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="visit-date"
+                  className="block text-xs font-semibold text-muted-foreground mb-1"
+                >
+                  Which day are you going?
+                </label>
+                <input
+                  id="visit-date"
+                  type="date"
+                  value={date}
+                  min={today}
+                  onChange={(e) => setDate(e.target.value)}
+                  required
+                  className="w-full min-h-[44px] rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+            </CardContent>
+
+            <div className="flex items-center justify-end gap-2 border-t border-border p-4">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? 'Scheduling...' : 'Schedule Visit'}
+              </button>
+            </div>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/contacts/ScheduleOfficeVisitModal.tsx
+++ b/src/components/contacts/ScheduleOfficeVisitModal.tsx
@@ -12,6 +12,9 @@ export interface ScheduleOfficeVisitModalProps {
   onSchedule: (contact: Contact, dateKey: string) => Promise<void>;
 }
 
+/** Books a one-off reminder task tied to a contact: an office-hours visit
+ * for a professor/TA, or a study session for a classmate. Same modal, same
+ * flow either way - only the copy changes based on `contact.role`. */
 export function ScheduleOfficeVisitModal({
   contact,
   onClose,
@@ -37,6 +40,8 @@ export function ScheduleOfficeVisitModal({
 
   if (!contact) return null;
 
+  const isClassmate = contact.role === 'classmate';
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setSubmitError(null);
@@ -45,9 +50,7 @@ export function ScheduleOfficeVisitModal({
       await onSchedule(contact, date);
       onClose();
     } catch (err) {
-      setSubmitError(
-        err instanceof Error ? err.message : 'Failed to schedule the visit. Please try again.',
-      );
+      setSubmitError(err instanceof Error ? err.message : 'Failed to schedule. Please try again.');
     } finally {
       setSubmitting(false);
     }
@@ -69,7 +72,9 @@ export function ScheduleOfficeVisitModal({
       >
         <Card accent="none">
           <CardHeader>
-            <CardTitle id="schedule-visit-title">Schedule a Visit</CardTitle>
+            <CardTitle id="schedule-visit-title">
+              {isClassmate ? 'Schedule a Study Session' : 'Schedule a Visit'}
+            </CardTitle>
             <CardDescription>Adds a reminder task to your Tasks list.</CardDescription>
           </CardHeader>
           <form onSubmit={handleSubmit}>
@@ -97,7 +102,7 @@ export function ScheduleOfficeVisitModal({
                   htmlFor="visit-date"
                   className="block text-xs font-semibold text-muted-foreground mb-1"
                 >
-                  Which day are you going?
+                  {isClassmate ? 'Which day are you meeting?' : 'Which day are you going?'}
                 </label>
                 <input
                   id="visit-date"
@@ -124,7 +129,11 @@ export function ScheduleOfficeVisitModal({
                 disabled={submitting}
                 className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {submitting ? 'Scheduling...' : 'Schedule Visit'}
+                {submitting
+                  ? 'Scheduling...'
+                  : isClassmate
+                    ? 'Schedule Study Session'
+                    : 'Schedule Visit'}
               </button>
             </div>
           </form>

--- a/src/components/courses/AttendanceGauge.tsx
+++ b/src/components/courses/AttendanceGauge.tsx
@@ -373,7 +373,7 @@ export function AttendanceGauge({
           aria-labelledby="log-absence-title"
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
         >
-          <Card className="relative w-full max-w-md p-6 space-y-4">
+          <Card accent="none" className="relative w-full max-w-md p-6 space-y-4">
             <div className="flex items-center justify-between border-b border-border pb-3">
               <h3 id="log-absence-title" className="text-base font-bold text-foreground">
                 Log Course Absence

--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
@@ -143,13 +144,9 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
           </span>
           <h2 className="text-base font-semibold text-foreground">AI Summary</h2>
         </div>
-        <button
-          onClick={handleGenerate}
-          disabled={generating}
-          className="text-xs font-semibold text-primary hover:underline disabled:pointer-events-none disabled:opacity-50"
-        >
+        <CardActionButton variant="solid" onClick={handleGenerate} disabled={generating}>
           {generating ? 'Generating…' : summary ? 'Regenerate' : 'Generate'}
-        </button>
+        </CardActionButton>
       </div>
 
       {error && <p className="text-sm text-destructive">{error}</p>}

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -644,15 +644,26 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
           </div>
 
           {courseContacts.length === 0 && !addContactOpen && (
-            <div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-border px-3 py-3">
-              <p className="text-sm text-muted-foreground">No contacts yet for this course.</p>
-              <button
-                onClick={() => setAddContactOpen(true)}
-                className="shrink-0 text-xs font-semibold text-primary hover:underline"
-              >
-                + Add
-              </button>
-            </div>
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+                  />
+                </svg>
+              }
+              title="No contacts yet for this course"
+              description="Add a professor or TA, or upload a syllabus above to extract contacts automatically."
+              action={{ label: '+ Add contact', onClick: () => setAddContactOpen(true) }}
+            />
           )}
 
           {courseContacts.length > 0 && (
@@ -705,7 +716,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         </div>
                         <button
                           onClick={() => handleStartEditContact(contact)}
-                          className="shrink-0 text-xs font-semibold text-primary hover:underline"
+                          className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                         >
                           Edit
                         </button>
@@ -788,20 +799,20 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
               )}
             </div>
             {!addingObjective && (
-              <button
-                onClick={() => setAddingObjective(true)}
-                className="shrink-0 text-xs font-semibold text-primary hover:underline"
-              >
-                + Add objective
-              </button>
+              <CardActionButton variant="solid" withPlus onClick={() => setAddingObjective(true)}>
+                Add objective
+              </CardActionButton>
             )}
           </div>
 
           {course.learningObjectives && course.learningObjectives.length > 0 ? (
-            <ul className="space-y-2.5">
+            <ul className="flex flex-col gap-2">
               {course.learningObjectives.map((objective, i) =>
                 editingObjectiveIndex === i ? (
-                  <li key={i} className="flex items-center gap-2">
+                  <li
+                    key={i}
+                    className="flex items-center gap-2 rounded-lg border border-border p-3"
+                  >
                     <input
                       type="text"
                       value={objectiveDraft}
@@ -857,7 +868,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                 ) : (
                   <li
                     key={i}
-                    className="group flex items-start justify-between gap-3 text-sm text-foreground"
+                    className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
                   >
                     <div className="flex items-start gap-2.5 min-w-0">
                       <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
@@ -865,34 +876,14 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         {renderInlineBold(objective)}
                       </span>
                     </div>
-                    <div className="flex items-center gap-1.5 shrink-0 opacity-80 group-hover:opacity-100 transition-opacity">
-                      <button
-                        type="button"
-                        onClick={() => handleStartEditObjective(i)}
-                        className="rounded p-1 text-muted-foreground hover:text-primary transition-colors"
-                        aria-label="Edit objective"
-                      >
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
-                          />
-                        </svg>
-                      </button>
+                    <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                       {confirmingDeleteObjectiveIndex === i ? (
                         <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
                           <button
                             type="button"
                             onClick={() => handleDeleteObjective(i)}
                             disabled={deletingObjectiveIndex === i}
-                            className="font-semibold text-destructive hover:underline disabled:opacity-50"
+                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                           >
                             {deletingObjectiveIndex === i ? 'Deleting…' : 'Confirm'}
                           </button>
@@ -900,32 +891,54 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                             type="button"
                             onClick={() => setConfirmingDeleteObjectiveIndex(null)}
                             disabled={deletingObjectiveIndex === i}
-                            className="text-muted-foreground hover:underline disabled:opacity-50"
+                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
                           >
                             Cancel
                           </button>
                         </div>
                       ) : (
-                        <button
-                          type="button"
-                          onClick={() => setConfirmingDeleteObjectiveIndex(i)}
-                          className="rounded p-1 text-muted-foreground hover:text-destructive transition-colors"
-                          aria-label="Delete objective"
-                        >
-                          <svg
-                            className="h-3.5 w-3.5"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleStartEditObjective(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                            aria-label="Edit objective"
                           >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteObjectiveIndex(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                            aria-label="Delete objective"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                              />
+                            </svg>
+                          </button>
+                        </>
                       )}
                     </div>
                   </li>
@@ -934,7 +947,26 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
             </ul>
           ) : (
             !addingObjective && (
-              <p className="text-sm text-muted-foreground">No learning objectives yet.</p>
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                }
+                title="No learning objectives yet"
+                description="Add one, or upload a syllabus above to extract objectives automatically."
+                action={{ label: '+ Add objective', onClick: () => setAddingObjective(true) }}
+              />
             )
           )}
 
@@ -1051,18 +1083,18 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                           Edit
                         </button>
                         {confirmingDeleteItemId === item.id ? (
-                          <div className="flex items-center gap-2 text-xs">
+                          <div className="flex items-center gap-1.5 text-xs">
                             <button
                               onClick={() => handleDeleteTask(item)}
                               disabled={deletingItemId === item.id}
-                              className="font-semibold text-destructive hover:underline disabled:opacity-50"
+                              className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                             >
                               {deletingItemId === item.id ? 'Deleting…' : 'Confirm'}
                             </button>
                             <button
                               onClick={() => setConfirmingDeleteItemId(null)}
                               disabled={deletingItemId === item.id}
-                              className="text-muted-foreground hover:underline disabled:opacity-50"
+                              className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
                             >
                               Cancel
                             </button>
@@ -1070,7 +1102,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                         ) : (
                           <button
                             onClick={() => setConfirmingDeleteItemId(item.id)}
-                            className="text-xs font-semibold text-destructive hover:underline"
+                            className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
                           >
                             Delete
                           </button>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -218,6 +218,15 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [addingObjective, setAddingObjective] = useState(false);
   const [newObjectiveDraft, setNewObjectiveDraft] = useState('');
 
+  const [confirmingDeleteMaterialIndex, setConfirmingDeleteMaterialIndex] = useState<number | null>(
+    null,
+  );
+  const [deletingMaterialIndex, setDeletingMaterialIndex] = useState<number | null>(null);
+  const [editingMaterialIndex, setEditingMaterialIndex] = useState<number | null>(null);
+  const [materialDraft, setMaterialDraft] = useState('');
+  const [addingMaterial, setAddingMaterial] = useState(false);
+  const [newMaterialDraft, setNewMaterialDraft] = useState('');
+
   const course = state.courses.find((c) => c.id === courseId);
   const items = state.scheduleItems
     .filter((item) => item.courseId === courseId)
@@ -251,6 +260,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       color: values.color,
       icon: values.icon,
       meetingTimes: values.meetingTimes ?? [],
+      skipDates: values.skipDates ?? [],
       ...(values.instructor ? { instructor: values.instructor } : {}),
       ...(values.modality ? { modality: values.modality } : {}),
     };
@@ -471,6 +481,50 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     );
     setNewObjectiveDraft('');
     setAddingObjective(false);
+  };
+
+  const handleStartEditMaterial = (index: number) => {
+    setMaterialDraft(course.materials?.[index] ?? '');
+    setEditingMaterialIndex(index);
+  };
+
+  const handleCommitMaterialEdit = async (index: number) => {
+    if (!user) return;
+    const current = [...(course.materials ?? [])];
+    const trimmed = materialDraft.trim();
+    if (trimmed) {
+      current[index] = trimmed;
+    } else {
+      current.splice(index, 1);
+    }
+    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+    setEditingMaterialIndex(null);
+  };
+
+  const handleDeleteMaterial = async (index: number) => {
+    if (!user) return;
+    setDeletingMaterialIndex(index);
+    try {
+      const current = [...(course.materials ?? [])];
+      current.splice(index, 1);
+      await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+      setConfirmingDeleteMaterialIndex(null);
+    } finally {
+      setDeletingMaterialIndex(null);
+    }
+  };
+
+  const handleAddMaterial = async () => {
+    if (!user) return;
+    const trimmed = newMaterialDraft.trim();
+    if (!trimmed) {
+      setAddingMaterial(false);
+      return;
+    }
+    const current = [...(course.materials ?? []), trimmed];
+    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+    setNewMaterialDraft('');
+    setAddingMaterial(false);
   };
 
   const handleExportICS = () => {
@@ -1028,6 +1082,214 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                   type="button"
                   onClick={handleAddObjective}
                   disabled={!newObjectiveDraft.trim()}
+                  className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <Card className="rounded-2xl p-6 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-base font-semibold text-foreground">Materials</h2>
+            {!addingMaterial && (
+              <CardActionButton variant="solid" withPlus onClick={() => setAddingMaterial(true)}>
+                Add material
+              </CardActionButton>
+            )}
+          </div>
+
+          {course.materials && course.materials.length > 0 ? (
+            <ul className="flex flex-col gap-2">
+              {course.materials.map((material, i) =>
+                editingMaterialIndex === i ? (
+                  <li
+                    key={i}
+                    className="flex items-center gap-2 rounded-lg border border-border p-3"
+                  >
+                    <input
+                      type="text"
+                      value={materialDraft}
+                      onChange={(e) => setMaterialDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleCommitMaterialEdit(i);
+                        if (e.key === 'Escape') setEditingMaterialIndex(null);
+                      }}
+                      className="flex-1 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleCommitMaterialEdit(i)}
+                      className="rounded p-1 text-primary hover:bg-primary/10"
+                      aria-label="Save this material"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M4.5 12.75l6 6 9-13.5"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingMaterialIndex(null)}
+                      className="rounded p-1 text-muted-foreground hover:bg-muted"
+                      aria-label="Cancel editing"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                ) : (
+                  <li
+                    key={i}
+                    className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
+                  >
+                    <div className="min-w-0">
+                      <span className="leading-relaxed break-words">{material}</span>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
+                      {confirmingDeleteMaterialIndex === i ? (
+                        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteMaterial(i)}
+                            disabled={deletingMaterialIndex === i}
+                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                          >
+                            {deletingMaterialIndex === i ? 'Deleting…' : 'Confirm'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteMaterialIndex(null)}
+                            disabled={deletingMaterialIndex === i}
+                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleStartEditMaterial(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                            aria-label="Edit material"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmingDeleteMaterialIndex(i)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                            aria-label="Delete material"
+                          >
+                            <svg
+                              className="h-3.5 w-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                              />
+                            </svg>
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </li>
+                ),
+              )}
+            </ul>
+          ) : (
+            !addingMaterial && (
+              <EmptyState
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                    />
+                  </svg>
+                }
+                title="No materials yet"
+                description="Add a textbook, calculator, or other required supply, or upload a syllabus above to extract them automatically."
+                action={{ label: '+ Add material', onClick: () => setAddingMaterial(true) }}
+              />
+            )
+          )}
+
+          {addingMaterial && (
+            <div className="space-y-2 rounded-lg border border-border p-3">
+              <input
+                type="text"
+                value={newMaterialDraft}
+                onChange={(e) => setNewMaterialDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAddMaterial();
+                  if (e.key === 'Escape') setAddingMaterial(false);
+                }}
+                placeholder="e.g. Introduction to Algorithms, 3rd Edition"
+                className="w-full rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">Press Enter to save.</p>
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setAddingMaterial(false)}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAddMaterial}
+                  disabled={!newMaterialDraft.trim()}
                   className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
                   Add

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -16,7 +16,7 @@ import {
   updateScheduleItem,
   deleteScheduleItem,
 } from '@/lib/firestore/scheduleItems';
-import { createContact, updateContact } from '@/lib/firestore/contacts';
+import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
@@ -206,6 +206,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [deletingObjectiveIndex, setDeletingObjectiveIndex] = useState<number | null>(null);
 
   const [addContactOpen, setAddContactOpen] = useState(false);
+  const [confirmingDeleteContactId, setConfirmingDeleteContactId] = useState<string | null>(null);
+  const [deletingContactId, setDeletingContactId] = useState<string | null>(null);
   const [newContact, setNewContact] = useState<ContactFormState>(EMPTY_CONTACT_FORM);
   const [savingContact, setSavingContact] = useState(false);
   const [editingContactId, setEditingContactId] = useState<string | null>(null);
@@ -395,6 +397,17 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       dispatch,
     );
     setEditingContactId(null);
+  };
+
+  const handleDeleteContact = async (contact: Contact) => {
+    if (!user) return;
+    setDeletingContactId(contact.id);
+    try {
+      await deleteContact(user.uid, contact, dispatch);
+      setConfirmingDeleteContactId(null);
+    } finally {
+      setDeletingContactId(null);
+    }
   };
 
   const handleStartEditObjective = (index: number) => {
@@ -714,12 +727,39 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                             <span className="text-xs text-muted-foreground">{contact.title}</span>
                           )}
                         </div>
-                        <button
-                          onClick={() => handleStartEditContact(contact)}
-                          className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
-                        >
-                          Edit
-                        </button>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <button
+                            onClick={() => handleStartEditContact(contact)}
+                            className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                          >
+                            Edit
+                          </button>
+                          {confirmingDeleteContactId === contact.id ? (
+                            <div className="flex items-center gap-1.5 text-xs">
+                              <button
+                                onClick={() => handleDeleteContact(contact)}
+                                disabled={deletingContactId === contact.id}
+                                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                              >
+                                {deletingContactId === contact.id ? 'Deleting…' : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmingDeleteContactId(null)}
+                                disabled={deletingContactId === contact.id}
+                                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmingDeleteContactId(contact.id)}
+                              className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+                            >
+                              Delete
+                            </button>
+                          )}
+                        </div>
                       </div>
                       {contact.howToAddress && (
                         <p className="text-xs text-muted-foreground">

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -288,6 +288,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );
@@ -308,6 +310,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -301,6 +301,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
         ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
+        ...(values.assignedTo ? { assignedTo: values.assignedTo } : {}),
       },
       dispatch,
     );
@@ -323,6 +324,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         ...(values.progress ? { progress: Number(values.progress) } : {}),
         ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
         ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
+        ...(values.assignedTo ? { assignedTo: values.assignedTo } : {}),
       },
       dispatch,
     );
@@ -1347,6 +1349,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     completed={item.completed}
                     progress={item.progress}
                     priority={item.priority}
+                    assignedTo={item.assignedTo}
                     onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                     trailing={
                       <>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -783,21 +783,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
         <Card className="rounded-2xl p-6 space-y-4">
           <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2.5">
-              <h2 className="text-base font-semibold text-foreground">Learning Objectives</h2>
-              {course.learningObjectives && course.learningObjectives.length > 0 && (
-                <span
-                  className={cn(
-                    'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
-                    course.learningObjectivesApproved
-                      ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-                      : 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
-                  )}
-                >
-                  {course.learningObjectivesApproved ? 'Approved' : 'Needs review'}
-                </span>
-              )}
-            </div>
+            <h2 className="text-base font-semibold text-foreground">Learning Objectives</h2>
             {!addingObjective && (
               <CardActionButton variant="solid" withPlus onClick={() => setAddingObjective(true)}>
                 Add objective
@@ -870,8 +856,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     key={i}
                     className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
                   >
-                    <div className="flex items-start gap-2.5 min-w-0">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                    <div className="min-w-0">
                       <span className="leading-relaxed break-words">
                         {renderInlineBold(objective)}
                       </span>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -22,6 +22,7 @@ import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
 import { SyllabusList } from '@/components/syllabus/SyllabusList';
 import { CourseAiSummaryCard } from '@/components/courses/CourseAiSummaryCard';
+import { SourcesCard } from '@/components/courses/SourcesCard';
 import { AttendanceGauge } from '@/components/courses/AttendanceGauge';
 import { formatTimeLabel } from '@/lib/calendar/meetings';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
@@ -1298,6 +1299,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
             </div>
           )}
         </Card>
+
+        <SourcesCard course={course} />
 
         <Card className="rounded-2xl p-6">
           <div className="flex items-center justify-between mb-4">

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -28,6 +28,7 @@ import { formatTimeLabel } from '@/lib/calendar/meetings';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
 import { generateRateMyProfessorUrl } from '@/lib/export/rateMyProfessor';
 import { courseSwatch } from '@/lib/courseColors';
+import { normalizeMaterials, sumMaterialCosts } from '@/lib/courses/materials';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
@@ -225,8 +226,10 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const [deletingMaterialIndex, setDeletingMaterialIndex] = useState<number | null>(null);
   const [editingMaterialIndex, setEditingMaterialIndex] = useState<number | null>(null);
   const [materialDraft, setMaterialDraft] = useState('');
+  const [materialCostDraft, setMaterialCostDraft] = useState('');
   const [addingMaterial, setAddingMaterial] = useState(false);
   const [newMaterialDraft, setNewMaterialDraft] = useState('');
+  const [newMaterialCostDraft, setNewMaterialCostDraft] = useState('');
 
   const course = state.courses.find((c) => c.id === courseId);
   const items = state.scheduleItems
@@ -251,6 +254,9 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       </div>
     );
   }
+
+  const courseMaterials = normalizeMaterials(course.materials);
+  const materialsTotal = sumMaterialCosts(courseMaterials);
 
   const handleEditCourse = async (values: CourseFormValues) => {
     if (!user) throw new Error('You must be signed in to edit a course.');
@@ -487,16 +493,22 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   };
 
   const handleStartEditMaterial = (index: number) => {
-    setMaterialDraft(course.materials?.[index] ?? '');
+    const material = courseMaterials[index];
+    setMaterialDraft(material?.name ?? '');
+    setMaterialCostDraft(material?.cost !== undefined ? String(material.cost) : '');
     setEditingMaterialIndex(index);
   };
 
   const handleCommitMaterialEdit = async (index: number) => {
     if (!user) return;
-    const current = [...(course.materials ?? [])];
-    const trimmed = materialDraft.trim();
-    if (trimmed) {
-      current[index] = trimmed;
+    const current = [...courseMaterials];
+    const trimmedName = materialDraft.trim();
+    const parsedCost = materialCostDraft.trim() ? Number(materialCostDraft) : NaN;
+    if (trimmedName) {
+      current[index] = {
+        name: trimmedName,
+        ...(!Number.isNaN(parsedCost) && parsedCost >= 0 ? { cost: parsedCost } : {}),
+      };
     } else {
       current.splice(index, 1);
     }
@@ -508,7 +520,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     if (!user) return;
     setDeletingMaterialIndex(index);
     try {
-      const current = [...(course.materials ?? [])];
+      const current = [...courseMaterials];
       current.splice(index, 1);
       await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
       setConfirmingDeleteMaterialIndex(null);
@@ -519,14 +531,22 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleAddMaterial = async () => {
     if (!user) return;
-    const trimmed = newMaterialDraft.trim();
-    if (!trimmed) {
+    const trimmedName = newMaterialDraft.trim();
+    if (!trimmedName) {
       setAddingMaterial(false);
       return;
     }
-    const current = [...(course.materials ?? []), trimmed];
+    const parsedCost = newMaterialCostDraft.trim() ? Number(newMaterialCostDraft) : NaN;
+    const current = [
+      ...courseMaterials,
+      {
+        name: trimmedName,
+        ...(!Number.isNaN(parsedCost) && parsedCost >= 0 ? { cost: parsedCost } : {}),
+      },
+    ];
     await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
     setNewMaterialDraft('');
+    setNewMaterialCostDraft('');
     setAddingMaterial(false);
   };
 
@@ -1104,9 +1124,9 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
             )}
           </div>
 
-          {course.materials && course.materials.length > 0 ? (
+          {courseMaterials.length > 0 ? (
             <ul className="flex flex-col gap-2">
-              {course.materials.map((material, i) =>
+              {courseMaterials.map((material, i) =>
                 editingMaterialIndex === i ? (
                   <li
                     key={i}
@@ -1122,6 +1142,20 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                       }}
                       className="flex-1 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
                       autoFocus
+                    />
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={materialCostDraft}
+                      onChange={(e) => setMaterialCostDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleCommitMaterialEdit(i);
+                        if (e.key === 'Escape') setEditingMaterialIndex(null);
+                      }}
+                      placeholder="Cost"
+                      aria-label="Material cost"
+                      className="w-24 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
                     />
                     <button
                       type="button"
@@ -1169,8 +1203,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     key={i}
                     className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30"
                   >
-                    <div className="min-w-0">
-                      <span className="leading-relaxed break-words">{material}</span>
+                    <div className="min-w-0 flex flex-wrap items-center gap-2">
+                      <span className="leading-relaxed break-words">{material.name}</span>
+                      {material.cost !== undefined && (
+                        <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                          ${material.cost.toFixed(2)}
+                        </span>
+                      )}
                     </div>
                     <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                       {confirmingDeleteMaterialIndex === i ? (
@@ -1266,21 +1305,46 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
             )
           )}
 
+          {materialsTotal > 0 && (
+            <div className="flex items-center justify-between rounded-lg bg-primary/10 px-3 py-2 text-sm font-semibold text-primary">
+              <span>Course materials total</span>
+              <span>${materialsTotal.toFixed(2)}</span>
+            </div>
+          )}
+
           {addingMaterial && (
             <div className="space-y-2 rounded-lg border border-border p-3">
-              <input
-                type="text"
-                value={newMaterialDraft}
-                onChange={(e) => setNewMaterialDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleAddMaterial();
-                  if (e.key === 'Escape') setAddingMaterial(false);
-                }}
-                placeholder="e.g. Introduction to Algorithms, 3rd Edition"
-                className="w-full rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
-                autoFocus
-              />
-              <p className="text-xs text-muted-foreground">Press Enter to save.</p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={newMaterialDraft}
+                  onChange={(e) => setNewMaterialDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAddMaterial();
+                    if (e.key === 'Escape') setAddingMaterial(false);
+                  }}
+                  placeholder="e.g. Introduction to Algorithms, 3rd Edition"
+                  className="flex-1 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  autoFocus
+                />
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={newMaterialCostDraft}
+                  onChange={(e) => setNewMaterialCostDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAddMaterial();
+                    if (e.key === 'Escape') setAddingMaterial(false);
+                  }}
+                  placeholder="Cost"
+                  aria-label="Material cost"
+                  className="w-24 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Cost is optional. Press Enter to save.
+              </p>
               <div className="flex items-center justify-end gap-2">
                 <button
                   type="button"

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -14,6 +14,7 @@ import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course
 import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 import { useAppState } from '@/context/AppStateContext';
 import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
 import { COURSE_ICON_PRESETS, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
@@ -67,6 +68,7 @@ const emptyValues: CourseFormValues = {
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
   const { state } = useAppState();
   const [values, setValues] = useState<CourseFormValues>(emptyValues);
+  const [baseline, setBaseline] = useState<CourseFormValues>(emptyValues);
   const [errors, setErrors] = useState<Partial<Record<keyof CourseFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -80,29 +82,34 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
 
   useEffect(() => {
     if (!open) return;
-    setValues(
-      initialCourse
-        ? {
-            code: initialCourse.code,
-            title: initialCourse.title,
-            instructor: initialCourse.instructor ?? '',
-            term: initialCourse.term ?? '',
-            color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
-            icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
-            modality: initialCourse.modality,
-            meetingTimes: initialCourse.meetingTimes ?? [],
-            skipDates: initialCourse.skipDates ?? [],
-          }
-        : // A fresh course defaults to whichever preset is least represented
-          // among the user's existing courses, so a student with 8+ courses
-          // doesn't land on the same blue every time.
-          { ...emptyValues, color: pickNextCourseColor(coursesRef.current) },
-    );
+    const initial: CourseFormValues = initialCourse
+      ? {
+          code: initialCourse.code,
+          title: initialCourse.title,
+          instructor: initialCourse.instructor ?? '',
+          term: initialCourse.term ?? '',
+          color: initialCourse.color ?? COURSE_COLOR_PRESETS[0].value,
+          icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
+          modality: initialCourse.modality,
+          meetingTimes: initialCourse.meetingTimes ?? [],
+          skipDates: initialCourse.skipDates ?? [],
+        }
+      : // A fresh course defaults to whichever preset is least represented
+        // among the user's existing courses, so a student with 8+ courses
+        // doesn't land on the same blue every time.
+        { ...emptyValues, color: pickNextCourseColor(coursesRef.current) };
+    setValues(initial);
+    setBaseline(initial);
     setErrors({});
     setSubmitError(null);
   }, [open, initialCourse]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -195,14 +202,40 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
       role="dialog"
       aria-modal="true"
       aria-labelledby="course-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this course that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="course-form-title">
@@ -498,7 +531,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             <CardFooter className="justify-end gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
               >
                 Cancel

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -9,6 +9,7 @@ import {
   CardContent,
   CardFooter,
 } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import { courseFormSchema, type CourseFormValues } from '@/lib/validation/course';
 import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
@@ -173,7 +174,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="course-form-title">
               {initialCourse ? 'Edit Course' : 'Add Course'}
@@ -333,13 +334,9 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-foreground">Weekly meetings</span>
-                  <button
-                    type="button"
-                    onClick={addMeetingTime}
-                    className="text-xs font-semibold text-primary hover:underline"
-                  >
-                    + Add meeting time
-                  </button>
+                  <CardActionButton variant="solid" withPlus onClick={addMeetingTime}>
+                    Add meeting time
+                  </CardActionButton>
                 </div>
                 {meetingTimes.length === 0 ? (
                   <p className="text-xs text-muted-foreground">

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -61,6 +61,7 @@ const emptyValues: CourseFormValues = {
   icon: DEFAULT_COURSE_ICON,
   modality: undefined,
   meetingTimes: [],
+  skipDates: [],
 };
 
 export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: CourseFormModalProps) {
@@ -90,6 +91,7 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
             icon: initialCourse.icon ?? DEFAULT_COURSE_ICON,
             modality: initialCourse.modality,
             meetingTimes: initialCourse.meetingTimes ?? [],
+            skipDates: initialCourse.skipDates ?? [],
           }
         : // A fresh course defaults to whichever preset is least represented
           // among the user's existing courses, so a student with 8+ courses
@@ -133,9 +135,36 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
     setErrors((e) => (e.meetingTimes ? { ...e, meetingTimes: undefined } : e));
   };
 
+  const skipDates = values.skipDates ?? [];
+
+  const addSkipDate = () => {
+    setValues((s) => ({ ...s, skipDates: [...(s.skipDates ?? []), ''] }));
+  };
+
+  const removeSkipDate = (index: number) => {
+    setValues((s) => ({
+      ...s,
+      skipDates: (s.skipDates ?? []).filter((_, i) => i !== index),
+    }));
+  };
+
+  const updateSkipDate = (index: number, value: string) => {
+    setValues((s) => ({
+      ...s,
+      skipDates: (s.skipDates ?? []).map((d, i) => (i === index ? value : d)),
+    }));
+    setErrors((e) => (e.skipDates ? { ...e, skipDates: undefined } : e));
+  };
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const result = courseFormSchema.safeParse(values);
+    // A skip-date row the user added but hasn't picked a date for yet
+    // shouldn't block submission - drop empty rows rather than fail
+    // validation on a placeholder.
+    const result = courseFormSchema.safeParse({
+      ...values,
+      skipDates: (values.skipDates ?? []).filter((d) => d.trim().length > 0),
+    });
     if (!result.success) {
       const fieldErrors: Partial<Record<keyof CourseFormValues, string>> = {};
       for (const issue of result.error.issues) {
@@ -422,6 +451,48 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
                 {errors.meetingTimes && (
                   <p className="text-xs text-destructive">{errors.meetingTimes}</p>
                 )}
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-foreground">
+                    Skip dates (holidays &amp; breaks)
+                  </span>
+                  <CardActionButton variant="solid" withPlus onClick={addSkipDate}>
+                    Add skip date
+                  </CardActionButton>
+                </div>
+                {skipDates.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No skipped dates yet — add one to hide a weekly meeting on a holiday or break.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {skipDates.map((date, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-2 rounded-lg border border-border p-2"
+                      >
+                        <input
+                          aria-label={`Skip date ${index + 1}`}
+                          type="date"
+                          value={date}
+                          onChange={(e) => updateSkipDate(index, e.target.value)}
+                          className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeSkipDate(index)}
+                          aria-label={`Remove skip date ${index + 1}`}
+                          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {errors.skipDates && <p className="text-xs text-destructive">{errors.skipDates}</p>}
               </div>
             </CardContent>
             <CardFooter className="justify-end gap-2">

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -119,6 +119,7 @@ export function CoursesListView() {
         ...(values.term ? { term: values.term } : {}),
         ...(values.modality ? { modality: values.modality } : {}),
         ...(values.meetingTimes?.length ? { meetingTimes: values.meetingTimes } : {}),
+        ...(values.skipDates?.length ? { skipDates: values.skipDates } : {}),
       },
       dispatch,
     );

--- a/src/components/courses/GradeCalculatorModal.tsx
+++ b/src/components/courses/GradeCalculatorModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useAppState } from '@/context/AppStateContext';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
+import { useModalA11y } from '@/hooks/useModalA11y';
 import {
   GradeCategory,
   calculateCurrentWeightedGrade,
@@ -45,16 +46,7 @@ export function GradeCalculatorModal({
     }
   }, [initialCourseId, state.courses, selectedCourseId]);
 
-  // Handle Escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   // Math Calculations
   const currentGrade = useMemo(() => {
@@ -132,7 +124,11 @@ export function GradeCalculatorModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <Card accent="none" className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
+      <Card
+        ref={dialogRef}
+        accent="none"
+        className="relative w-full max-w-2xl overflow-hidden transition-all my-8"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border/40 px-5 py-4 bg-muted/20">
           <div className="flex items-center gap-3">

--- a/src/components/courses/GradeCalculatorModal.tsx
+++ b/src/components/courses/GradeCalculatorModal.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useAppState } from '@/context/AppStateContext';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
 import {
   GradeCategory,
   calculateCurrentWeightedGrade,
@@ -131,7 +132,7 @@ export function GradeCalculatorModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <Card className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
+      <Card accent="none" className="relative w-full max-w-2xl overflow-hidden transition-all my-8">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border/40 px-5 py-4 bg-muted/20">
           <div className="flex items-center gap-3">
@@ -326,12 +327,9 @@ export function GradeCalculatorModal({
                     >
                       Total Weight: {totalWeight}% {totalWeight !== 100 && '(Adjust to 100%)'}
                     </span>
-                    <button
-                      onClick={handleAddCategory}
-                      className="rounded-md bg-muted px-2 py-1 text-xs font-semibold text-foreground hover:bg-accent transition-colors"
-                    >
-                      + Add Category
-                    </button>
+                    <CardActionButton variant="solid" withPlus onClick={handleAddCategory}>
+                      Add Category
+                    </CardActionButton>
                   </div>
                 </div>
 

--- a/src/components/courses/SourceFormModal.tsx
+++ b/src/components/courses/SourceFormModal.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
+import { useModalA11y } from '@/hooks/useModalA11y';
+import type { Source, SourceAuthor, SourceType } from '@/types/source';
+
+export interface SourceFormValues {
+  type: SourceType;
+  title: string;
+  authors: SourceAuthor[];
+  year: string;
+  publisher: string;
+  journalName: string;
+  volume: string;
+  issue: string;
+  pages: string;
+  siteName: string;
+  url: string;
+  accessedDate: string;
+  notes: string;
+}
+
+const SOURCE_TYPE_OPTIONS: { value: SourceType; label: string }[] = [
+  { value: 'book', label: 'Book' },
+  { value: 'website', label: 'Website' },
+  { value: 'journal', label: 'Journal Article' },
+  { value: 'other', label: 'Other' },
+];
+
+function emptyValues(): SourceFormValues {
+  return {
+    type: 'book',
+    title: '',
+    authors: [{ firstName: '', lastName: '' }],
+    year: '',
+    publisher: '',
+    journalName: '',
+    volume: '',
+    issue: '',
+    pages: '',
+    siteName: '',
+    url: '',
+    accessedDate: '',
+    notes: '',
+  };
+}
+
+function valuesFromSource(source: Source): SourceFormValues {
+  return {
+    type: source.type,
+    title: source.title,
+    authors: source.authors.length > 0 ? source.authors : [{ firstName: '', lastName: '' }],
+    year: source.year ?? '',
+    publisher: source.publisher ?? '',
+    journalName: source.journalName ?? '',
+    volume: source.volume ?? '',
+    issue: source.issue ?? '',
+    pages: source.pages ?? '',
+    siteName: source.siteName ?? '',
+    url: source.url ?? '',
+    accessedDate: source.accessedDate ?? '',
+    notes: source.notes ?? '',
+  };
+}
+
+export interface SourceFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: SourceFormValues) => Promise<void>;
+  initialSource?: Source | null;
+}
+
+const fieldClass =
+  'w-full min-h-[44px] rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+const labelClass = 'block text-xs font-semibold text-muted-foreground mb-1';
+
+export function SourceFormModal({ open, onClose, onSubmit, initialSource }: SourceFormModalProps) {
+  const [values, setValues] = useState<SourceFormValues>(emptyValues());
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setValues(initialSource ? valuesFromSource(initialSource) : emptyValues());
+    setError(null);
+  }, [open, initialSource]);
+
+  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+
+  if (!open) return null;
+
+  const update = <K extends keyof SourceFormValues>(key: K, value: SourceFormValues[K]) =>
+    setValues((v) => ({ ...v, [key]: value }));
+
+  const updateAuthor = (index: number, field: keyof SourceAuthor, value: string) => {
+    setValues((v) => ({
+      ...v,
+      authors: v.authors.map((a, i) => (i === index ? { ...a, [field]: value } : a)),
+    }));
+  };
+
+  const addAuthor = () =>
+    setValues((v) => ({ ...v, authors: [...v.authors, { firstName: '', lastName: '' }] }));
+
+  const removeAuthor = (index: number) =>
+    setValues((v) => ({ ...v, authors: v.authors.filter((_, i) => i !== index) }));
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!values.title.trim()) {
+      setError('Title is required.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        ...values,
+        authors: values.authors.filter((a) => a.firstName.trim() || a.lastName.trim()),
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save this source. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="source-form-title"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-lg outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card accent="none">
+          <CardHeader>
+            <CardTitle id="source-form-title">
+              {initialSource ? 'Edit Source' : 'Add Source'}
+            </CardTitle>
+            <CardDescription>Formatted into APA, MLA, or Chicago automatically.</CardDescription>
+          </CardHeader>
+          <form onSubmit={handleSubmit}>
+            <CardContent className="max-h-[65vh] space-y-4 overflow-y-auto">
+              {error && (
+                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                  {error}
+                </div>
+              )}
+
+              <div>
+                <label className={labelClass}>Source type</label>
+                <div className="flex flex-wrap gap-1.5">
+                  {SOURCE_TYPE_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => update('type', opt.value)}
+                      className={`min-h-[36px] rounded-full px-3 text-xs font-semibold transition-colors ${
+                        values.type === opt.value
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted/50 text-muted-foreground hover:bg-accent'
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="source-title" className={labelClass}>
+                  Title
+                </label>
+                <input
+                  id="source-title"
+                  value={values.title}
+                  onChange={(e) => update('title', e.target.value)}
+                  className={fieldClass}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className={labelClass}>Authors</label>
+                <div className="space-y-2">
+                  {values.authors.map((author, i) => (
+                    <div key={i} className="flex gap-2">
+                      <input
+                        aria-label={`Author ${i + 1} first name`}
+                        placeholder="First name"
+                        value={author.firstName}
+                        onChange={(e) => updateAuthor(i, 'firstName', e.target.value)}
+                        className={fieldClass}
+                      />
+                      <input
+                        aria-label={`Author ${i + 1} last name`}
+                        placeholder="Last name"
+                        value={author.lastName}
+                        onChange={(e) => updateAuthor(i, 'lastName', e.target.value)}
+                        className={fieldClass}
+                      />
+                      {values.authors.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removeAuthor(i)}
+                          aria-label={`Remove author ${i + 1}`}
+                          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-destructive"
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={addAuthor}
+                  className="mt-2 text-xs font-semibold text-primary hover:underline"
+                >
+                  + Add another author
+                </button>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="source-year" className={labelClass}>
+                    Year
+                  </label>
+                  <input
+                    id="source-year"
+                    value={values.year}
+                    onChange={(e) => update('year', e.target.value)}
+                    placeholder="2024"
+                    className={fieldClass}
+                  />
+                </div>
+
+                {values.type === 'book' && (
+                  <div>
+                    <label htmlFor="source-publisher" className={labelClass}>
+                      Publisher
+                    </label>
+                    <input
+                      id="source-publisher"
+                      value={values.publisher}
+                      onChange={(e) => update('publisher', e.target.value)}
+                      className={fieldClass}
+                    />
+                  </div>
+                )}
+              </div>
+
+              {values.type === 'website' && (
+                <>
+                  <div>
+                    <label htmlFor="source-site-name" className={labelClass}>
+                      Site name
+                    </label>
+                    <input
+                      id="source-site-name"
+                      value={values.siteName}
+                      onChange={(e) => update('siteName', e.target.value)}
+                      className={fieldClass}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="source-url" className={labelClass}>
+                      URL
+                    </label>
+                    <input
+                      id="source-url"
+                      type="url"
+                      value={values.url}
+                      onChange={(e) => update('url', e.target.value)}
+                      className={fieldClass}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="source-accessed" className={labelClass}>
+                      Accessed on
+                    </label>
+                    <input
+                      id="source-accessed"
+                      type="date"
+                      value={values.accessedDate}
+                      onChange={(e) => update('accessedDate', e.target.value)}
+                      className={fieldClass}
+                    />
+                  </div>
+                </>
+              )}
+
+              {values.type === 'journal' && (
+                <>
+                  <div>
+                    <label htmlFor="source-journal-name" className={labelClass}>
+                      Journal name
+                    </label>
+                    <input
+                      id="source-journal-name"
+                      value={values.journalName}
+                      onChange={(e) => update('journalName', e.target.value)}
+                      className={fieldClass}
+                    />
+                  </div>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div>
+                      <label htmlFor="source-volume" className={labelClass}>
+                        Volume
+                      </label>
+                      <input
+                        id="source-volume"
+                        value={values.volume}
+                        onChange={(e) => update('volume', e.target.value)}
+                        className={fieldClass}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="source-issue" className={labelClass}>
+                        Issue
+                      </label>
+                      <input
+                        id="source-issue"
+                        value={values.issue}
+                        onChange={(e) => update('issue', e.target.value)}
+                        className={fieldClass}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="source-pages" className={labelClass}>
+                        Pages
+                      </label>
+                      <input
+                        id="source-pages"
+                        value={values.pages}
+                        onChange={(e) => update('pages', e.target.value)}
+                        placeholder="210-234"
+                        className={fieldClass}
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {values.type === 'other' && (
+                <div>
+                  <label htmlFor="source-notes" className={labelClass}>
+                    Notes
+                  </label>
+                  <textarea
+                    id="source-notes"
+                    value={values.notes}
+                    onChange={(e) => update('notes', e.target.value)}
+                    rows={2}
+                    className={fieldClass}
+                  />
+                </div>
+              )}
+            </CardContent>
+
+            <div className="flex items-center justify-end gap-2 border-t border-border p-4">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? 'Saving...' : initialSource ? 'Save Changes' : 'Add Source'}
+              </button>
+            </div>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/SourcesCard.tsx
+++ b/src/components/courses/SourcesCard.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useToast } from '@/components/ui/Toast';
+import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { createSource, updateSource, deleteSource } from '@/lib/firestore/sources';
+import { formatCitation, formatBibliography, sortSources } from '@/lib/citations/formatCitation';
+import { SourceFormModal, type SourceFormValues } from '@/components/courses/SourceFormModal';
+import { CITATION_STYLE_LABEL, type CitationStyle, type Source } from '@/types/source';
+import type { Course } from '@/types/schedule';
+
+const STYLES: CitationStyle[] = ['apa', 'mla', 'chicago'];
+
+export function SourcesCard({ course }: { course: Course }) {
+  const { state, dispatch } = useAppState();
+  const { user } = useAuth();
+  const { showError } = useToast();
+
+  const [style, setStyle] = useState<CitationStyle>('apa');
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingSource, setEditingSource] = useState<Source | null>(null);
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const sources = state.sources.filter((s) => s.courseId === course.id);
+
+  const openCreate = () => {
+    setEditingSource(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (source: Source) => {
+    setEditingSource(source);
+    setFormOpen(true);
+  };
+
+  const handleSubmit = async (values: SourceFormValues) => {
+    if (!user) throw new Error('You must be signed in to save a source.');
+
+    const base = {
+      courseId: course.id,
+      type: values.type,
+      title: values.title.trim(),
+      authors: values.authors,
+      ...(values.year.trim() ? { year: values.year.trim() } : {}),
+      ...(values.publisher.trim() ? { publisher: values.publisher.trim() } : {}),
+      ...(values.journalName.trim() ? { journalName: values.journalName.trim() } : {}),
+      ...(values.volume.trim() ? { volume: values.volume.trim() } : {}),
+      ...(values.issue.trim() ? { issue: values.issue.trim() } : {}),
+      ...(values.pages.trim() ? { pages: values.pages.trim() } : {}),
+      ...(values.siteName.trim() ? { siteName: values.siteName.trim() } : {}),
+      ...(values.url.trim() ? { url: values.url.trim() } : {}),
+      ...(values.accessedDate.trim() ? { accessedDate: values.accessedDate.trim() } : {}),
+      ...(values.notes.trim() ? { notes: values.notes.trim() } : {}),
+    };
+
+    if (editingSource) {
+      await updateSource(user.uid, editingSource, { id: editingSource.id, ...base }, dispatch);
+    } else {
+      await createSource(user.uid, { id: crypto.randomUUID(), ...base }, dispatch);
+    }
+  };
+
+  const handleDelete = async (source: Source) => {
+    if (!user) return;
+    try {
+      await deleteSource(user.uid, source, dispatch);
+    } catch (err) {
+      showError('Could not delete this source', err instanceof Error ? err.message : undefined);
+    } finally {
+      setConfirmingDeleteId(null);
+    }
+  };
+
+  const handleCopyBibliography = async () => {
+    const text = formatBibliography(sources, style);
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        showError('Could not copy the bibliography', 'Try selecting and copying the text below.');
+      }
+    }
+  };
+
+  return (
+    <>
+      <Card className="rounded-2xl p-6 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-base font-semibold text-foreground">Sources</h2>
+          <CardActionButton variant="solid" withPlus onClick={openCreate}>
+            Add Source
+          </CardActionButton>
+        </div>
+
+        {sources.length === 0 ? (
+          <EmptyState
+            icon={
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                />
+              </svg>
+            }
+            title="No sources yet"
+            description="Save sources as you research this course's papers, and copy a finished bibliography when you're done."
+            action={{ label: '+ Add Source', onClick: openCreate }}
+          />
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
+              <div className="flex items-center rounded-xl bg-muted/50 p-1 border border-border">
+                {STYLES.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setStyle(s)}
+                    className={`min-h-[36px] rounded-lg px-3 text-xs font-semibold transition-all ${
+                      style === s
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {CITATION_STYLE_LABEL[s]}
+                  </button>
+                ))}
+              </div>
+              <button
+                onClick={handleCopyBibliography}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-primary/10 px-3 text-xs font-semibold text-primary transition-colors hover:bg-primary/20"
+              >
+                {copied ? 'Copied!' : 'Copy Full Bibliography'}
+              </button>
+            </div>
+
+            <ul className="space-y-3">
+              {sortSources(sources).map((source) => (
+                <li key={source.id} className="flex items-start justify-between gap-3 text-sm">
+                  <p className="text-foreground">{formatCitation(source, style)}</p>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {confirmingDeleteId === source.id ? (
+                      <>
+                        <button
+                          onClick={() => handleDelete(source)}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-destructive/10 px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/20"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmingDeleteId(null)}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 text-xs text-muted-foreground transition-colors hover:bg-accent"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => openEdit(source)}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => setConfirmingDeleteId(source.id)}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-full px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </Card>
+
+      <SourceFormModal
+        open={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleSubmit}
+        initialSource={editingSource}
+      />
+    </>
+  );
+}

--- a/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
+++ b/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
@@ -107,7 +107,7 @@ describe('GradeCalculatorModal (Item 36)', () => {
     const onClose = vi.fn();
     renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={onClose} />);
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
+++ b/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
@@ -35,7 +35,7 @@ function renderWithProviders(ui: React.ReactElement, stateOverrides: Partial<App
   return render(
     <ThemeProvider>
       <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
-    </ThemeProvider>
+    </ThemeProvider>,
   );
 }
 
@@ -58,7 +58,9 @@ describe('GradeCalculatorModal (Item 36)', () => {
   });
 
   it('renders nothing when isOpen is false', () => {
-    const { container } = renderWithProviders(<GradeCalculatorModal isOpen={false} onClose={vi.fn()} />);
+    const { container } = renderWithProviders(
+      <GradeCalculatorModal isOpen={false} onClose={vi.fn()} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
@@ -95,7 +97,7 @@ describe('GradeCalculatorModal (Item 36)', () => {
   it('allows adding and updating categories dynamically', () => {
     renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={vi.fn()} />);
 
-    const addBtn = screen.getByText('+ Add Category');
+    const addBtn = screen.getByText('Add Category');
     fireEvent.click(addBtn);
 
     expect(screen.getByLabelText('Category 4 Name')).toBeDefined();

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -184,6 +184,7 @@ export function DashboardView() {
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
         ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
+        ...(values.assignedTo ? { assignedTo: values.assignedTo } : {}),
       },
       dispatch,
     );
@@ -317,6 +318,7 @@ export function DashboardView() {
                       completed={item.completed}
                       progress={item.progress}
                       priority={item.priority}
+                      assignedTo={item.assignedTo}
                       onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
                       trailing={
                         // DA-1: stacked (badge above date) rather than

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -155,8 +155,11 @@ export function DashboardView() {
         title: values.title,
         color: values.color,
         icon: values.icon,
+        meetingTimes: values.meetingTimes ?? [],
+        skipDates: values.skipDates ?? [],
         ...(values.instructor ? { instructor: values.instructor } : {}),
         ...(values.term ? { term: values.term } : {}),
+        ...(values.modality ? { modality: values.modality } : {}),
       },
       dispatch,
     );

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -17,6 +17,7 @@ import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
+import { MaterialsBudgetCard } from '@/components/dashboard/MaterialsBudgetCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
@@ -242,6 +243,8 @@ export function DashboardView() {
         </div>
 
         <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
+
+        <MaterialsBudgetCard courses={state.courses} />
 
         <div className="space-y-4">
           <Card accent="left" className="rounded-2xl p-6">

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -431,13 +431,14 @@ export function DashboardView() {
                   <p className="text-xs text-muted-foreground">
                     Add your first course to start tracking assignments and workload.
                   </p>
-                  <button
-                    type="button"
+                  <CardActionButton
+                    variant="solid"
+                    withPlus
                     onClick={() => setAddCourseOpen(true)}
-                    className="mt-1 rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                    className="mt-1"
                   >
-                    + Add Course
-                  </button>
+                    Add Course
+                  </CardActionButton>
                 </div>
               ) : (
                 <div className="flex items-center gap-4">

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -178,6 +178,8 @@ export function DashboardView() {
         priority: values.priority,
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -16,6 +16,7 @@ import { createScheduleItem, updateScheduleItem } from '@/lib/firestore/schedule
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
+import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
@@ -238,6 +239,8 @@ export function DashboardView() {
             </button>
           </div>
         </div>
+
+        <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
 
         <div className="space-y-4">
           <Card accent="left" className="rounded-2xl p-6">

--- a/src/components/dashboard/MaterialsBudgetCard.tsx
+++ b/src/components/dashboard/MaterialsBudgetCard.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Card } from '@/components/ui/Card';
+import { normalizeMaterials, sumMaterialCosts } from '@/lib/courses/materials';
+import type { Course } from '@/types/schedule';
+
+export interface MaterialsBudgetCardProps {
+  courses: Course[];
+}
+
+/** A running semester total for course materials with a recorded cost -
+ * renders nothing until at least one material actually has a cost on file,
+ * so a brand-new account (or one that only ever uses free/no-cost
+ * materials) never sees an empty "$0.00" card. */
+export function MaterialsBudgetCard({ courses }: MaterialsBudgetCardProps) {
+  const courseTotals = courses
+    .map((course) => ({
+      course,
+      total: sumMaterialCosts(normalizeMaterials(course.materials)),
+    }))
+    .filter((entry) => entry.total > 0)
+    .sort((a, b) => b.total - a.total);
+
+  const semesterTotal = courseTotals.reduce((sum, entry) => sum + entry.total, 0);
+
+  if (semesterTotal === 0) return null;
+
+  return (
+    <Card accent="none" className="rounded-2xl border-primary/20 bg-primary/5 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-bold text-primary">Semester Materials Budget</h2>
+        <span className="text-lg font-extrabold text-primary">${semesterTotal.toFixed(2)}</span>
+      </div>
+      <ul className="mt-3 space-y-1">
+        {courseTotals.map(({ course, total }) => (
+          <li
+            key={course.id}
+            className="flex items-center justify-between text-xs text-muted-foreground"
+          >
+            <span className="truncate">{course.code}</span>
+            <span className="shrink-0 font-semibold">${total.toFixed(2)}</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/src/components/dashboard/WeeklyBriefingCard.tsx
+++ b/src/components/dashboard/WeeklyBriefingCard.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useAuth } from '@/context/AuthContext';
+import { calculateWorkloadBreakdown } from '@/lib/planner/projectChunker';
+import type { ScheduleItem } from '@/types/schedule';
+
+/** Monday of the calendar week containing `date`, as a YYYY-MM-DD key - used
+ * to dismiss the briefing "for the week" regardless of which day the
+ * student first opens the dashboard on. */
+function weekStartKey(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay(); // 0 = Sunday
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diffToMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+function dismissedStorageKey(uid: string, weekKey: string): string {
+  return `weekly-briefing-dismissed:${uid}:${weekKey}`;
+}
+
+export interface WeeklyBriefingCardProps {
+  scheduleItems: ScheduleItem[];
+}
+
+/** A once-a-week "here's what's ahead" summary, generated entirely from data
+ * the workload engine already computes - no notification backend required.
+ * Dismissing it hides it until the following week's Monday. */
+export function WeeklyBriefingCard({ scheduleItems }: WeeklyBriefingCardProps) {
+  const { user } = useAuth();
+  const weekKey = useMemo(() => weekStartKey(new Date()), []);
+  const [dismissed, setDismissed] = useState(() => {
+    if (!user || typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(dismissedStorageKey(user.uid, weekKey)) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const breakdown = useMemo(() => calculateWorkloadBreakdown(scheduleItems), [scheduleItems]);
+
+  const { thisWeek } = breakdown;
+  const pendingDays = thisWeek.days.map((day) => ({
+    ...day,
+    items: day.items.filter((item) => !item.completed),
+  }));
+  const pendingItemCount = pendingDays.reduce((sum, day) => sum + day.items.length, 0);
+  const examCount = pendingDays.reduce(
+    (sum, day) => sum + day.items.filter((item) => item.type === 'exam').length,
+    0,
+  );
+  const heaviestDay = pendingDays.reduce(
+    (max, day) => (day.totalMinutes > max.totalMinutes ? day : max),
+    pendingDays[0],
+  );
+
+  if (dismissed || pendingItemCount === 0 || !heaviestDay || heaviestDay.totalMinutes === 0) {
+    return null;
+  }
+
+  const totalHours = Math.round((thisWeek.totalMinutes / 60) * 10) / 10;
+  const heaviestTitles = heaviestDay.items
+    .slice(0, 2)
+    .map((item) => item.title)
+    .join(', ');
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (!user) return;
+    try {
+      window.localStorage.setItem(dismissedStorageKey(user.uid, weekKey), 'true');
+    } catch {
+      // Non-fatal: worst case the briefing reappears next visit this week.
+    }
+  };
+
+  return (
+    <Card accent="none" className="rounded-2xl border-primary/20 bg-primary/5 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-bold text-primary">
+            This week: {totalHours}h
+            {examCount > 0 ? `, ${examCount} exam${examCount > 1 ? 's' : ''}` : ''}
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Heaviest day: {heaviestDay.dayName} ({heaviestTitles}
+            {heaviestDay.items.length > 2 ? `, +${heaviestDay.items.length - 2} more` : ''})
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss this week's briefing"
+          className="shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/flashcards/FlashcardDeckCard.tsx
+++ b/src/components/flashcards/FlashcardDeckCard.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { useSyllabi } from '@/lib/firestore/useSyllabi';
+import { createFlashcards, deleteFlashcard } from '@/lib/firestore/flashcards';
+import { isCardDue } from '@/lib/flashcards/sm2';
+import { SM2_DEFAULTS } from '@/lib/flashcards/sm2';
+import { toDayKey } from '@/lib/calendar/dates';
+import { generatedFlashcardsSchema } from '@/types/flashcard';
+import type { Flashcard } from '@/types/flashcard';
+import type { Course } from '@/types/schedule';
+
+/** A card is treated as "mastered" once it's survived two consecutive
+ * successful reviews - matches SM-2's own graduation point (the interval
+ * stops being a fixed 1/6 days and starts compounding by the ease factor). */
+const MASTERED_REPETITIONS = 2;
+
+export function FlashcardDeckCard({
+  course,
+  onReview,
+}: {
+  course: Course;
+  onReview: (cards: Flashcard[]) => void;
+}) {
+  const { user } = useAuth();
+  const { state, dispatch } = useAppState();
+  const syllabi = useSyllabi(user?.uid, course.id);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const latestSyllabus = syllabi
+    .slice()
+    .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
+
+  const deckCards = state.flashcards.filter((c) => c.courseId === course.id);
+  const dueCards = deckCards.filter((c) => isCardDue(c));
+  const masteredCount = deckCards.filter((c) => c.repetitions >= MASTERED_REPETITIONS).length;
+  const masteredPct = deckCards.length ? Math.round((masteredCount / deckCards.length) * 100) : 0;
+
+  const handleGenerate = async () => {
+    if (!user || !latestSyllabus) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch('/api/syllabus/flashcards', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          storagePath: latestSyllabus.storagePath,
+          fileName: latestSyllabus.fileName,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'Flashcard generation failed.');
+
+      const generated = generatedFlashcardsSchema.parse(body.cards);
+      const today = toDayKey(new Date());
+      const newCards: Flashcard[] = generated.map((g) => ({
+        id: crypto.randomUUID(),
+        courseId: course.id,
+        front: g.front,
+        back: g.back,
+        ...SM2_DEFAULTS,
+        dueDate: today,
+        createdAt: new Date().toISOString(),
+        sourceFileName: latestSyllabus.fileName,
+      }));
+      await createFlashcards(user.uid, newCards, dispatch);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleDeleteDeck = async () => {
+    if (!user) return;
+    setDeleting(true);
+    try {
+      await Promise.all(deckCards.map((c) => deleteFlashcard(user.uid, c, dispatch)));
+    } finally {
+      setDeleting(false);
+      setConfirmingDelete(false);
+    }
+  };
+
+  if (!latestSyllabus && deckCards.length === 0) {
+    return (
+      <Card accent="none" className="rounded-2xl border-dashed p-5 opacity-90">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-muted-foreground">{course.code}</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Upload a syllabus on this course&apos;s page to generate flashcards.
+            </p>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="rounded-2xl p-5 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-foreground">{course.code}</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {deckCards.length} {deckCards.length === 1 ? 'card' : 'cards'}
+          </p>
+        </div>
+        {dueCards.length > 0 && (
+          <span className="shrink-0 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+            Due: {dueCards.length}
+          </span>
+        )}
+      </div>
+
+      {deckCards.length > 0 && (
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-gradient-brand transition-all"
+            style={{ width: `${masteredPct}%` }}
+          />
+        </div>
+      )}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {dueCards.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onReview(dueCards)}
+            className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-primary px-3 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Review {dueCards.length} due
+          </button>
+        )}
+        {latestSyllabus && (
+          <CardActionButton
+            variant={deckCards.length === 0 ? 'solid' : 'ghost'}
+            onClick={handleGenerate}
+            disabled={generating}
+          >
+            {generating ? 'Generating…' : deckCards.length === 0 ? 'Generate Cards' : 'Add more'}
+          </CardActionButton>
+        )}
+        {deckCards.length > 0 &&
+          (confirmingDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={handleDeleteDeck}
+                disabled={deleting}
+                className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-destructive/10 px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {deleting ? 'Deleting…' : 'Confirm'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                disabled={deleting}
+                className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs text-muted-foreground transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+            >
+              Delete deck
+            </button>
+          ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/flashcards/FlashcardReviewSession.tsx
+++ b/src/components/flashcards/FlashcardReviewSession.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useModalA11y } from '@/hooks/useModalA11y';
+import type { Flashcard } from '@/types/flashcard';
+import type { ReviewRating } from '@/lib/flashcards/sm2';
+
+const RATING_BUTTONS: { rating: ReviewRating; label: string; className: string }[] = [
+  {
+    rating: 'again',
+    label: 'Again',
+    className: 'bg-destructive/10 text-destructive hover:bg-destructive/20',
+  },
+  {
+    rating: 'hard',
+    label: 'Hard',
+    className: 'bg-load-medium/10 text-load-medium hover:bg-load-medium/20',
+  },
+  { rating: 'good', label: 'Good', className: 'bg-primary/10 text-primary hover:bg-primary/20' },
+  { rating: 'easy', label: 'Easy', className: 'bg-load-low/10 text-load-low hover:bg-load-low/20' },
+];
+
+export interface FlashcardReviewSessionProps {
+  /** Snapshot of the cards due when the session opened - frozen so a card
+   * rescheduled mid-session doesn't reshuffle the queue out from under the
+   * student. `null` means the session is closed. */
+  cards: Flashcard[] | null;
+  onClose: () => void;
+  onRate: (card: Flashcard, rating: ReviewRating) => Promise<void>;
+}
+
+export function FlashcardReviewSession({ cards, onClose, onRate }: FlashcardReviewSessionProps) {
+  const [index, setIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [rating, setRating] = useState(false);
+
+  const open = !!cards;
+  const dialogRef = useModalA11y<HTMLDivElement>(open, handleClose);
+
+  function handleClose() {
+    setIndex(0);
+    setRevealed(false);
+    onClose();
+  }
+
+  if (!cards) return null;
+
+  const done = index >= cards.length;
+  const card = done ? null : cards[index];
+
+  const handleRate = async (r: ReviewRating) => {
+    if (!card || rating) return;
+    setRating(true);
+    try {
+      await onRate(card, r);
+      setIndex((i) => i + 1);
+      setRevealed(false);
+    } finally {
+      setRating(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="flashcard-review-title"
+      onClick={handleClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-lg outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card accent="none" className="p-6">
+          <div className="flex items-center justify-between">
+            <h2 id="flashcard-review-title" className="text-sm font-bold text-foreground">
+              {done ? 'Session complete' : `Card ${index + 1} of ${cards.length}`}
+            </h2>
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="Close review session"
+              className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {done ? (
+            <div className="mt-6 flex flex-col items-center gap-3 py-6 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-brand text-white">
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <p className="text-sm font-semibold text-foreground">All caught up on this review.</p>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="mt-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Done
+              </button>
+            </div>
+          ) : (
+            <div className="mt-5 space-y-4">
+              <button
+                type="button"
+                onClick={() => setRevealed((r) => !r)}
+                className="flex min-h-[180px] w-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-muted/40 p-6 text-center transition-colors hover:border-primary/40"
+              >
+                <p className="text-base font-semibold leading-relaxed text-foreground">
+                  {card!.front}
+                </p>
+                {revealed && (
+                  <>
+                    <div className="h-px w-16 bg-border" />
+                    <p className="text-sm leading-relaxed text-muted-foreground">{card!.back}</p>
+                  </>
+                )}
+                {!revealed && (
+                  <span className="text-xs font-semibold text-primary">Tap to reveal answer</span>
+                )}
+              </button>
+
+              {revealed ? (
+                <div className="grid grid-cols-4 gap-2">
+                  {RATING_BUTTONS.map(({ rating: r, label, className }) => (
+                    <button
+                      key={r}
+                      type="button"
+                      disabled={rating}
+                      onClick={() => handleRate(r)}
+                      className={`min-h-[44px] rounded-lg text-xs font-semibold transition-colors disabled:opacity-50 ${className}`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-center text-xs text-muted-foreground">
+                  Reveal the answer, then rate how well you remembered it.
+                </p>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flashcards/FlashcardsView.tsx
+++ b/src/components/flashcards/FlashcardsView.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { updateFlashcard } from '@/lib/firestore/flashcards';
+import { applySM2, isCardDue, type ReviewRating } from '@/lib/flashcards/sm2';
+import { FlashcardDeckCard } from '@/components/flashcards/FlashcardDeckCard';
+import { FlashcardReviewSession } from '@/components/flashcards/FlashcardReviewSession';
+import type { Flashcard } from '@/types/flashcard';
+
+export function FlashcardsView() {
+  const { user } = useAuth();
+  const { state, dispatch } = useAppState();
+  const [reviewQueue, setReviewQueue] = useState<Flashcard[] | null>(null);
+
+  const dueCards = state.flashcards.filter((c) => isCardDue(c));
+
+  const handleRate = async (card: Flashcard, rating: ReviewRating) => {
+    if (!user) return;
+    const next = applySM2(card, rating);
+    await updateFlashcard(
+      user.uid,
+      card,
+      { ...card, ...next, lastReviewedAt: new Date().toISOString() },
+      dispatch,
+    );
+  };
+
+  return (
+    <>
+      <div className="max-w-5xl space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground tracking-tight">Flashcards</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Generated from your syllabi, reviewed with spaced repetition (SM-2) so the cards you
+            keep forgetting come back sooner.
+          </p>
+        </div>
+
+        {dueCards.length > 0 && (
+          <Card accent="none" className="rounded-2xl border-primary/20 bg-primary/5 p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-bold text-primary">
+                  {dueCards.length} {dueCards.length === 1 ? 'card' : 'cards'} due across every
+                  course
+                </h2>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Reviewing across courses interleaves material - the way spaced repetition actually
+                  works.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setReviewQueue(dueCards)}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Review {dueCards.length} due cards →
+              </button>
+            </div>
+          </Card>
+        )}
+
+        {state.courses.length === 0 ? (
+          <Card className="rounded-2xl p-6">
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                  />
+                </svg>
+              }
+              title="No courses yet"
+              description="Add a course and upload its syllabus to generate flashcards."
+            />
+          </Card>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {state.courses.map((course) => (
+              <FlashcardDeckCard key={course.id} course={course} onReview={setReviewQueue} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <FlashcardReviewSession
+        cards={reviewQueue}
+        onClose={() => setReviewQueue(null)}
+        onRate={handleRate}
+      />
+    </>
+  );
+}

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -2,34 +2,10 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { cn } from '@/lib/utils';
+import { saveSession } from '@/lib/focus/pomodoroSessions';
 
-interface PomodoroSession {
-  startedAt: string;
-  duration: number; // seconds
-  taskId?: string;
-}
-
-const STORAGE_KEY = 'syllabus-sense:pomodoro-sessions';
 const WORK_DURATION = 25 * 60; // 25 minutes
 const BREAK_DURATION = 5 * 60; //  5 minutes
-
-function loadSessions(): PomodoroSession[] {
-  try {
-    const raw = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
-    return raw ? (JSON.parse(raw) as PomodoroSession[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveSession(session: PomodoroSession): void {
-  try {
-    const existing = loadSessions();
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([...existing, session]));
-  } catch {
-    // Silently ignore — localStorage may be unavailable (SSR, privacy mode).
-  }
-}
 
 /** Plays a brief 880 Hz beep using the Web Audio API to signal a timer end. */
 function playBeep(): void {

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -92,6 +92,25 @@ const tabItems: TabItem[] = [
 
 const moreItems: TabItem[] = [
   {
+    name: 'Flashcards',
+    href: '/flashcards',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 4.5v15m0-15a1.5 1.5 0 011.5-1.5h9A1.5 1.5 0 0121 4.5v10.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 019 15M3 6.75h6M3 12h6m-6 5.25h6"
+        />
+      </svg>
+    ),
+  },
+  {
     name: 'Planner',
     href: '/planner',
     icon: (

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -111,6 +111,25 @@ const moreItems: TabItem[] = [
     ),
   },
   {
+    name: 'Quizzes',
+    href: '/quizzes',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    ),
+  },
+  {
     name: 'Planner',
     href: '/planner',
     icon: (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -111,6 +111,25 @@ export default function Sidebar() {
       ),
     },
     {
+      name: 'Quizzes',
+      href: '/quizzes',
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+    },
+    {
       name: 'Planner',
       href: '/planner',
       icon: (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -92,6 +92,25 @@ export default function Sidebar() {
       ),
     },
     {
+      name: 'Flashcards',
+      href: '/flashcards',
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 4.5v15m0-15a1.5 1.5 0 011.5-1.5h9A1.5 1.5 0 0121 4.5v10.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 019 15M3 6.75h6M3 12h6m-6 5.25h6"
+          />
+        </svg>
+      ),
+    },
+    {
       name: 'Planner',
       href: '/planner',
       icon: (

--- a/src/components/layout/TermSwitcher.tsx
+++ b/src/components/layout/TermSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { inferCurrentTerm, useAppState } from '@/context/AppStateContext';
 import { cn } from '@/lib/utils';
 
@@ -40,6 +40,24 @@ function sortTermsChronologically(terms: string[]): string[] {
 export function TermSwitcher() {
   const { state, dispatch } = useAppState();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const close = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
 
   const terms = useMemo(
     () =>
@@ -59,12 +77,13 @@ export function TermSwitcher() {
 
   const select = (term: string) => {
     dispatch({ type: 'SELECT_TERM', payload: term });
-    setOpen(false);
+    close();
   };
 
   return (
     <div className="relative">
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
@@ -89,11 +108,7 @@ export function TermSwitcher() {
       </button>
       {open && (
         <>
-          <div
-            className="fixed inset-0 z-[60] bg-transparent"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
+          <div className="fixed inset-0 z-[60] bg-transparent" onClick={close} aria-hidden="true" />
           <div
             role="listbox"
             aria-label="Select term"

--- a/src/components/planner/ProjectChunkerModal.tsx
+++ b/src/components/planner/ProjectChunkerModal.tsx
@@ -217,7 +217,7 @@ export function ProjectChunkerModal({
       aria-modal="true"
       aria-labelledby="project-chunker-title"
     >
-      <Card ref={dialogRef} className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+      <Card ref={dialogRef} accent="none" className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <CardHeader className="flex-row items-center justify-between space-y-0 border-b border-border pb-4">
           <div className="flex items-center gap-2.5">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">

--- a/src/components/planner/ProjectChunkerModal.tsx
+++ b/src/components/planner/ProjectChunkerModal.tsx
@@ -135,6 +135,7 @@ export function ProjectChunkerModal({
   const [selectedCourseId, setSelectedCourseId] = useState<string>('');
   const [saving, setSaving] = useState(false);
   const [savedSuccess, setSavedSuccess] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const dialogRef = useModalA11y<HTMLDivElement>(isModalOpen, onClose);
   const availableCourses = courses || state.courses;
@@ -164,6 +165,7 @@ export function ProjectChunkerModal({
   const handlePersistChunks = async () => {
     if (!user || previewChunks.length === 0) return;
     setSaving(true);
+    setSaveError(null);
     try {
       if (onSaveChunks) {
         await onSaveChunks(previewChunks);
@@ -205,6 +207,9 @@ export function ProjectChunkerModal({
       }, 1200);
     } catch (err) {
       console.error('Failed to save study chunks:', err);
+      setSaveError(
+        "Couldn't save these chunks - some may have been added before the failure. Check your planner, then try again.",
+      );
     } finally {
       setSaving(false);
     }
@@ -391,6 +396,11 @@ export function ProjectChunkerModal({
         </CardContent>
 
         <CardFooter className="flex-wrap items-center justify-between gap-3">
+          {saveError && (
+            <p className="w-full rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-xs text-load-critical">
+              {saveError}
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">
             Total Work: <span className="font-bold text-foreground">{totalHours} hrs</span> spread
             across{' '}

--- a/src/components/planner/SemesterHeatmapCard.tsx
+++ b/src/components/planner/SemesterHeatmapCard.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useAppState } from '@/context/AppStateContext';
+import { computeSemesterHeatmap, type SemesterHeatmapDay } from '@/lib/planner/semesterHeatmap';
+import { WORKLOAD_SWATCH_CLASS } from '@/lib/workload/uiClasses';
+import { parseDayKey } from '@/lib/calendar/dates';
+import { cn } from '@/lib/utils';
+
+const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short' });
+const DAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+
+/**
+ * A GitHub-contribution-style calendar heatmap spanning every due date the
+ * student has on record, colored with the same low/medium/high/critical
+ * scale as the rest of the workload UI. Distinct from
+ * WorkloadOverviewDashboard above it, which forecasts the next 7 days - this
+ * answers "when in the whole semester am I going to be slammed", visible
+ * before those weeks actually arrive.
+ */
+export function SemesterHeatmapCard() {
+  const { state } = useAppState();
+  const days = useMemo(() => computeSemesterHeatmap(state.scheduleItems), [state.scheduleItems]);
+
+  if (days.length === 0) return null;
+
+  // Pad the front so the first real day lands in its correct weekday row
+  // (0 = Sunday) of a GitHub-style 7-row, weeks-as-columns grid.
+  const leadingBlanks = parseDayKey(days[0].dateKey).getDay();
+  const cells: (SemesterHeatmapDay | null)[] = [...Array(leadingBlanks).fill(null), ...days];
+
+  // Month labels: one per calendar month that appears in range, positioned
+  // above the week-column where that month's first visible day falls.
+  const monthLabels: { label: string; columnIndex: number }[] = [];
+  let lastMonth = '';
+  cells.forEach((cell, i) => {
+    if (!cell) return;
+    const columnIndex = Math.floor(i / 7);
+    const month = MONTH_FORMATTER.format(parseDayKey(cell.dateKey));
+    if (month !== lastMonth) {
+      monthLabels.push({ label: month, columnIndex });
+      lastMonth = month;
+    }
+  });
+  const columnCount = Math.ceil(cells.length / 7);
+
+  return (
+    <Card className="rounded-2xl p-6" data-testid="semester-heatmap-card">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Semester load</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Every due date on record, at a glance - spot the heavy weeks before they arrive.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span>Lighter</span>
+          <span className="h-2.5 w-2.5 rounded-sm bg-muted/50" />
+          <span className={cn('h-2.5 w-2.5 rounded-sm', WORKLOAD_SWATCH_CLASS.low)} />
+          <span className={cn('h-2.5 w-2.5 rounded-sm', WORKLOAD_SWATCH_CLASS.medium)} />
+          <span className={cn('h-2.5 w-2.5 rounded-sm', WORKLOAD_SWATCH_CLASS.high)} />
+          <span className={cn('h-2.5 w-2.5 rounded-sm', WORKLOAD_SWATCH_CLASS.critical)} />
+          <span>Heavier</span>
+        </div>
+      </div>
+
+      <div className="mt-4 overflow-x-auto pb-1">
+        <div
+          className="relative grid gap-1"
+          style={{
+            gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
+            gridAutoFlow: 'column',
+            gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+          }}
+        >
+          {monthLabels.map(({ label, columnIndex }) => (
+            <span
+              key={`${label}-${columnIndex}`}
+              className="absolute -top-4 text-[10px] font-medium text-muted-foreground"
+              style={{ left: `calc(${columnIndex} * (0.75rem + 0.25rem))` }}
+            >
+              {label}
+            </span>
+          ))}
+          {cells.map((cell, i) =>
+            cell ? (
+              <div
+                key={cell.dateKey}
+                title={`${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} · ${cell.hours}h due`}
+                className={cn(
+                  'h-3 w-3 rounded-sm',
+                  cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-muted/50',
+                )}
+              />
+            ) : (
+              <div key={`blank-${i}`} className="h-3 w-3" />
+            ),
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -416,6 +416,7 @@ function PlannedTaskRow({
       completed={item.completed}
       progress={item.progress}
       priority={item.priority}
+      assignedTo={item.assignedTo}
       onToggleComplete={onToggleComplete}
       // PL-2: stacked (not side-by-side) so the trailing block's natural
       // width is the widest SINGLE line, not badge+gap+date combined.

--- a/src/components/planner/WorkloadOverviewDashboard.tsx
+++ b/src/components/planner/WorkloadOverviewDashboard.tsx
@@ -190,7 +190,7 @@ export function WorkloadOverviewDashboard({
             breathe), so a genuinely heavy or overdue day is visibly louder
             than a merely busy one instead of every non-quiet day getting
             an identical fixed "urgent" treatment. */}
-        <Card className={cn('xl:col-span-1 p-5', WORKLOAD_GLOW_CLASS[glowLevel])}>
+        <Card accent="glow" className={cn('xl:col-span-1 p-5', WORKLOAD_GLOW_CLASS[glowLevel])}>
           <CardHeader className="flex-row items-start justify-between gap-3 space-y-0 border-b border-border p-0 pb-5">
             <div>
               <CardTitle>Workload Load</CardTitle>

--- a/src/components/planner/WorkloadOverviewDashboard.tsx
+++ b/src/components/planner/WorkloadOverviewDashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { ProjectChunkerModal } from './ProjectChunkerModal';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
 import { cn } from '@/lib/utils';
 import { toLocalDateStr } from '@/lib/planner/projectChunker';
 import {
@@ -51,6 +52,7 @@ export function WorkloadOverviewDashboard({
 }: WorkloadOverviewDashboardProps = {}) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const [chunkerOpen, setChunkerOpen] = useState(false);
   const [selectedDayDate, setSelectedDayDate] = useState<string | null>(selectedDate ?? null);
 
@@ -109,6 +111,7 @@ export function WorkloadOverviewDashboard({
       await updateScheduleItem(user.uid, task, updatedItem, dispatch);
     } catch (err) {
       console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
     }
   };
 
@@ -126,6 +129,7 @@ export function WorkloadOverviewDashboard({
       await updateScheduleItem(user.uid, task, updatedItem, dispatch);
     } catch (err) {
       console.error('Failed to shift task date:', err);
+      showError("Couldn't reschedule that task. Try again in a moment.");
     }
   };
 

--- a/src/components/planner/__tests__/ProjectChunkerModal.test.tsx
+++ b/src/components/planner/__tests__/ProjectChunkerModal.test.tsx
@@ -37,6 +37,7 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(() => ({})),
   setDoc: vi.fn().mockResolvedValue(undefined),
   deleteDoc: vi.fn().mockResolvedValue(undefined),
@@ -59,12 +60,15 @@ function renderModal(props: { open: boolean; onClose?: () => void }) {
       <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: [] }}>
         <ProjectChunkerModal open={props.open} onClose={onClose} />
       </AppStateProvider>
-    </AuthProvider>
+    </AuthProvider>,
   );
 
-  const getTitleInput = () => rendered.container.querySelector('input[type="text"]') as HTMLInputElement;
-  const getHoursInput = () => rendered.container.querySelector('input[type="number"]') as HTMLInputElement;
-  const getDateInput = () => rendered.container.querySelector('input[type="date"]') as HTMLInputElement;
+  const getTitleInput = () =>
+    rendered.container.querySelector('input[type="text"]') as HTMLInputElement;
+  const getHoursInput = () =>
+    rendered.container.querySelector('input[type="number"]') as HTMLInputElement;
+  const getDateInput = () =>
+    rendered.container.querySelector('input[type="date"]') as HTMLInputElement;
   const getCourseSelect = () => rendered.container.querySelector('select') as HTMLSelectElement;
 
   return {
@@ -155,7 +159,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
       renderModal({ open: true });
       fireEvent.click(screen.getByRole('button', { name: /Essay \/ Term Paper/i }));
 
-      expect(screen.getAllByText(/Thesis Statement & Literature Outline/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Thesis Statement & Literature Outline/i).length).toBeGreaterThan(
+        0,
+      );
     });
 
     it('F2-4: toggling pacing to Weekly Major Milestones updates chunk preview count', () => {
@@ -176,7 +182,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
 
   describe('Tier 1: Feature F3 - 1-Click Firestore Persistence', () => {
     it('F3-1: clicking "Add Chunks to Task List" persists all generated chunks to Firestore', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       renderModal({ open: true });
 
       const addBtn = screen.getByRole('button', { name: /Add Chunks to Task List/i });
@@ -195,7 +203,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('F3-2: correctly maps target type to assignment type (e.g. exam -> exam, quiz -> quiz)', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       renderModal({ open: true });
 
       fireEvent.click(screen.getByRole('button', { name: /Exam Study Plan/i }));
@@ -209,7 +219,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('F3-3: associates persisted chunks with the selected course ID', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getCourseSelect } = renderModal({ open: true });
 
       fireEvent.change(getCourseSelect(), { target: { value: 'c1' } });
@@ -320,7 +332,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
 
   describe('Tier 3: Pairwise Combinations', () => {
     it('P1: Target Type Switch + Custom Hours + Weekly Pace + Course Selection', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getTitleInput, getHoursInput, getCourseSelect } = renderModal({ open: true });
 
       // 1. Select Coding / Repository
@@ -352,13 +366,18 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
 
     it('P2: Handles Firestore persistence error gracefully and restores button state', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockRejectedValue(new Error('Network offline'));
+      vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockRejectedValue(
+        new Error('Network offline'),
+      );
       renderModal({ open: true });
 
       fireEvent.click(screen.getByRole('button', { name: /Add Chunks to Task List/i }));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Chunks to Task List/i })).toHaveProperty('disabled', false);
+        expect(screen.getByRole('button', { name: /Add Chunks to Task List/i })).toHaveProperty(
+          'disabled',
+          false,
+        );
       });
       consoleErrorSpy.mockRestore();
     });
@@ -370,7 +389,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
 
   describe('Tier 4: Real-World User Workflows', () => {
     it('Scenario 1: Midterm Exam 1 Prep Interactive Workflow', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getTitleInput, getHoursInput, getCourseSelect } = renderModal({ open: true });
 
       // Student chooses Exam Study Plan
@@ -392,14 +413,18 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 2: Term Research Paper with Citations & Proofreading Workflow', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getTitleInput, getCourseSelect } = renderModal({ open: true });
 
       fireEvent.click(screen.getByRole('button', { name: /Essay \/ Term Paper/i }));
       fireEvent.change(getTitleInput(), { target: { value: 'ENG 202 Research Paper' } });
       fireEvent.change(getCourseSelect(), { target: { value: 'c3' } });
 
-      expect(screen.getAllByText(/Thesis Statement & Literature Outline/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Thesis Statement & Literature Outline/i).length).toBeGreaterThan(
+        0,
+      );
 
       fireEvent.click(screen.getByRole('button', { name: /Add Chunks to Task List/i }));
       await waitFor(() => {
@@ -409,7 +434,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 3: Presentation & Slide Deck Preparation Workflow', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getTitleInput } = renderModal({ open: true });
 
       fireEvent.click(screen.getByRole('button', { name: /Presentation \/ Slides/i }));
@@ -423,7 +450,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 4: Flashcard Mastery Cram Session Workflow', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getTitleInput } = renderModal({ open: true });
 
       fireEvent.click(screen.getByRole('button', { name: /Flashcard Mastery/i }));
@@ -436,7 +465,9 @@ describe('ProjectChunkerModal Component Suite (Tier 1-4)', () => {
     });
 
     it('Scenario 5: General Independent Study with No Course Selected', async () => {
-      const createSpy = vi.spyOn(scheduleItemsLib, 'createScheduleItem').mockResolvedValue(undefined);
+      const createSpy = vi
+        .spyOn(scheduleItemsLib, 'createScheduleItem')
+        .mockResolvedValue(undefined);
       const { getCourseSelect } = renderModal({ open: true });
 
       // Leave Course as General / Independent (value: '')

--- a/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
+++ b/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
@@ -39,6 +39,7 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(() => ({})),
   setDoc: vi.fn().mockResolvedValue(undefined),
   deleteDoc: vi.fn().mockResolvedValue(undefined),

--- a/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
+++ b/src/components/planner/__tests__/WorkloadOverviewDashboard.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { WorkloadOverviewDashboard } from '../WorkloadOverviewDashboard';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import { toLocalDateStr } from '@/lib/planner/projectChunker';
 import * as scheduleItemsLib from '@/lib/firestore/scheduleItems';
 import type { ScheduleItem, AssignmentType, Course } from '@/types/schedule';
@@ -96,9 +97,11 @@ function renderDashboard(
 ) {
   return render(
     <AuthProvider>
-      <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: items }}>
-        <WorkloadOverviewDashboard {...props} />
-      </AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: items }}>
+          <WorkloadOverviewDashboard {...props} />
+        </AppStateProvider>
+      </ToastProvider>
     </AuthProvider>,
   );
 }

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -275,7 +275,7 @@ export function ProfileView() {
             {!editing && (
               <button
                 onClick={() => setEditing(true)}
-                className="text-xs font-semibold text-primary hover:underline"
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
               >
                 Edit
               </button>
@@ -312,7 +312,7 @@ export function ProfileView() {
               <button
                 type="submit"
                 disabled={saving}
-                className="text-xs font-semibold text-primary hover:underline disabled:opacity-50"
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
               >
                 {saving ? 'Saving...' : 'Save'}
               </button>
@@ -323,7 +323,7 @@ export function ProfileView() {
                   setName(user.displayName ?? '');
                   clearError();
                 }}
-                className="text-xs font-medium text-muted-foreground hover:underline"
+                className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel
               </button>
@@ -551,7 +551,7 @@ export function ProfileView() {
                       setPasswordFormError(null);
                       clearError();
                     }}
-                    className="text-xs font-semibold text-primary hover:underline"
+                    className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
                   >
                     Change password
                   </button>
@@ -642,7 +642,7 @@ export function ProfileView() {
                         setPasswordFormError(null);
                         clearError();
                       }}
-                      className="text-xs font-medium text-muted-foreground hover:underline"
+                      className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
                     >
                       Cancel
                     </button>
@@ -753,7 +753,7 @@ export function ProfileView() {
                     setDeletePassword('');
                     clearError();
                   }}
-                  className="text-xs font-medium text-muted-foreground hover:underline"
+                  className="rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
                 >
                   Cancel
                 </button>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -2,12 +2,16 @@
 
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import { collection, getDocs } from 'firebase/firestore';
 import { Card } from '@/components/ui/Card';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
+import { db } from '@/lib/firebase/client';
 import { updateUserPreferences, type UserPreferences } from '@/lib/firestore/preferences';
+import type { SyllabusUpload } from '@/types/syllabus';
 import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import { GpaGoalRadial } from './GpaGoalRadial';
@@ -112,6 +116,7 @@ export function ProfileView() {
   const { user, error, updateDisplayName, changePassword, deleteAccount, signOut, clearError } =
     useAuth();
   const { state, dispatch } = useAppState();
+  const { showError } = useToast();
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(user?.displayName ?? '');
@@ -129,6 +134,9 @@ export function ProfileView() {
   const [passwordSaving, setPasswordSaving] = useState(false);
   const [passwordSuccess, setPasswordSuccess] = useState(false);
   const [passwordFormError, setPasswordFormError] = useState<string | null>(null);
+
+  // --- Account & Data: data export ---
+  const [downloadingData, setDownloadingData] = useState(false);
 
   // --- Account & Data: delete account ---
   const [deleting, setDeleting] = useState(false);
@@ -212,26 +220,47 @@ export function ProfileView() {
     }
   };
 
-  const handleDownloadData = () => {
-    const payload = {
-      exportedAt: new Date().toISOString(),
-      account: {
-        email: user.email,
-        displayName: user.displayName,
-        memberSince: user.metadata.creationTime ?? null,
-      },
-      courses: state.courses,
-      scheduleItems: state.scheduleItems,
-    };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `syllabus-sense-data-${user.uid}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+  const handleDownloadData = async () => {
+    const firestore = db;
+    if (!firestore) return;
+    setDownloadingData(true);
+    try {
+      const syllabiByCourse = await Promise.all(
+        state.courses.map((course) =>
+          getDocs(collection(firestore, 'users', user.uid, 'courses', course.id, 'syllabi')),
+        ),
+      );
+      const syllabi: SyllabusUpload[] = syllabiByCourse.flatMap((snapshot) =>
+        snapshot.docs.map((doc) => doc.data() as SyllabusUpload),
+      );
+
+      const payload = {
+        exportedAt: new Date().toISOString(),
+        account: {
+          email: user.email,
+          displayName: user.displayName,
+          memberSince: user.metadata.creationTime ?? null,
+        },
+        courses: state.courses,
+        scheduleItems: state.scheduleItems,
+        contacts: state.contacts,
+        preferences: state.preferences,
+        syllabi,
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `syllabus-sense-data-${user.uid}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch {
+      showError("Couldn't put together your data export. Try again in a moment.");
+    } finally {
+      setDownloadingData(false);
+    }
   };
 
   const deleteReady =
@@ -663,14 +692,16 @@ export function ProfileView() {
           <h3 className="text-sm font-semibold text-foreground">Your data</h3>
           <div className="mt-2 flex items-center justify-between gap-4">
             <p className="text-sm text-muted-foreground">
-              Download every course and task in your account as a JSON file.
+              Download every course, task, contact, syllabus, and preference in your account as a
+              JSON file.
             </p>
             <button
               type="button"
               onClick={handleDownloadData}
-              className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:bg-accent"
+              disabled={downloadingData}
+              className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Download my data
+              {downloadingData ? 'Preparing...' : 'Download my data'}
             </button>
           </div>
         </div>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -15,6 +15,7 @@ import type { SyllabusUpload } from '@/types/syllabus';
 import { COURSE_COLOR_PRESETS } from '@/lib/courseColors';
 import { cn } from '@/lib/utils';
 import { GpaGoalRadial } from './GpaGoalRadial';
+import { StudyStreakCard } from './StudyStreakCard';
 import { type LetterGrade } from '@/lib/gpa/gpaMath';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -554,6 +555,8 @@ export function ProfileView() {
           that&apos;s why every switch shows off. Your selection is still saved for the day they do.
         </p>
       </Card>
+
+      <StudyStreakCard />
 
       {/* ---------------------------------------------------------------
           Account & Data - the real security/data controls this page was

--- a/src/components/profile/StudyStreakCard.tsx
+++ b/src/components/profile/StudyStreakCard.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { loadSessions } from '@/lib/focus/pomodoroSessions';
+import {
+  getSessionDateSet,
+  computeCurrentStreak,
+  computeHeatmapDays,
+} from '@/lib/focus/studyStreak';
+
+const HEATMAP_DAYS = 28;
+
+/**
+ * A quiet, always-visible study streak built from completed Focus Timer
+ * sessions. Deliberately a local-device metric, not synced through
+ * Firestore - Pomodoro sessions themselves are localStorage-only (see
+ * lib/focus/pomodoroSessions.ts), so a streak that claimed to be
+ * account-wide would be lying about what it actually measures. Promoting
+ * session history to Firestore is a bigger, separate change.
+ */
+export function StudyStreakCard() {
+  // Sessions live in localStorage, written by a different mounted component
+  // (PomodoroTimer) - read once on mount rather than trying to keep this in
+  // sync live, since the streak only meaningfully changes once a session
+  // actually completes and the page is revisited.
+  const [dateSet, setDateSet] = useState<Set<string> | null>(null);
+
+  useEffect(() => {
+    setDateSet(getSessionDateSet(loadSessions()));
+  }, []);
+
+  if (!dateSet) return null;
+
+  const streak = computeCurrentStreak(dateSet);
+  const heatmap = computeHeatmapDays(dateSet, new Date(), HEATMAP_DAYS);
+
+  if (streak === 0 && heatmap.every((day) => !day.active)) {
+    return null;
+  }
+
+  return (
+    <Card className="rounded-2xl p-6" data-testid="study-streak-card">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Study streak</h3>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Days in a row with at least one completed focus session, on this device.
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="text-2xl font-bold text-primary tabular-nums">{streak}</div>
+          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            day{streak === 1 ? '' : 's'}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-1" aria-hidden="true">
+        {heatmap.map((day) => (
+          <div
+            key={day.dateKey}
+            title={day.dateKey}
+            className={`h-3 w-3 rounded-sm ${
+              day.active ? 'bg-primary' : day.isToday ? 'border border-primary/40' : 'bg-muted'
+            }`}
+          />
+        ))}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">Last {HEATMAP_DAYS} days</p>
+    </Card>
+  );
+}

--- a/src/components/quizzes/QuizCard.tsx
+++ b/src/components/quizzes/QuizCard.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { useSyllabi } from '@/lib/firestore/useSyllabi';
+import { createQuiz, deleteQuiz } from '@/lib/firestore/quizzes';
+import { generatedQuizQuestionsSchema } from '@/types/quiz';
+import type { Quiz } from '@/types/quiz';
+import type { Course } from '@/types/schedule';
+
+export function QuizCard({ course, onTake }: { course: Course; onTake: (quiz: Quiz) => void }) {
+  const { user } = useAuth();
+  const { state, dispatch } = useAppState();
+  const syllabi = useSyllabi(user?.uid, course.id);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const latestSyllabus = syllabi
+    .slice()
+    .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
+
+  const quiz = state.quizzes.find((q) => q.courseId === course.id);
+  const attempts = state.quizAttempts
+    .filter((a) => a.courseId === course.id)
+    .sort((a, b) => new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime());
+  const bestAttempt = attempts.reduce<(typeof attempts)[number] | null>((best, a) => {
+    if (!best) return a;
+    return a.score / a.total > best.score / best.total ? a : best;
+  }, null);
+
+  const handleGenerate = async () => {
+    if (!user || !latestSyllabus) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch('/api/syllabus/quiz', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          storagePath: latestSyllabus.storagePath,
+          fileName: latestSyllabus.fileName,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'Quiz generation failed.');
+
+      const generated = generatedQuizQuestionsSchema.parse(body.questions);
+      const newQuiz: Quiz = {
+        id: crypto.randomUUID(),
+        courseId: course.id,
+        questions: generated,
+        createdAt: new Date().toISOString(),
+        sourceFileName: latestSyllabus.fileName,
+      };
+      if (quiz) {
+        await deleteQuiz(user.uid, quiz, dispatch);
+      }
+      await createQuiz(user.uid, newQuiz, dispatch);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleDeleteQuiz = async () => {
+    if (!user || !quiz) return;
+    setDeleting(true);
+    try {
+      await deleteQuiz(user.uid, quiz, dispatch);
+    } finally {
+      setDeleting(false);
+      setConfirmingDelete(false);
+    }
+  };
+
+  if (!latestSyllabus && !quiz) {
+    return (
+      <Card accent="none" className="rounded-2xl border-dashed p-5 opacity-90">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-muted-foreground">{course.code}</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Upload a syllabus on this course&apos;s page to generate a practice quiz.
+            </p>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="rounded-2xl p-5 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-foreground">{course.code}</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {quiz ? `${quiz.questions.length} questions` : 'No quiz yet'}
+          </p>
+        </div>
+        {bestAttempt && (
+          <span className="shrink-0 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+            Best: {bestAttempt.score}/{bestAttempt.total}
+          </span>
+        )}
+      </div>
+
+      {attempts.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Last attempt: {attempts[0].score}/{attempts[0].total} &middot; {attempts.length}{' '}
+          {attempts.length === 1 ? 'attempt' : 'attempts'} total
+        </p>
+      )}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {quiz && (
+          <button
+            type="button"
+            onClick={() => onTake(quiz)}
+            className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-primary px-3 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Take Quiz
+          </button>
+        )}
+        {latestSyllabus && (
+          <CardActionButton
+            variant={quiz ? 'ghost' : 'solid'}
+            onClick={handleGenerate}
+            disabled={generating}
+          >
+            {generating ? 'Generating…' : quiz ? 'Regenerate' : 'Generate Quiz'}
+          </CardActionButton>
+        )}
+        {quiz &&
+          (confirmingDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={handleDeleteQuiz}
+                disabled={deleting}
+                className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-destructive/10 px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {deleting ? 'Deleting…' : 'Confirm'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                disabled={deleting}
+                className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs text-muted-foreground transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+            >
+              Delete quiz
+            </button>
+          ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/quizzes/QuizSession.tsx
+++ b/src/components/quizzes/QuizSession.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { useModalA11y } from '@/hooks/useModalA11y';
+import type { Quiz } from '@/types/quiz';
+
+export interface QuizSessionProps {
+  quiz: Quiz | null;
+  onClose: () => void;
+  onComplete: (score: number, total: number) => Promise<void>;
+}
+
+export function QuizSession({ quiz, onClose, onComplete }: QuizSessionProps) {
+  const [index, setIndex] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [score, setScore] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+
+  const open = !!quiz;
+  const dialogRef = useModalA11y<HTMLDivElement>(open, handleClose);
+
+  function handleClose() {
+    setIndex(0);
+    setSelected(null);
+    setScore(0);
+    onClose();
+  }
+
+  if (!quiz) return null;
+
+  const done = index >= quiz.questions.length;
+  const question = done ? null : quiz.questions[index];
+
+  const handleSelect = (choiceIndex: number) => {
+    if (selected !== null) return;
+    setSelected(choiceIndex);
+    if (choiceIndex === question!.correctIndex) {
+      setScore((s) => s + 1);
+    }
+  };
+
+  const handleNext = async () => {
+    const nextIndex = index + 1;
+    setIndex(nextIndex);
+    setSelected(null);
+    if (nextIndex >= quiz.questions.length) {
+      setSubmitting(true);
+      try {
+        await onComplete(score, quiz.questions.length);
+      } finally {
+        setSubmitting(false);
+      }
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="quiz-session-title"
+      onClick={handleClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-lg outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card accent="none" className="p-6">
+          <div className="flex items-center justify-between">
+            <h2 id="quiz-session-title" className="text-sm font-bold text-foreground">
+              {done ? 'Quiz complete' : `Question ${index + 1} of ${quiz.questions.length}`}
+            </h2>
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="Close quiz"
+              className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {done ? (
+            <div className="mt-6 flex flex-col items-center gap-3 py-6 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-brand text-white">
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <p className="text-lg font-bold text-foreground">
+                {score} / {quiz.questions.length}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {submitting ? 'Saving your score…' : 'Score saved to this course.'}
+              </p>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="mt-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Done
+              </button>
+            </div>
+          ) : (
+            <div className="mt-5 space-y-4">
+              <p className="text-base font-semibold leading-relaxed text-foreground">
+                {question!.question}
+              </p>
+              <div className="space-y-2">
+                {question!.choices.map((choice, choiceIndex) => {
+                  const isSelected = selected === choiceIndex;
+                  const isCorrect = choiceIndex === question!.correctIndex;
+                  const revealed = selected !== null;
+                  const stateClass = !revealed
+                    ? 'border-border hover:border-primary/40'
+                    : isCorrect
+                      ? 'border-load-low bg-load-low/10 text-load-low'
+                      : isSelected
+                        ? 'border-destructive bg-destructive/10 text-destructive'
+                        : 'border-border opacity-60';
+                  return (
+                    <button
+                      key={choiceIndex}
+                      type="button"
+                      onClick={() => handleSelect(choiceIndex)}
+                      disabled={revealed}
+                      className={`block w-full rounded-xl border px-4 py-2.5 text-left text-sm font-medium transition-colors disabled:cursor-not-allowed ${stateClass}`}
+                    >
+                      {choice}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {selected !== null && (
+                <div className="rounded-xl bg-muted/40 p-3 text-xs text-muted-foreground">
+                  {question!.explanation}
+                </div>
+              )}
+
+              {selected !== null && (
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  {index + 1 >= quiz.questions.length ? 'Finish' : 'Next question →'}
+                </button>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/quizzes/QuizzesView.tsx
+++ b/src/components/quizzes/QuizzesView.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { createQuizAttempt } from '@/lib/firestore/quizzes';
+import { QuizCard } from '@/components/quizzes/QuizCard';
+import { QuizSession } from '@/components/quizzes/QuizSession';
+import type { Quiz } from '@/types/quiz';
+
+export function QuizzesView() {
+  const { user } = useAuth();
+  const { state, dispatch } = useAppState();
+  const [activeQuiz, setActiveQuiz] = useState<Quiz | null>(null);
+
+  const handleComplete = async (score: number, total: number) => {
+    if (!user || !activeQuiz) return;
+    await createQuizAttempt(
+      user.uid,
+      {
+        id: crypto.randomUUID(),
+        quizId: activeQuiz.id,
+        courseId: activeQuiz.courseId,
+        score,
+        total,
+        completedAt: new Date().toISOString(),
+      },
+      dispatch,
+    );
+  };
+
+  return (
+    <>
+      <div className="max-w-5xl space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground tracking-tight">Practice Quizzes</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            AI-generated multiple-choice quizzes from your syllabi, so you can check how well
+            something actually stuck before it counts.
+          </p>
+        </div>
+
+        {state.courses.length === 0 ? (
+          <Card className="rounded-2xl p-6">
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              }
+              title="No courses yet"
+              description="Add a course and upload its syllabus to generate a practice quiz."
+            />
+          </Card>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {state.courses.map((course) => (
+              <QuizCard key={course.id} course={course} onTake={setActiveQuiz} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <QuizSession
+        quiz={activeQuiz}
+        onClose={() => setActiveQuiz(null)}
+        onComplete={handleComplete}
+      />
+    </>
+  );
+}

--- a/src/components/schedule/ExtracurricularView.tsx
+++ b/src/components/schedule/ExtracurricularView.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { EmptyState } from '@/components/ui/EmptyState';
 
 export type ActivityCategory = 'club' | 'research' | 'internship' | 'athletics' | 'volunteering';
 
@@ -366,22 +368,14 @@ export function ExtracurricularView({
             Balance leadership, lab research, and career milestones alongside your coursework.
           </p>
         </div>
-        <button
+        <CardActionButton
+          variant="solid"
+          withPlus
           onClick={openCreateModal}
           data-testid="add-activity-btn"
-          className="inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-primary hover:opacity-90 text-primary-foreground text-sm font-medium transition-all shadow-lg shadow-primary/20 active:scale-95 cursor-pointer min-h-[44px]"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
           Add Activity
-        </button>
+        </CardActionButton>
       </div>
 
       {/* Commitment Capacity Meter Card */}
@@ -571,32 +565,32 @@ export function ExtracurricularView({
           </h2>
 
           {filteredActivities.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-border p-8 text-center bg-muted/30">
-              <svg
-                className="w-10 h-10 text-muted-foreground mx-auto mb-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
-              <p className="text-muted-foreground font-medium">No activities match your filters</p>
-              <button
-                onClick={() => {
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              }
+              title="No activities match your filters"
+              action={{
+                label: 'Clear all filters',
+                onClick: () => {
                   setSelectedCategory('all');
                   setStatusFilter('all');
                   setSearchQuery('');
-                }}
-                className="mt-3 text-xs text-primary hover:underline cursor-pointer"
-              >
-                Clear all filters
-              </button>
-            </div>
+                },
+              }}
+            />
           ) : (
             filteredActivities.map((act) => {
               const cfg = CATEGORY_CONFIG[act.category];
@@ -905,7 +899,10 @@ export function ExtracurricularView({
           aria-labelledby="activity-modal-title"
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
         >
-          <Card className="relative w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+          <Card
+            accent="none"
+            className="relative w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto"
+          >
             <div className="flex items-center justify-between border-b border-border pb-3">
               <h3 id="activity-modal-title" className="text-lg font-bold text-foreground">
                 {editingActivity ? 'Edit Activity' : 'Add Extracurricular Activity'}

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -455,16 +455,16 @@ export function PlannerView() {
                 Edit
               </button>
               {isConfirmingThisDelete ? (
-                <div className="flex items-center gap-2 text-xs">
+                <div className="flex items-center gap-1.5 text-xs">
                   <button
                     onClick={() => handleDeleteTask(item)}
-                    className="inline-flex min-h-[44px] items-center justify-center px-2 font-semibold text-foreground hover:underline"
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground/10 px-2.5 font-semibold text-foreground transition-colors hover:bg-foreground/15"
                   >
                     Confirm
                   </button>
                   <button
                     onClick={() => setConfirmingDeleteId(null)}
-                    className="inline-flex min-h-[44px] items-center justify-center px-2 text-muted-foreground hover:underline"
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-full px-2.5 text-muted-foreground transition-colors hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -475,7 +475,7 @@ export function PlannerView() {
                 // doesn't compete with the one badge that should stand out.
                 <button
                   onClick={() => setConfirmingDeleteId(item.id)}
-                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full px-2.5 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 >
                   Delete
                 </button>

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -388,6 +388,8 @@ export function PlannerView() {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -391,6 +391,7 @@ export function PlannerView() {
         ...(values.progress ? { progress: Number(values.progress) } : {}),
         ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
         ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
+        ...(values.assignedTo ? { assignedTo: values.assignedTo } : {}),
       },
       dispatch,
     );
@@ -427,6 +428,7 @@ export function PlannerView() {
         progress={item.progress}
         priority={item.priority}
         gradeWeight={item.gradeWeight}
+        assignedTo={item.assignedTo}
         onToggleComplete={user ? () => handleToggleComplete(item) : undefined}
         trailing={
           <>

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -153,6 +153,7 @@ function groupByMonth(
 }
 
 import { WorkloadOverviewDashboard } from '@/components/planner/WorkloadOverviewDashboard';
+import { SemesterHeatmapCard } from '@/components/planner/SemesterHeatmapCard';
 
 /** Default number of task rows a group shows before collapsing the rest
  * behind a "Show N more" toggle. A real semester's task list can run into
@@ -493,6 +494,8 @@ export function PlannerView() {
     <>
       <div className="max-w-5xl space-y-6 sm:space-y-8">
         <WorkloadOverviewDashboard />
+
+        <SemesterHeatmapCard />
 
         {/* Header, stats, and filters as one panel (matching the Card
          * language WorkloadOverviewDashboard already establishes above)

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -842,7 +842,9 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         ...(course.term ? { term: course.term } : {}),
         ...(course.modality ? { modality: course.modality } : {}),
         ...(course.meetingTimes.length ? { meetingTimes: course.meetingTimes } : {}),
-        ...(course.materials.length ? { materials: course.materials.filter(Boolean) } : {}),
+        ...(course.materials.length
+          ? { materials: course.materials.filter(Boolean).map((name) => ({ name })) }
+          : {}),
         ...(course.skipDates.length ? { skipDates: course.skipDates } : {}),
         ...(course.notes ? { notes: course.notes } : {}),
         // Only written when the student left "Save to course" checked -

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardFooter } from '@/components/ui/Card';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { EmptyState } from '@/components/ui/EmptyState';
 import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
 import { createCourseWithScheduleItems } from '@/lib/firestore/courses';
 import { createContacts, updateContact } from '@/lib/firestore/contacts';
@@ -49,6 +51,45 @@ const STEPS: { key: Step; label: string }[] = [
   { key: 'review', label: 'Review' },
   { key: 'saving', label: 'Save' },
 ];
+
+interface CourseDraft {
+  code: string;
+  title: string;
+  instructor: string;
+  term: string;
+  color: string;
+  icon: string;
+  modality: CourseModality | undefined;
+  meetingTimes: MeetingTime[];
+  materials: string[];
+  skipDates: string[];
+  notes: string;
+}
+
+/** The review-screen state worth protecting against a closed tab or an
+ * accidentally-dismissed modal - everything Claude extracted plus whatever
+ * the student has already hand-corrected. Deliberately excludes the
+ * uploaded `File` itself (not serializable, and not needed to resume - the
+ * expensive part to lose is the human review, not the raw upload) and
+ * `savedCourseId` (a course that's already in Firestore has nothing left to
+ * resume). Persisted to localStorage rather than Firestore since this is a
+ * same-device recovery net, not cross-device sync. */
+interface PersistedAutofillDraft {
+  savedAt: string;
+  fileName: string;
+  course: CourseDraft;
+  items: DraftItem[];
+  unresolved: string[];
+  learningObjectivesText: string;
+  learningObjectivesApproved: boolean;
+  contactDrafts: DraftContact[];
+}
+
+const AUTOFILL_DRAFT_STORAGE_PREFIX = 'syllabus-autofill-draft';
+
+function autofillDraftStorageKey(userId: string): string {
+  return `${AUTOFILL_DRAFT_STORAGE_PREFIX}:${userId}`;
+}
 
 interface DraftItem extends ExtractedScheduleItem {
   /** Local id for React keys/editing - not persisted as-is. */
@@ -342,19 +383,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * gets a confirmation instead of losing that work silently (SY-5). */
   const initialDraftRef = useRef<string | null>(null);
 
-  const [course, setCourse] = useState<{
-    code: string;
-    title: string;
-    instructor: string;
-    term: string;
-    color: string;
-    icon: string;
-    modality: CourseModality | undefined;
-    meetingTimes: MeetingTime[];
-    materials: string[];
-    skipDates: string[];
-    notes: string;
-  } | null>(null);
+  const [course, setCourse] = useState<CourseDraft | null>(null);
   const [items, setItems] = useState<DraftItem[]>([]);
   const [unresolved, setUnresolved] = useState<string[]>([]);
   /** Claude's suggested syllabus file name, freely editable - not just a
@@ -366,11 +395,6 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * array so a student can restructure freely, split back into lines at
    * render/save time. */
   const [learningObjectivesText, setLearningObjectivesText] = useState('');
-  /** Whether the objectives section renders at all - set once at extraction
-   * time from whether Claude found any, independent of later edits (mirrors
-   * the "Claude also caught" notes/skipDates section, which stays visible
-   * once populated even as its content is edited). */
-  const [hasLearningObjectives, setHasLearningObjectives] = useState(false);
   const [learningObjectivesApproved, setLearningObjectivesApproved] = useState(true);
   /** Index into `learningObjectivesLines` currently open for editing, or
    * null when every objective is just static text with a pencil button. */
@@ -382,6 +406,96 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
    * failure without letting a second Confirm click create a duplicate
    * course. Cleared on full success/close and on reset. */
   const [savedCourseId, setSavedCourseId] = useState<string | null>(null);
+  /** A draft found in localStorage from a previous session that closed
+   * (tab closed, modal dismissed) before the student confirmed - offered as
+   * a resume/discard choice on the upload screen rather than silently
+   * dropped or silently auto-loaded over a fresh upload. */
+  const [pendingDraft, setPendingDraft] = useState<PersistedAutofillDraft | null>(null);
+
+  const clearPersistedDraft = () => {
+    if (!user) return;
+    try {
+      localStorage.removeItem(autofillDraftStorageKey(user.uid));
+    } catch {
+      // Best-effort - a failure here just means a stale draft lingers,
+      // which the next open will still offer to discard.
+    }
+  };
+
+  // Offer to resume a draft left over from a closed tab/dismissed modal,
+  // checked once per modal open rather than continuously.
+  useEffect(() => {
+    if (!open || !user) return;
+    try {
+      const raw = localStorage.getItem(autofillDraftStorageKey(user.uid));
+      if (raw) setPendingDraft(JSON.parse(raw) as PersistedAutofillDraft);
+    } catch {
+      // Corrupt or inaccessible storage - treat as "no draft to resume".
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, user]);
+
+  // Autosaves the review-screen draft on every edit so a closed tab or a
+  // dismissed modal doesn't lose the student's work - cleared once the
+  // course is actually saved (see handleConfirm) or explicitly discarded.
+  useEffect(() => {
+    if (!user || step !== 'review' || !course) return;
+    try {
+      const draft: PersistedAutofillDraft = {
+        savedAt: new Date().toISOString(),
+        fileName,
+        course,
+        items,
+        unresolved,
+        learningObjectivesText,
+        learningObjectivesApproved,
+        contactDrafts,
+      };
+      localStorage.setItem(autofillDraftStorageKey(user.uid), JSON.stringify(draft));
+    } catch {
+      // Quota exceeded or storage disabled (e.g. private browsing) - the
+      // review screen itself still works, it just loses the safety net.
+    }
+  }, [
+    user,
+    step,
+    course,
+    items,
+    unresolved,
+    fileName,
+    learningObjectivesText,
+    learningObjectivesApproved,
+    contactDrafts,
+  ]);
+
+  const resumeDraft = () => {
+    if (!pendingDraft) return;
+    setCourse(pendingDraft.course);
+    setItems(pendingDraft.items);
+    setUnresolved(pendingDraft.unresolved);
+    setFileName(pendingDraft.fileName);
+    setLearningObjectivesText(pendingDraft.learningObjectivesText);
+    setLearningObjectivesApproved(pendingDraft.learningObjectivesApproved);
+    setContactDrafts(pendingDraft.contactDrafts);
+    // Baseline the SY-5 dirty-check against the resumed draft itself, not a
+    // fresh extraction - re-running Claude from here should compare against
+    // what's actually on screen.
+    initialDraftRef.current = JSON.stringify({
+      course: pendingDraft.course,
+      items: pendingDraft.items.map(omitDraftKey),
+      unresolved: pendingDraft.unresolved,
+      learningObjectivesText: pendingDraft.learningObjectivesText,
+      learningObjectivesApproved: pendingDraft.learningObjectivesApproved,
+      contactDrafts: pendingDraft.contactDrafts.map(omitContactDraftKey),
+    });
+    setStep('review');
+    setPendingDraft(null);
+  };
+
+  const discardDraft = () => {
+    clearPersistedDraft();
+    setPendingDraft(null);
+  };
 
   const reset = () => {
     setStep('upload');
@@ -392,7 +506,6 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setUnresolved([]);
     setFileName('');
     setLearningObjectivesText('');
-    setHasLearningObjectives(false);
     setLearningObjectivesApproved(true);
     setContactDrafts([]);
     setSavedCourseId(null);
@@ -401,6 +514,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     initialDraftRef.current = null;
   };
 
+  // Deliberately does NOT clear the persisted draft - closing the modal
+  // (tab close, Cancel, the X button) is exactly the case this feature
+  // protects against, so the in-progress review survives to be resumed
+  // next time the modal opens. Only a successful save or an explicit
+  // "Discard" clears it.
   const handleClose = () => {
     reset();
     onClose();
@@ -468,14 +586,12 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       }));
       const nextUnresolved = result.unresolved ?? [];
       const nextLearningObjectivesText = result.course.learningObjectives.join('\n');
-      const nextHasLearningObjectives = result.course.learningObjectives.length > 0;
       const nextContactDrafts = buildContactDrafts(result.course.contacts, state.contacts);
 
       setCourse(nextCourse);
       setItems(nextItems);
       setUnresolved(nextUnresolved);
       setLearningObjectivesText(nextLearningObjectivesText);
-      setHasLearningObjectives(nextHasLearningObjectives);
       setLearningObjectivesApproved(true);
       setContactDrafts(nextContactDrafts);
       setFileName(
@@ -641,18 +757,36 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
     setEditingObjectiveIndex(index);
   };
 
+  // `editingObjectiveIndex === learningObjectivesLines.length` (one past the
+  // last real line) is the "adding a new objective" state - reuses the same
+  // edit-row UI instead of a separate add form.
+  const startAddingObjective = () => {
+    setObjectiveDraft('');
+    setEditingObjectiveIndex(learningObjectivesLines.length);
+  };
+
   // A blank commit removes that objective rather than saving an empty
-  // bullet - editing down to nothing is how a student deletes one.
+  // bullet - editing an existing one down to nothing is still a valid way
+  // to delete it, alongside the explicit trash button below.
   const commitObjectiveEdit = (index: number) => {
     const nextLines = [...learningObjectivesLines];
     const trimmed = objectiveDraft.trim();
-    if (trimmed) {
+    if (index >= nextLines.length) {
+      if (trimmed) nextLines.push(trimmed);
+    } else if (trimmed) {
       nextLines[index] = trimmed;
     } else {
       nextLines.splice(index, 1);
     }
     setLearningObjectivesText(nextLines.join('\n'));
     setEditingObjectiveIndex(null);
+  };
+
+  const removeObjective = (index: number) => {
+    const nextLines = [...learningObjectivesLines];
+    nextLines.splice(index, 1);
+    setLearningObjectivesText(nextLines.join('\n'));
+    if (editingObjectiveIndex === index) setEditingObjectiveIndex(null);
   };
 
   const approvedCount = items.filter((i) => i.approved).length;
@@ -739,6 +873,11 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
       // together or not at all, instead of the course succeeding while a
       // mid-loop failure leaves some assignments missing.
       await createCourseWithScheduleItems(user.uid, newCourse, scheduleItems, dispatch);
+      // The course now exists in Firestore - resuming the localStorage draft
+      // from here on would recreate it as a duplicate, so the recovery net
+      // is no longer needed regardless of what happens next (syllabus file,
+      // contacts).
+      clearPersistedDraft();
 
       if (file) {
         try {
@@ -800,7 +939,7 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
         className="max-h-full w-full max-w-3xl overflow-y-auto outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
+        <Card accent="none" className="overflow-hidden rounded-3xl border-none p-0 shadow-modal">
           <div className="bg-gradient-brand px-6 py-6 text-white sm:px-8">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
               Syllabus Autofill
@@ -838,6 +977,51 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   />
                 </svg>
                 <span>{error}</span>
+              </div>
+            )}
+
+            {step === 'upload' && !file && pendingDraft && (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary/30 bg-primary/5 px-4 py-3">
+                <div className="flex items-start gap-2.5">
+                  <svg
+                    className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      Resume your unfinished review
+                      {pendingDraft.course.code ? ` for ${pendingDraft.course.code}` : ''}?
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      You closed this before confirming - your edits are still here.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={discardDraft}
+                    className="rounded-full px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resumeDraft}
+                    className="rounded-full bg-primary px-3.5 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                  >
+                    Resume
+                  </button>
+                </div>
               </div>
             )}
 
@@ -1318,28 +1502,28 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                   </section>
                 )}
 
-                {hasLearningObjectives && (
-                  <section
-                    className="review-reveal space-y-2.5 rounded-xl border border-primary/20 bg-primary/5 p-3 sm:p-4"
-                    style={{ animationDelay: '165ms' }}
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <h3 className="flex items-center gap-1.5 text-xs font-semibold text-primary">
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s4.332.477 5.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                          />
-                        </svg>
-                        Learning Objectives
-                      </h3>
+                <section
+                  className="review-reveal space-y-2.5 rounded-xl border border-primary/20 bg-primary/5 p-3 sm:p-4"
+                  style={{ animationDelay: '165ms' }}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="flex items-center gap-1.5 text-xs font-semibold text-primary">
+                      <svg
+                        className="h-3.5 w-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s4.332.477 5.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                        />
+                      </svg>
+                      Learning Objectives
+                    </h3>
+                    <div className="flex items-center gap-3">
                       <label className="flex items-center gap-1.5 text-xs font-medium text-foreground">
                         <input
                           type="checkbox"
@@ -1349,79 +1533,118 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                         />
                         Save to course
                       </label>
+                      {editingObjectiveIndex !== learningObjectivesLines.length && (
+                        <CardActionButton variant="solid" withPlus onClick={startAddingObjective}>
+                          Add objective
+                        </CardActionButton>
+                      )}
                     </div>
-                    {learningObjectivesLines.length > 0 && (
-                      <ul className="space-y-1 text-xs text-foreground">
-                        {learningObjectivesLines.map((line, i) =>
-                          editingObjectiveIndex === i ? (
-                            <li key={i} className="flex items-start gap-1.5">
-                              <span className="mt-1 text-primary">&bull;</span>
-                              <textarea
-                                autoFocus
-                                value={objectiveDraft}
-                                onChange={(e) => setObjectiveDraft(e.target.value)}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter' && !e.shiftKey) {
-                                    e.preventDefault();
-                                    commitObjectiveEdit(i);
-                                  } else if (e.key === 'Escape') {
-                                    setEditingObjectiveIndex(null);
-                                  }
-                                }}
-                                rows={2}
-                                className="max-h-32 flex-1 resize-y overflow-y-auto rounded-lg border border-primary bg-card px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                              />
-                              <div className="flex shrink-0 flex-col gap-1">
-                                <button
-                                  type="button"
-                                  onClick={() => commitObjectiveEdit(i)}
-                                  className="rounded p-0.5 text-primary hover:bg-primary/10"
-                                  aria-label="Save this objective"
+                  </div>
+                  {learningObjectivesLines.length === 0 &&
+                  editingObjectiveIndex !== learningObjectivesLines.length ? (
+                    <EmptyState
+                      icon={
+                        <svg
+                          className="h-5 w-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                      }
+                      title="No learning objectives yet"
+                      description="Claude didn't find any in this syllabus - add one, or skip this section."
+                      action={{ label: '+ Add objective', onClick: startAddingObjective }}
+                    />
+                  ) : (
+                    <ul className="space-y-1.5 text-xs text-foreground">
+                      {[
+                        ...learningObjectivesLines,
+                        ...(editingObjectiveIndex === learningObjectivesLines.length ? [''] : []),
+                      ].map((line, i) =>
+                        editingObjectiveIndex === i ? (
+                          <li
+                            key={i}
+                            className="flex items-start gap-1.5 rounded-lg border border-primary/30 p-2"
+                          >
+                            <textarea
+                              autoFocus
+                              value={objectiveDraft}
+                              onChange={(e) => setObjectiveDraft(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                  e.preventDefault();
+                                  commitObjectiveEdit(i);
+                                } else if (e.key === 'Escape') {
+                                  setEditingObjectiveIndex(null);
+                                }
+                              }}
+                              rows={2}
+                              placeholder="e.g. Design multi-tier web applications"
+                              className="max-h-32 flex-1 resize-y overflow-y-auto rounded-lg border border-primary bg-card px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                            />
+                            <div className="flex shrink-0 flex-col gap-1">
+                              <button
+                                type="button"
+                                onClick={() => commitObjectiveEdit(i)}
+                                className="rounded p-1 text-primary hover:bg-primary/10"
+                                aria-label="Save this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
                                 >
-                                  <svg
-                                    className="h-3.5 w-3.5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M4.5 12.75l6 6 9-13.5"
-                                    />
-                                  </svg>
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => setEditingObjectiveIndex(null)}
-                                  className="rounded p-0.5 text-muted-foreground hover:bg-muted"
-                                  aria-label="Cancel editing this objective"
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M4.5 12.75l6 6 9-13.5"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setEditingObjectiveIndex(null)}
+                                className="rounded p-1 text-muted-foreground hover:bg-muted"
+                                aria-label="Cancel editing this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
                                 >
-                                  <svg
-                                    className="h-3.5 w-3.5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M6 18L18 6M6 6l12 12"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </li>
-                          ) : (
-                            <li key={i} className="flex items-start gap-1.5">
-                              <span className="text-primary">&bull;</span>
-                              <span className="flex-1">{renderInlineMarkdown(line)}</span>
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </li>
+                        ) : (
+                          <li
+                            key={i}
+                            className="group flex items-start justify-between gap-1.5 rounded-lg border border-border p-2 transition-colors hover:border-primary/30"
+                          >
+                            <span className="flex-1 leading-relaxed">
+                              {renderInlineMarkdown(line)}
+                            </span>
+                            <div className="flex items-center gap-0.5 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                               <button
                                 type="button"
                                 onClick={() => startEditingObjective(i)}
-                                className="shrink-0 text-muted-foreground transition-colors hover:text-primary"
+                                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
                                 aria-label="Edit this objective"
                               >
                                 <svg
@@ -1438,18 +1661,39 @@ export function SyllabusAutofillModal({ open, onClose }: SyllabusAutofillModalPr
                                   />
                                 </svg>
                               </button>
-                            </li>
-                          ),
-                        )}
-                      </ul>
-                    )}
+                              <button
+                                type="button"
+                                onClick={() => removeObjective(i)}
+                                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                                aria-label="Remove this objective"
+                              >
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  )}
+                  {learningObjectivesLines.length > 0 && (
                     <p className="text-xs text-muted-foreground">
-                      Click the pencil to edit an objective, or clear its text to remove it. Uncheck
-                      &quot;Save to course&quot; to skip saving these for now without losing what
-                      Claude found.
+                      Uncheck &quot;Save to course&quot; to skip saving these for now without losing
+                      what Claude found.
                     </p>
-                  </section>
-                )}
+                  )}
+                </section>
 
                 {contactDrafts.length > 0 && (
                   <section className="space-y-3">

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -5,6 +5,7 @@ import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import type { Course, AssignmentType } from '@/types/schedule';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { useModalA11y } from '@/hooks/useModalA11y';
 
 export interface SuggestedChunk {
   title: string;
@@ -97,16 +98,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isLoading]);
 
-  // Handle Escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   const selectedCourse: Course | undefined = state.courses.find((c) => c.id === selectedCourseId);
 
@@ -231,7 +223,10 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
       }}
     >
       <div className="fixed inset-y-0 right-0 flex max-w-full pl-6 sm:pl-10">
-        <aside className="w-screen max-w-md md:max-w-lg border-l border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl flex flex-col justify-between">
+        <aside
+          ref={dialogRef}
+          className="w-screen max-w-md md:max-w-lg border-l border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl flex flex-col justify-between"
+        >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border/40 px-4 py-3.5 bg-muted/20">
             <div className="flex items-center gap-2.5">

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import type { Course, AssignmentType } from '@/types/schedule';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useToast } from '@/components/ui/Toast';
 
 export interface SuggestedChunk {
   title: string;
@@ -41,6 +42,7 @@ const STARTER_PROMPTS = [
 export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: SyllabusChatDrawerProps) {
   const { state } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const [selectedCourseId, setSelectedCourseId] = useState<string>(initialCourseId || '');
   const [inputQuery, setInputQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +72,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
       setUploadedFile({ name: file.name, base64 });
     } catch (err) {
       console.error('Failed to read upload file:', err);
+      showError("Couldn't read that file. Try a different one.");
     } finally {
       setFileUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -503,6 +506,7 @@ function SuggestedChunksCard({
 }) {
   const { user } = useAuth();
   const { dispatch } = useAppState();
+  const { showError } = useToast();
   const [loading, setLoading] = useState(false);
   const [applied, setApplied] = useState(false);
 
@@ -530,6 +534,9 @@ function SuggestedChunksCard({
       setApplied(true);
     } catch (err) {
       console.error('Failed to apply suggested chunks:', err);
+      showError(
+        "Couldn't add these to your planner - some may have been added before the failure. Check your task list, then try again.",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -5,6 +5,7 @@ import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import type { Course, AssignmentType } from '@/types/schedule';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
+import { normalizeMaterials } from '@/lib/courses/materials';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useToast } from '@/components/ui/Toast';
 
@@ -140,7 +141,9 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
             instructor: selectedCourse?.instructor,
             location: selectedCourse?.meetingTimes?.[0]?.location,
             notes: selectedCourse?.notes,
-            materials: selectedCourse?.materials,
+            materials: normalizeMaterials(selectedCourse?.materials).map((m) =>
+              m.cost !== undefined ? `${m.name} ($${m.cost.toFixed(2)})` : m.name,
+            ),
             learningObjectives: selectedCourse?.learningObjectives,
             fileBase64: attachedFile?.base64 || undefined,
             fileName: attachedFile?.name || undefined,

--- a/src/components/syllabus/SyllabusDiffModal.tsx
+++ b/src/components/syllabus/SyllabusDiffModal.tsx
@@ -86,7 +86,10 @@ export function SyllabusDiffModal({
       aria-labelledby="syllabus-diff-title"
       className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4 bg-black/40 backdrop-blur-sm"
     >
-      <Card className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col">
+      <Card
+        accent="none"
+        className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col"
+      >
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-border pb-4 shrink-0">
           <div>

--- a/src/components/syllabus/SyllabusDiffModal.tsx
+++ b/src/components/syllabus/SyllabusDiffModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import { analyzeSyllabusRevision, PolicyChange, PolicyDiffReport } from '@/lib/syllabus/diffEngine';
+import { useModalA11y } from '@/hooks/useModalA11y';
 
 export interface SyllabusDiffModalProps {
   courseCode?: string;
@@ -38,6 +39,8 @@ export function SyllabusDiffModal({
       setSelectedChangeIds(new Set(report.changes.map((c) => c.id)));
     }
   }, [report]);
+
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
   if (!isOpen) return null;
 
@@ -87,6 +90,7 @@ export function SyllabusDiffModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4 bg-black/40 backdrop-blur-sm"
     >
       <Card
+        ref={dialogRef}
         accent="none"
         className="relative w-full max-w-4xl p-5 sm:p-7 space-y-5 max-h-[92vh] flex flex-col"
       >

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -55,19 +55,19 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
             <span className="text-xs text-muted-foreground">{formatSize(syllabus.sizeBytes)}</span>
           </div>
           {confirmingDeleteId === syllabus.id ? (
-            <div className="flex items-center gap-2 text-xs shrink-0">
+            <div className="flex items-center gap-1.5 text-xs shrink-0">
               <button
                 onClick={() => {
                   if (userId) deleteSyllabusUpload(userId, syllabus);
                   setConfirmingDeleteId(null);
                 }}
-                className="font-semibold text-destructive hover:underline"
+                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20"
               >
                 Confirm
               </button>
               <button
                 onClick={() => setConfirmingDeleteId(null)}
-                className="text-muted-foreground hover:underline"
+                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel
               </button>
@@ -75,7 +75,7 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
           ) : (
             <button
               onClick={() => setConfirmingDeleteId(syllabus.id)}
-              className="text-xs font-semibold text-destructive hover:underline shrink-0"
+              className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
             >
               Delete
             </button>

--- a/src/components/syllabus/SyllabusUploader.tsx
+++ b/src/components/syllabus/SyllabusUploader.tsx
@@ -97,17 +97,26 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
               style={{ width: `${progress}%` }}
             />
           </div>
-          <div className="flex gap-3 text-xs font-semibold">
+          <div className="flex gap-1.5 text-xs font-semibold">
             {status === 'uploading' ? (
-              <button onClick={pause} className="text-primary hover:underline">
+              <button
+                onClick={pause}
+                className="rounded-full px-2.5 py-1 text-primary transition-colors hover:bg-primary/10"
+              >
                 Pause
               </button>
             ) : (
-              <button onClick={resume} className="text-primary hover:underline">
+              <button
+                onClick={resume}
+                className="rounded-full px-2.5 py-1 text-primary transition-colors hover:bg-primary/10"
+              >
                 Resume
               </button>
             )}
-            <button onClick={cancel} className="text-destructive hover:underline">
+            <button
+              onClick={cancel}
+              className="rounded-full px-2.5 py-1 text-destructive transition-colors hover:bg-destructive/10"
+            >
               Cancel
             </button>
           </div>
@@ -117,7 +126,10 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
       {status === 'success' && (
         <div className="flex items-center justify-between rounded-xl border border-border p-4 text-sm">
           <span className="text-foreground">Upload complete.</span>
-          <button onClick={reset} className="text-xs font-semibold text-primary hover:underline">
+          <button
+            onClick={reset}
+            className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+          >
             Upload another
           </button>
         </div>

--- a/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
@@ -148,7 +148,7 @@ describe('SyllabusChatDrawer (Item 35)', () => {
     const onClose = vi.fn();
     renderWithProviders(<SyllabusChatDrawer isOpen={true} onClose={onClose} />);
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SyllabusChatDrawer } from '../SyllabusChatDrawer';
 import { AppStateProvider, AppState } from '@/context/AppStateContext';
 import { ThemeProvider } from '@/context/ThemeProvider';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Course } from '@/types/schedule';
 
 vi.mock('@/context/AuthContext', () => ({
@@ -51,7 +52,9 @@ function renderWithProviders(ui: React.ReactElement, stateOverrides: Partial<App
 
   return render(
     <ThemeProvider>
-      <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+      </ToastProvider>
     </ThemeProvider>,
   );
 }

--- a/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusChatDrawer.test.tsx
@@ -27,7 +27,7 @@ const mockCourses: Course[] = [
     ],
     term: 'Fall 2026',
     notes: 'Late work allowed up to 3 days with penalty.',
-    materials: ['CLRS Algorithms Textbook'],
+    materials: [{ name: 'CLRS Algorithms Textbook' }],
   },
   {
     id: 'course-2',

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -282,6 +282,8 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
         ...(values.estimatedHours ? { estimatedHours: Number(values.estimatedHours) } : {}),
         ...(values.notes ? { notes: values.notes } : {}),
         ...(values.progress ? { progress: Number(values.progress) } : {}),
+        ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
+        ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
       },
       dispatch,
     );

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -284,6 +284,7 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
         ...(values.progress ? { progress: Number(values.progress) } : {}),
         ...(values.gradeWeight ? { gradeWeight: Number(values.gradeWeight) } : {}),
         ...(values.gradeCategory ? { gradeCategory: values.gradeCategory } : {}),
+        ...(values.assignedTo ? { assignedTo: values.assignedTo } : {}),
       },
       dispatch,
     );
@@ -348,6 +349,11 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
               {item.gradeWeight !== undefined && (
                 <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
                   {item.gradeWeight}% of grade{item.gradeCategory ? ` · ${item.gradeCategory}` : ''}
+                </span>
+              )}
+              {item.assignedTo && (
+                <span className="rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  Assigned: {item.assignedTo}
                 </span>
               )}
               {item.source === 'ai' && (

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -133,7 +133,7 @@ export function TaskFormModal({
         className="w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        <Card>
+        <Card accent="none">
           <CardHeader>
             <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
             <CardDescription>

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -50,6 +50,7 @@ function emptyValues(defaultCourseId: string): ScheduleItemFormValues {
     progress: '',
     gradeWeight: '',
     gradeCategory: '',
+    assignedTo: '',
   };
 }
 
@@ -82,6 +83,7 @@ export function TaskFormModal({
           progress: initialItem.progress?.toString() ?? '',
           gradeWeight: initialItem.gradeWeight?.toString() ?? '',
           gradeCategory: initialItem.gradeCategory ?? '',
+          assignedTo: initialItem.assignedTo ?? '',
         }
       : emptyValues(courses[0]?.id ?? '');
     setValues(initial);
@@ -328,6 +330,15 @@ export function TaskFormModal({
                       placeholder="e.g. Homework"
                     />
                   </div>
+
+                  <Field
+                    id="assignedTo"
+                    label="Assigned To"
+                    value={values.assignedTo ?? ''}
+                    error={errors.assignedTo}
+                    onChange={(v) => updateField('assignedTo', v)}
+                    placeholder="e.g. Priya, or You - visible only to you"
+                  />
 
                   <Field
                     id="notes"

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -13,6 +13,7 @@ import { scheduleItemFormSchema, type ScheduleItemFormValues } from '@/lib/valid
 import type { Course, ScheduleItem, AssignmentType, Priority } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 
 const TYPE_OPTIONS: { value: AssignmentType; label: string }[] = [
   { value: 'assignment', label: 'Assignment' },
@@ -60,33 +61,41 @@ export function TaskFormModal({
   initialItem,
 }: TaskFormModalProps) {
   const [values, setValues] = useState<ScheduleItemFormValues>(emptyValues(courses[0]?.id ?? ''));
+  const [baseline, setBaseline] = useState<ScheduleItemFormValues>(
+    emptyValues(courses[0]?.id ?? ''),
+  );
   const [errors, setErrors] = useState<Partial<Record<keyof ScheduleItemFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    setValues(
-      initialItem
-        ? {
-            title: initialItem.title,
-            type: initialItem.type,
-            courseId: initialItem.courseId,
-            dueDate: initialItem.dueDate.slice(0, 10),
-            estimatedHours: initialItem.estimatedHours?.toString() ?? '',
-            priority: initialItem.priority ?? 'medium',
-            notes: initialItem.notes ?? '',
-            progress: initialItem.progress?.toString() ?? '',
-            gradeWeight: initialItem.gradeWeight?.toString() ?? '',
-            gradeCategory: initialItem.gradeCategory ?? '',
-          }
-        : emptyValues(courses[0]?.id ?? ''),
-    );
+    const initial: ScheduleItemFormValues = initialItem
+      ? {
+          title: initialItem.title,
+          type: initialItem.type,
+          courseId: initialItem.courseId,
+          dueDate: initialItem.dueDate.slice(0, 10),
+          estimatedHours: initialItem.estimatedHours?.toString() ?? '',
+          priority: initialItem.priority ?? 'medium',
+          notes: initialItem.notes ?? '',
+          progress: initialItem.progress?.toString() ?? '',
+          gradeWeight: initialItem.gradeWeight?.toString() ?? '',
+          gradeCategory: initialItem.gradeCategory ?? '',
+        }
+      : emptyValues(courses[0]?.id ?? '');
+    setValues(initial);
+    setBaseline(initial);
     setErrors({});
     setSubmitError(null);
   }, [open, initialItem, courses]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -129,14 +138,40 @@ export function TaskFormModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="task-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this task that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
@@ -308,7 +343,7 @@ export function TaskFormModal({
             <CardFooter className="justify-end gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
               >
                 Cancel

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -47,6 +47,8 @@ function emptyValues(defaultCourseId: string): ScheduleItemFormValues {
     priority: 'medium',
     notes: '',
     progress: '',
+    gradeWeight: '',
+    gradeCategory: '',
   };
 }
 
@@ -75,6 +77,8 @@ export function TaskFormModal({
             priority: initialItem.priority ?? 'medium',
             notes: initialItem.notes ?? '',
             progress: initialItem.progress?.toString() ?? '',
+            gradeWeight: initialItem.gradeWeight?.toString() ?? '',
+            gradeCategory: initialItem.gradeCategory ?? '',
           }
         : emptyValues(courses[0]?.id ?? ''),
     );
@@ -269,6 +273,26 @@ export function TaskFormModal({
                       )}
                     </div>
                   )}
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field
+                      id="gradeWeight"
+                      label="Grade Weight (%)"
+                      type="number"
+                      value={values.gradeWeight ?? ''}
+                      error={errors.gradeWeight}
+                      onChange={(v) => updateField('gradeWeight', v)}
+                      placeholder="Optional"
+                    />
+                    <Field
+                      id="gradeCategory"
+                      label="Grade Category"
+                      value={values.gradeCategory ?? ''}
+                      error={errors.gradeCategory}
+                      onChange={(v) => updateField('gradeCategory', v)}
+                      placeholder="e.g. Homework"
+                    />
+                  </div>
 
                   <Field
                     id="notes"

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -5,16 +5,17 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   hoverable?: boolean;
   /**
-   * Every card carries the brand-gradient "Neon Edge" border + ambient glow
-   * (globals.css `.glow-edge-low`) by default - the calm, static everyday
-   * treatment used sitewide. `true` (or `"top"`) instead draws a gradient
-   * bar along the top edge; `"left"` draws a solid primary-colored border
-   * down the left edge; `"none"` opts out back to a flat bordered card,
-   * reserved for cards whose border already carries other meaning (a
-   * destructive/error state, a dashed empty-state prompt) that a brand
-   * gradient would contradict. A card whose glow should escalate with real
-   * severity (medium/high/critical, breathing) uses WORKLOAD_GLOW_CLASS
-   * (lib/workload/uiClasses.ts) as `className` instead of this prop.
+   * Every card is a plain flat bordered card by default - a modal dialog is
+   * already the sole focus of attention behind its own backdrop, and an
+   * in-page card sitting in normal page flow doesn't need a decorative
+   * border to earn a look, so the default costs nothing extra to opt out
+   * of. `"glow"` opts in to the brand-gradient "Neon Edge" border + ambient
+   * glow (globals.css `.glow-edge-low`) for a card that should genuinely
+   * stand out; `true` (or `"top"`) instead draws a gradient bar along the
+   * top edge; `"left"` draws a solid primary-colored border down the left
+   * edge. A card whose glow should escalate with real severity
+   * (medium/high/critical, breathing) passes `accent="glow"` and layers
+   * WORKLOAD_GLOW_CLASS (lib/workload/uiClasses.ts) on top via `className`.
    */
   accent?: boolean | 'top' | 'left' | 'glow' | 'none';
 }
@@ -24,7 +25,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const isInteractive = interactive || hoverable;
     const accentTop = accent === true || accent === 'top';
     const accentLeft = accent === 'left';
-    const accentGlow = !accentTop && !accentLeft && accent !== 'none';
+    const accentGlow = accent === 'glow';
     return (
       <div
         ref={ref}

--- a/src/components/ui/CardAction.tsx
+++ b/src/components/ui/CardAction.tsx
@@ -78,25 +78,22 @@ export function CardActionLink({
 }
 
 export function CardActionButton({
-  onClick,
   children,
   variant = 'ghost',
   withPlus,
   withChevron,
   className,
-  disabled,
   type = 'button',
-}: SharedProps & {
-  onClick?: () => void;
-  disabled?: boolean;
-  type?: 'button' | 'submit';
-}) {
+  ...rest
+}: SharedProps & { type?: 'button' | 'submit' } & Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    'type' | 'className' | 'children'
+  >) {
   return (
     <button
       type={type}
-      onClick={onClick}
-      disabled={disabled}
       className={cn(baseClass, variantClass[variant], 'disabled:opacity-50', className)}
+      {...rest}
     >
       {withPlus && <PlusIcon />}
       {children}

--- a/src/components/ui/TaskRow.tsx
+++ b/src/components/ui/TaskRow.tsx
@@ -95,6 +95,11 @@ export interface TaskRowProps {
    * this stays a signal for genuinely high-stakes work (an exam, a big
    * project) rather than noise on every graded item. */
   gradeWeight?: number;
+  /** Private "who's doing this" label (ScheduleItem.assignedTo) for a group
+   * project sub-task - visible only to the signed-in user, not shared with
+   * anyone. Appended to the meta line rather than its own pill, since it's
+   * informational rather than something that needs to grab attention. */
+  assignedTo?: string;
   onToggleComplete?: () => void;
   /** Right-aligned custom content: due labels, badges, edit/delete links. */
   trailing?: ReactNode;
@@ -124,6 +129,7 @@ export function TaskRow({
   href,
   variant = 'card',
   gradeWeight,
+  assignedTo,
 }: TaskRowProps) {
   if (variant === 'touch') {
     return (
@@ -140,6 +146,7 @@ export function TaskRow({
         trailing={trailing}
         href={href}
         gradeWeight={gradeWeight}
+        assignedTo={assignedTo}
       />
     );
   }
@@ -158,12 +165,14 @@ export function TaskRow({
       trailing={trailing}
       href={href}
       gradeWeight={gradeWeight}
+      assignedTo={assignedTo}
     />
   );
 }
 
-function metaLine(courseCode: string | undefined, type: AssignmentType) {
-  return courseCode ? `${courseCode} · ${TYPE_LABEL[type]}` : TYPE_LABEL[type];
+function metaLine(courseCode: string | undefined, type: AssignmentType, assignedTo?: string) {
+  const base = courseCode ? `${courseCode} · ${TYPE_LABEL[type]}` : TYPE_LABEL[type];
+  return assignedTo ? `${base} · Assigned: ${assignedTo}` : base;
 }
 
 /** Shared "in progress" strip: never renders for a task nobody has touched
@@ -218,6 +227,7 @@ function CardRow({
   trailing,
   href,
   gradeWeight,
+  assignedTo,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed' | 'priority'>> &
   Pick<
     TaskRowProps,
@@ -229,6 +239,7 @@ function CardRow({
     | 'trailing'
     | 'href'
     | 'gradeWeight'
+    | 'assignedTo'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
@@ -348,7 +359,7 @@ function CardRow({
             {!completed && <GradeWeightPill gradeWeight={gradeWeight} />}
           </div>
           <div className="mt-1 text-caption text-muted-foreground">
-            {metaLine(courseCode, type)}
+            {metaLine(courseCode, type, assignedTo)}
           </div>
           {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
         </div>
@@ -437,6 +448,7 @@ function TouchRow({
   trailing,
   href,
   gradeWeight,
+  assignedTo,
 }: Required<Pick<TaskRowProps, 'title' | 'type' | 'completed'>> &
   Pick<
     TaskRowProps,
@@ -449,6 +461,7 @@ function TouchRow({
     | 'trailing'
     | 'href'
     | 'gradeWeight'
+    | 'assignedTo'
   >) {
   const status = getTaskStatus({ completed, progress });
   const progressPct = clampProgress(progress ?? 0);
@@ -536,7 +549,7 @@ function TouchRow({
               {!completed && <GradeWeightPill gradeWeight={gradeWeight} />}
             </div>
             <div className="mt-0.5 text-caption text-muted-foreground">
-              {metaLine(courseCode, type)}
+              {metaLine(courseCode, type, assignedTo)}
             </div>
             {status === 'in_progress' && <ProgressStrip percent={progressPct} />}
           </div>

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 import { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
+import type { Flashcard } from '@/types/flashcard';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 
 export interface AppState {
@@ -10,6 +11,7 @@ export interface AppState {
   scheduleItems: ScheduleItem[];
   contacts: Contact[];
   sources: Source[];
+  flashcards: Flashcard[];
   selectedCourseId: string | null;
   /** #101 semester switcher. `null` means "no explicit choice made yet" -
    * consumers should fall back to `inferCurrentTerm`. The literal string
@@ -44,6 +46,11 @@ export type AppAction =
   | { type: 'ADD_SOURCE'; payload: Source }
   | { type: 'UPDATE_SOURCE'; payload: Source }
   | { type: 'REMOVE_SOURCE'; payload: string }
+  | { type: 'SET_FLASHCARDS'; payload: Flashcard[] }
+  | { type: 'ADD_FLASHCARD'; payload: Flashcard }
+  | { type: 'ADD_FLASHCARDS'; payload: Flashcard[] }
+  | { type: 'UPDATE_FLASHCARD'; payload: Flashcard }
+  | { type: 'REMOVE_FLASHCARD'; payload: string }
   | { type: 'SELECT_COURSE'; payload: string | null }
   | { type: 'SELECT_TERM'; payload: string | null }
   | { type: 'SET_PREFERENCES'; payload: UserPreferences };
@@ -53,6 +60,7 @@ export const initialAppState: AppState = {
   scheduleItems: [],
   contacts: [],
   sources: [],
+  flashcards: [],
   selectedCourseId: null,
   selectedTerm: null,
   preferences: DEFAULT_PREFERENCES,
@@ -80,6 +88,7 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
         scheduleItems: state.scheduleItems.filter((item) => item.courseId !== action.payload),
         contacts: state.contacts.filter((c) => c.courseId !== action.payload),
         sources: state.sources.filter((s) => s.courseId !== action.payload),
+        flashcards: state.flashcards.filter((f) => f.courseId !== action.payload),
         selectedCourseId: state.selectedCourseId === action.payload ? null : state.selectedCourseId,
       };
     case 'SET_SCHEDULE_ITEMS':
@@ -129,6 +138,19 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       };
     case 'REMOVE_SOURCE':
       return { ...state, sources: state.sources.filter((s) => s.id !== action.payload) };
+    case 'SET_FLASHCARDS':
+      return { ...state, flashcards: action.payload };
+    case 'ADD_FLASHCARD':
+      return { ...state, flashcards: [...state.flashcards, action.payload] };
+    case 'ADD_FLASHCARDS':
+      return { ...state, flashcards: [...state.flashcards, ...action.payload] };
+    case 'UPDATE_FLASHCARD':
+      return {
+        ...state,
+        flashcards: state.flashcards.map((f) => (f.id === action.payload.id ? action.payload : f)),
+      };
+    case 'REMOVE_FLASHCARD':
+      return { ...state, flashcards: state.flashcards.filter((f) => f.id !== action.payload) };
     case 'SELECT_COURSE':
       return { ...state, selectedCourseId: action.payload };
     case 'SELECT_TERM':

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -2,12 +2,14 @@
 
 import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 import { Contact, Course, ScheduleItem } from '@/types/schedule';
+import type { Source } from '@/types/source';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 
 export interface AppState {
   courses: Course[];
   scheduleItems: ScheduleItem[];
   contacts: Contact[];
+  sources: Source[];
   selectedCourseId: string | null;
   /** #101 semester switcher. `null` means "no explicit choice made yet" -
    * consumers should fall back to `inferCurrentTerm`. The literal string
@@ -38,6 +40,10 @@ export type AppAction =
   | { type: 'ADD_CONTACTS'; payload: Contact[] }
   | { type: 'UPDATE_CONTACT'; payload: Contact }
   | { type: 'REMOVE_CONTACT'; payload: string }
+  | { type: 'SET_SOURCES'; payload: Source[] }
+  | { type: 'ADD_SOURCE'; payload: Source }
+  | { type: 'UPDATE_SOURCE'; payload: Source }
+  | { type: 'REMOVE_SOURCE'; payload: string }
   | { type: 'SELECT_COURSE'; payload: string | null }
   | { type: 'SELECT_TERM'; payload: string | null }
   | { type: 'SET_PREFERENCES'; payload: UserPreferences };
@@ -46,6 +52,7 @@ export const initialAppState: AppState = {
   courses: [],
   scheduleItems: [],
   contacts: [],
+  sources: [],
   selectedCourseId: null,
   selectedTerm: null,
   preferences: DEFAULT_PREFERENCES,
@@ -72,6 +79,7 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
         courses: state.courses.filter((c) => c.id !== action.payload),
         scheduleItems: state.scheduleItems.filter((item) => item.courseId !== action.payload),
         contacts: state.contacts.filter((c) => c.courseId !== action.payload),
+        sources: state.sources.filter((s) => s.courseId !== action.payload),
         selectedCourseId: state.selectedCourseId === action.payload ? null : state.selectedCourseId,
       };
     case 'SET_SCHEDULE_ITEMS':
@@ -110,6 +118,17 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       };
     case 'REMOVE_CONTACT':
       return { ...state, contacts: state.contacts.filter((c) => c.id !== action.payload) };
+    case 'SET_SOURCES':
+      return { ...state, sources: action.payload };
+    case 'ADD_SOURCE':
+      return { ...state, sources: [...state.sources, action.payload] };
+    case 'UPDATE_SOURCE':
+      return {
+        ...state,
+        sources: state.sources.map((s) => (s.id === action.payload.id ? action.payload : s)),
+      };
+    case 'REMOVE_SOURCE':
+      return { ...state, sources: state.sources.filter((s) => s.id !== action.payload) };
     case 'SELECT_COURSE':
       return { ...state, selectedCourseId: action.payload };
     case 'SELECT_TERM':

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useEffect, useMemo, useReducer } from
 import { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
 import type { Flashcard } from '@/types/flashcard';
+import type { Quiz, QuizAttempt } from '@/types/quiz';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 
 export interface AppState {
@@ -12,6 +13,8 @@ export interface AppState {
   contacts: Contact[];
   sources: Source[];
   flashcards: Flashcard[];
+  quizzes: Quiz[];
+  quizAttempts: QuizAttempt[];
   selectedCourseId: string | null;
   /** #101 semester switcher. `null` means "no explicit choice made yet" -
    * consumers should fall back to `inferCurrentTerm`. The literal string
@@ -51,6 +54,12 @@ export type AppAction =
   | { type: 'ADD_FLASHCARDS'; payload: Flashcard[] }
   | { type: 'UPDATE_FLASHCARD'; payload: Flashcard }
   | { type: 'REMOVE_FLASHCARD'; payload: string }
+  | { type: 'SET_QUIZZES'; payload: Quiz[] }
+  | { type: 'ADD_QUIZ'; payload: Quiz }
+  | { type: 'REMOVE_QUIZ'; payload: string }
+  | { type: 'SET_QUIZ_ATTEMPTS'; payload: QuizAttempt[] }
+  | { type: 'ADD_QUIZ_ATTEMPT'; payload: QuizAttempt }
+  | { type: 'REMOVE_QUIZ_ATTEMPT'; payload: string }
   | { type: 'SELECT_COURSE'; payload: string | null }
   | { type: 'SELECT_TERM'; payload: string | null }
   | { type: 'SET_PREFERENCES'; payload: UserPreferences };
@@ -61,6 +70,8 @@ export const initialAppState: AppState = {
   contacts: [],
   sources: [],
   flashcards: [],
+  quizzes: [],
+  quizAttempts: [],
   selectedCourseId: null,
   selectedTerm: null,
   preferences: DEFAULT_PREFERENCES,
@@ -89,6 +100,8 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
         contacts: state.contacts.filter((c) => c.courseId !== action.payload),
         sources: state.sources.filter((s) => s.courseId !== action.payload),
         flashcards: state.flashcards.filter((f) => f.courseId !== action.payload),
+        quizzes: state.quizzes.filter((q) => q.courseId !== action.payload),
+        quizAttempts: state.quizAttempts.filter((a) => a.courseId !== action.payload),
         selectedCourseId: state.selectedCourseId === action.payload ? null : state.selectedCourseId,
       };
     case 'SET_SCHEDULE_ITEMS':
@@ -151,6 +164,21 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       };
     case 'REMOVE_FLASHCARD':
       return { ...state, flashcards: state.flashcards.filter((f) => f.id !== action.payload) };
+    case 'SET_QUIZZES':
+      return { ...state, quizzes: action.payload };
+    case 'ADD_QUIZ':
+      return { ...state, quizzes: [...state.quizzes, action.payload] };
+    case 'REMOVE_QUIZ':
+      return { ...state, quizzes: state.quizzes.filter((q) => q.id !== action.payload) };
+    case 'SET_QUIZ_ATTEMPTS':
+      return { ...state, quizAttempts: action.payload };
+    case 'ADD_QUIZ_ATTEMPT':
+      return { ...state, quizAttempts: [...state.quizAttempts, action.payload] };
+    case 'REMOVE_QUIZ_ATTEMPT':
+      return {
+        ...state,
+        quizAttempts: state.quizAttempts.filter((a) => a.id !== action.payload),
+      };
     case 'SELECT_COURSE':
       return { ...state, selectedCourseId: action.payload };
     case 'SELECT_TERM':

--- a/src/hooks/useDirtyClose.ts
+++ b/src/hooks/useDirtyClose.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Guards a form modal's close path (backdrop click, Escape, a Cancel button)
+ * behind a "discard unsaved changes?" confirmation whenever the current
+ * values have actually diverged from the snapshot taken when the form
+ * opened. Closing after a successful submit should call the modal's own
+ * `onClose` directly, bypassing this - a save is never a discard.
+ */
+export function useDirtyClose<T>(current: T, baseline: T, onClose: () => void) {
+  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
+  const isDirty = JSON.stringify(current) !== JSON.stringify(baseline);
+
+  const requestClose = () => {
+    if (isDirty) {
+      setConfirmingDiscard(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const confirmDiscard = () => {
+    setConfirmingDiscard(false);
+    onClose();
+  };
+
+  const cancelDiscard = () => setConfirmingDiscard(false);
+
+  return { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard, isDirty };
+}

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -181,6 +181,7 @@ describe('AppStateContext Reducer & Selectors', () => {
       courses: [mockCourse],
       scheduleItems: [mockItem],
       contacts: [],
+      sources: [],
       selectedCourseId: 'c1',
       selectedTerm: null,
       preferences: DEFAULT_PREFERENCES,

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -182,6 +182,7 @@ describe('AppStateContext Reducer & Selectors', () => {
       scheduleItems: [mockItem],
       contacts: [],
       sources: [],
+      flashcards: [],
       selectedCourseId: 'c1',
       selectedTerm: null,
       preferences: DEFAULT_PREFERENCES,

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -183,6 +183,8 @@ describe('AppStateContext Reducer & Selectors', () => {
       contacts: [],
       sources: [],
       flashcards: [],
+      quizzes: [],
+      quizAttempts: [],
       selectedCourseId: 'c1',
       selectedTerm: null,
       preferences: DEFAULT_PREFERENCES,

--- a/src/lib/__tests__/AuthContext.test.tsx
+++ b/src/lib/__tests__/AuthContext.test.tsx
@@ -62,6 +62,7 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(),
   setDoc: vi.fn(),
 }));

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { PlannerView } from '@/components/schedule/PlannerView';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Course, ScheduleItem } from '@/types/schedule';
 
 vi.hoisted(() => {
@@ -90,9 +91,11 @@ const scheduleItems: ScheduleItem[] = [
 function renderPlanner() {
   return render(
     <AuthProvider>
-      <AppStateProvider initialState={{ courses, scheduleItems, initialized: true }}>
-        <PlannerView />
-      </AppStateProvider>
+      <ToastProvider>
+        <AppStateProvider initialState={{ courses, scheduleItems, initialized: true }}>
+          <PlannerView />
+        </AppStateProvider>
+      </ToastProvider>
     </AuthProvider>,
   );
 }

--- a/src/lib/__tests__/PlannerView.test.tsx
+++ b/src/lib/__tests__/PlannerView.test.tsx
@@ -32,6 +32,7 @@ vi.mock('firebase/auth', () => ({
 }));
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(),
   setDoc: vi.fn(),
   deleteDoc: vi.fn(),

--- a/src/lib/__tests__/TaskRow.test.tsx
+++ b/src/lib/__tests__/TaskRow.test.tsx
@@ -91,4 +91,23 @@ describe('TaskRow', () => {
       expect(screen.getByText('25%')).toBeDefined();
     });
   });
+
+  describe('assignedTo (group project sub-task owner)', () => {
+    it('appends the assignee to the meta line when present', () => {
+      render(<TaskRow title="Literature review" courseCode="HIST 220" assignedTo="Priya" />);
+      expect(screen.getByText('HIST 220 · Assignment · Assigned: Priya')).toBeDefined();
+    });
+
+    it('leaves the meta line unchanged when no assignee is set', () => {
+      render(<TaskRow title="Unassigned task" courseCode="HIST 220" />);
+      expect(screen.getByText('HIST 220 · Assignment')).toBeDefined();
+    });
+
+    it('also appends for the touch variant', () => {
+      render(
+        <TaskRow title="Touch assignee" courseCode="HIST 220" assignedTo="You" variant="touch" />,
+      );
+      expect(screen.getByText('HIST 220 · Assignment · Assigned: You')).toBeDefined();
+    });
+  });
 });

--- a/src/lib/__tests__/firebase.test.ts
+++ b/src/lib/__tests__/firebase.test.ts
@@ -35,6 +35,7 @@ vi.mock('firebase/auth', () => {
 vi.mock('firebase/firestore', () => {
   return {
     getFirestore: vi.fn(() => ({})),
+    initializeFirestore: vi.fn(() => ({})),
     connectFirestoreEmulator: vi.fn(),
   };
 });

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -145,7 +145,9 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
             initialized: true,
           }}
         >
-          <ContactsListView />
+          <ToastProvider>
+            <ContactsListView />
+          </ToastProvider>
         </AppStateProvider>
       </AuthProvider>,
     );

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -9,6 +9,7 @@ import { MonthCalendar } from '@/components/calendar/MonthCalendar';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { ThemeProvider } from '@/context/ThemeProvider';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
 
 vi.hoisted(() => {
@@ -106,11 +107,13 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
   it('PlannerView select filters and action buttons meet the 44px touch target requirement', () => {
     render(
       <AuthProvider>
-        <AppStateProvider
-          initialState={{ courses: mockCourses, scheduleItems: mockItems, initialized: true }}
-        >
-          <PlannerView />
-        </AppStateProvider>
+        <ToastProvider>
+          <AppStateProvider
+            initialState={{ courses: mockCourses, scheduleItems: mockItems, initialized: true }}
+          >
+            <PlannerView />
+          </AppStateProvider>
+        </ToastProvider>
       </AuthProvider>,
     );
 

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -56,6 +56,7 @@ vi.mock('firebase/auth', () => ({
 }));
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
   doc: vi.fn(),
   setDoc: vi.fn(),
   deleteDoc: vi.fn(),

--- a/src/lib/ai/flashcardsTool.ts
+++ b/src/lib/ai/flashcardsTool.ts
@@ -1,0 +1,40 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+export const FLASHCARDS_SYSTEM_PROMPT = `You are helping a student turn a course syllabus into study flashcards. Read the whole document and generate flashcards that would actually help someone study for this course - not a restatement of logistics.
+
+Focus on things worth memorizing or being able to explain: key terms and their definitions, named concepts/theories/models the course covers, formulas, dates or figures central to the subject matter, and important distinctions between similar ideas. Skip pure logistics that don't belong on a study card (office hours, late-work policy, grading breakdown, attendance rules) unless the syllabus itself frames a specific policy detail as something students are tested on.
+
+Write each card as a genuine question-and-answer or term-and-definition pair, not a fragment of the syllabus text pasted verbatim. The front should be answerable from memory; the back should be a complete, standalone answer.
+
+Generate between 8 and 20 cards depending on how much study-worthy content the syllabus actually contains - a syllabus that's mostly logistics with little content detail should yield fewer cards, not padded ones.`;
+
+export const FLASHCARDS_TOOL: Anthropic.Tool = {
+  name: 'record_flashcards',
+  description: 'Records a set of study flashcards generated from a syllabus.',
+  input_schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['cards'],
+    properties: {
+      cards: {
+        type: 'array',
+        description: 'Between 8 and 20 flashcards, each a genuine question/term and answer pair.',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['front', 'back'],
+          properties: {
+            front: {
+              type: 'string',
+              description: 'The question or term shown first - what the student tries to recall.',
+            },
+            back: {
+              type: 'string',
+              description: 'The complete answer or definition.',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/lib/ai/quizTool.ts
+++ b/src/lib/ai/quizTool.ts
@@ -1,0 +1,53 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+export const QUIZ_SYSTEM_PROMPT = `You are helping a student build a practice quiz from a course syllabus. Read the whole document and generate multiple-choice questions that would actually test understanding of this course's content - not a restatement of logistics.
+
+Focus on things worth being tested on: key terms and their definitions, named concepts/theories/models the course covers, formulas, dates or figures central to the subject matter, and important distinctions between similar ideas. Skip pure logistics (office hours, late-work policy, grading breakdown, attendance rules) unless the syllabus itself frames a specific policy detail as something students are tested on.
+
+Each question needs exactly 4 answer choices, with exactly one correct. Wrong choices should be plausible - not obviously wrong filler - so the question actually discriminates between someone who studied and someone who didn't. Include a one or two sentence explanation of why the correct answer is correct, written to teach, not just confirm.
+
+Generate between 8 and 15 questions depending on how much study-worthy content the syllabus actually contains - a syllabus that's mostly logistics with little content detail should yield fewer questions, not padded ones.`;
+
+export const QUIZ_TOOL: Anthropic.Tool = {
+  name: 'record_quiz',
+  description: 'Records a multiple-choice practice quiz generated from a syllabus.',
+  input_schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['questions'],
+    properties: {
+      questions: {
+        type: 'array',
+        description: 'Between 8 and 15 multiple-choice questions.',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['question', 'choices', 'correctIndex', 'explanation'],
+          properties: {
+            question: {
+              type: 'string',
+              description: 'The question text.',
+            },
+            choices: {
+              type: 'array',
+              description: 'Exactly 4 answer choices.',
+              items: { type: 'string' },
+              minItems: 4,
+              maxItems: 4,
+            },
+            correctIndex: {
+              type: 'integer',
+              description: 'Index (0-3) of the correct choice within `choices`.',
+              minimum: 0,
+              maximum: 3,
+            },
+            explanation: {
+              type: 'string',
+              description: 'A brief explanation of why the correct answer is correct.',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/lib/citations/__tests__/formatCitation.test.ts
+++ b/src/lib/citations/__tests__/formatCitation.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { formatCitation, formatBibliography, sortSources } from '../formatCitation';
+import type { Source } from '@/types/source';
+
+function makeSource(overrides: Partial<Source>): Source {
+  return {
+    id: 's1',
+    courseId: 'c1',
+    type: 'book',
+    title: 'Historians’ Fallacies',
+    authors: [{ firstName: 'David', lastName: 'Fischer' }],
+    year: '1970',
+    publisher: 'Harper & Row',
+    ...overrides,
+  };
+}
+
+describe('formatCitation', () => {
+  it('formats a single-author book in APA', () => {
+    const source = makeSource({});
+    expect(formatCitation(source, 'apa')).toBe(
+      'Fischer, D. (1970). Historians’ Fallacies. Harper & Row.',
+    );
+  });
+
+  it('formats a single-author book in MLA', () => {
+    const source = makeSource({});
+    expect(formatCitation(source, 'mla')).toBe(
+      'Fischer, David. Historians’ Fallacies. Harper & Row, 1970.',
+    );
+  });
+
+  it('formats a single-author book in Chicago', () => {
+    const source = makeSource({});
+    expect(formatCitation(source, 'chicago')).toBe(
+      'Fischer, David. 1970. Historians’ Fallacies. Harper & Row.',
+    );
+  });
+
+  it('joins two authors with an ampersand in APA', () => {
+    const source = makeSource({
+      authors: [
+        { firstName: 'David', lastName: 'Fischer' },
+        { firstName: 'Jane', lastName: 'Carr' },
+      ],
+    });
+    expect(formatCitation(source, 'apa')).toBe(
+      'Fischer, D., & Carr, J. (1970). Historians’ Fallacies. Harper & Row.',
+    );
+  });
+
+  it('collapses three or more authors to "et al." in MLA', () => {
+    const source = makeSource({
+      authors: [
+        { firstName: 'David', lastName: 'Fischer' },
+        { firstName: 'Jane', lastName: 'Carr' },
+        { firstName: 'John', lastName: 'Tuchman' },
+      ],
+    });
+    expect(formatCitation(source, 'mla')).toBe(
+      'Fischer, David, et al. Historians’ Fallacies. Harper & Row, 1970.',
+    );
+  });
+
+  it('lists three authors with an Oxford comma and "and" in Chicago', () => {
+    const source = makeSource({
+      authors: [
+        { firstName: 'David', lastName: 'Fischer' },
+        { firstName: 'Jane', lastName: 'Carr' },
+        { firstName: 'John', lastName: 'Tuchman' },
+      ],
+    });
+    expect(formatCitation(source, 'chicago')).toBe(
+      'Fischer, David, Jane Carr, and John Tuchman. 1970. Historians’ Fallacies. Harper & Row.',
+    );
+  });
+
+  it('formats a website with a URL in APA', () => {
+    const source = makeSource({
+      type: 'website',
+      title: 'Understanding Historiography',
+      siteName: 'JSTOR Daily',
+      url: 'https://daily.jstor.org/example',
+      publisher: undefined,
+    });
+    expect(formatCitation(source, 'apa')).toBe(
+      'Fischer, D. (1970). Understanding Historiography. JSTOR Daily. https://daily.jstor.org/example',
+    );
+  });
+
+  it('quotes the title and uses "pp." for a journal article in MLA', () => {
+    const source = makeSource({
+      type: 'journal',
+      title: 'The Braided Narrative',
+      journalName: 'Journal of American History',
+      volume: '58',
+      issue: '2',
+      pages: '210-234',
+      publisher: undefined,
+    });
+    expect(formatCitation(source, 'mla')).toBe(
+      'Fischer, David. "The Braided Narrative." Journal of American History, vol. 58, no. 2, 1970, pp. 210-234.',
+    );
+  });
+
+  it('formats a journal article with volume(issue): pages in Chicago', () => {
+    const source = makeSource({
+      type: 'journal',
+      title: 'The Braided Narrative',
+      journalName: 'Journal of American History',
+      volume: '58',
+      issue: '2',
+      pages: '210-234',
+      publisher: undefined,
+    });
+    expect(formatCitation(source, 'chicago')).toBe(
+      'Fischer, David. 1970. "The Braided Narrative." Journal of American History 58 (2): 210-234.',
+    );
+  });
+
+  it('omits missing optional fields instead of leaving stray punctuation', () => {
+    const source = makeSource({ year: undefined, publisher: undefined });
+    expect(formatCitation(source, 'apa')).toBe('Fischer, D. Historians’ Fallacies.');
+  });
+
+  it('falls back to the title when a source has no author', () => {
+    const source = makeSource({ authors: [] });
+    expect(formatCitation(source, 'apa')).toBe('(1970). Historians’ Fallacies. Harper & Row.');
+  });
+});
+
+describe('sortSources', () => {
+  it('matches the order formatBibliography uses, so the on-screen list and the copied text agree', () => {
+    const sources: Source[] = [
+      makeSource({ id: 's1', authors: [{ firstName: 'Jane', lastName: 'Tuchman' }] }),
+      makeSource({ id: 's2', authors: [{ firstName: 'Ada', lastName: 'Carr' }] }),
+    ];
+    expect(sortSources(sources).map((s) => s.id)).toEqual(['s2', 's1']);
+  });
+});
+
+describe('formatBibliography', () => {
+  it('sorts sources alphabetically by first author last name', () => {
+    const sources: Source[] = [
+      makeSource({ id: 's1', authors: [{ firstName: 'Jane', lastName: 'Tuchman' }] }),
+      makeSource({ id: 's2', authors: [{ firstName: 'Ada', lastName: 'Carr' }] }),
+    ];
+    const bibliography = formatBibliography(sources, 'apa');
+    const carrIndex = bibliography.indexOf('Carr');
+    const tuchmanIndex = bibliography.indexOf('Tuchman');
+    expect(carrIndex).toBeGreaterThanOrEqual(0);
+    expect(tuchmanIndex).toBeGreaterThan(carrIndex);
+  });
+
+  it('separates entries with a blank line', () => {
+    const sources: Source[] = [
+      makeSource({ id: 's1', title: 'First Work' }),
+      makeSource({
+        id: 's2',
+        title: 'Second Work',
+        authors: [{ firstName: 'Zed', lastName: 'Zephyr' }],
+      }),
+    ];
+    expect(formatBibliography(sources, 'apa').split('\n\n')).toHaveLength(2);
+  });
+});

--- a/src/lib/citations/formatCitation.ts
+++ b/src/lib/citations/formatCitation.ts
@@ -1,0 +1,248 @@
+import type { CitationStyle, Source, SourceAuthor } from '@/types/source';
+
+/**
+ * Rule-based citation formatting for the three styles the app supports.
+ * This is a practical, common-case implementation of APA 7 / MLA 9 /
+ * Chicago (author-date, 17th ed.) - it covers the fields a student
+ * actually tracks (see Source), not every edge case of each style guide
+ * (no corporate authors, no edited-volume chapters, no multi-volume
+ * works). Missing optional fields are simply omitted rather than left as
+ * broken punctuation.
+ */
+
+function trimmed(value: string | undefined): string {
+  return (value ?? '').trim();
+}
+
+function hasName(a: SourceAuthor): boolean {
+  return trimmed(a.firstName).length > 0 || trimmed(a.lastName).length > 0;
+}
+
+function lastFirst(a: SourceAuthor): string {
+  const last = trimmed(a.lastName);
+  const first = trimmed(a.firstName);
+  if (last && first) return `${last}, ${first}`;
+  return last || first;
+}
+
+function firstLast(a: SourceAuthor): string {
+  const last = trimmed(a.lastName);
+  const first = trimmed(a.firstName);
+  if (last && first) return `${first} ${last}`;
+  return last || first;
+}
+
+function initial(first: string): string {
+  const t = trimmed(first);
+  return t ? `${t[0].toUpperCase()}.` : '';
+}
+
+function lastInitial(a: SourceAuthor): string {
+  const last = trimmed(a.lastName);
+  const init = initial(a.firstName);
+  if (last && init) return `${last}, ${init}`;
+  return last || init;
+}
+
+function namedAuthors(source: Pick<Source, 'authors'>): SourceAuthor[] {
+  return (source.authors ?? []).filter(hasName);
+}
+
+function formatAuthorsAPA(authors: SourceAuthor[]): string {
+  if (authors.length === 0) return '';
+  const names = authors.map(lastInitial);
+  if (names.length === 1) return names[0];
+  if (names.length <= 20) {
+    return `${names.slice(0, -1).join(', ')}, & ${names[names.length - 1]}`;
+  }
+  // APA 7: 21+ authors - first 19, an ellipsis, then the final author.
+  return `${names.slice(0, 19).join(', ')}, ... ${names[names.length - 1]}`;
+}
+
+function formatAuthorsMLA(authors: SourceAuthor[]): string {
+  if (authors.length === 0) return '';
+  if (authors.length === 1) return lastFirst(authors[0]);
+  if (authors.length === 2) return `${lastFirst(authors[0])}, and ${firstLast(authors[1])}`;
+  return `${lastFirst(authors[0])}, et al.`;
+}
+
+function formatAuthorsChicago(authors: SourceAuthor[]): string {
+  if (authors.length === 0) return '';
+  if (authors.length === 1) return lastFirst(authors[0]);
+  const first = lastFirst(authors[0]);
+  if (authors.length <= 10) {
+    const rest = authors.slice(1).map(firstLast);
+    if (rest.length === 1) return `${first}, and ${rest[0]}`;
+    return `${first}, ${rest.slice(0, -1).join(', ')}, and ${rest[rest.length - 1]}`;
+  }
+  // Chicago: 11+ authors - list the first seven, then "et al."
+  const firstSeven = [first, ...authors.slice(1, 7).map(firstLast)];
+  return `${firstSeven.join(', ')}, et al.`;
+}
+
+/** Joins already-punctuated segments, dropping any that are empty. */
+function join(segments: (string | undefined)[]): string {
+  return segments
+    .map((s) => (s ?? '').trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Appends a trailing period, unless the string already ends in one (an
+ * author list ending in an initial or "et al." already does) - avoids a
+ * double period like "Fischer, D..".
+ */
+function endSentence(s: string): string {
+  return s.endsWith('.') ? s : `${s}.`;
+}
+
+function formatAPA(source: Source): string {
+  const authors = formatAuthorsAPA(namedAuthors(source));
+  const year = trimmed(source.year);
+  const title = trimmed(source.title);
+
+  switch (source.type) {
+    case 'book':
+      return join([
+        authors && endSentence(authors),
+        year && `(${year}).`,
+        title && `${title}.`,
+        trimmed(source.publisher) && `${trimmed(source.publisher)}.`,
+      ]);
+    case 'website':
+      return join([
+        authors && endSentence(authors),
+        year && `(${year}).`,
+        title && `${title}.`,
+        trimmed(source.siteName) && `${trimmed(source.siteName)}.`,
+        trimmed(source.url),
+      ]);
+    case 'journal': {
+      const volIssue = trimmed(source.volume)
+        ? `${trimmed(source.volume)}${trimmed(source.issue) ? `(${trimmed(source.issue)})` : ''}`
+        : '';
+      return join([
+        authors && endSentence(authors),
+        year && `(${year}).`,
+        title && `${title}.`,
+        trimmed(source.journalName) &&
+          `${trimmed(source.journalName)}${volIssue ? `, ${volIssue}` : ''}${
+            trimmed(source.pages) ? `, ${trimmed(source.pages)}` : ''
+          }.`,
+      ]);
+    }
+    default:
+      return join([authors && endSentence(authors), year && `(${year}).`, title && `${title}.`]);
+  }
+}
+
+function formatMLA(source: Source): string {
+  const authors = formatAuthorsMLA(namedAuthors(source));
+  const year = trimmed(source.year);
+  const title = trimmed(source.title);
+
+  switch (source.type) {
+    case 'book':
+      return join([
+        authors && endSentence(authors),
+        title && `${title}.`,
+        trimmed(source.publisher) && `${trimmed(source.publisher)},`,
+        year && `${year}.`,
+      ]);
+    case 'website':
+      return join([
+        authors && endSentence(authors),
+        title && `"${title}."`,
+        trimmed(source.siteName) && `${trimmed(source.siteName)},`,
+        year && `${year},`,
+        trimmed(source.url) && `${trimmed(source.url)}.`,
+      ]);
+    case 'journal':
+      return join([
+        authors && endSentence(authors),
+        title && `"${title}."`,
+        trimmed(source.journalName) && `${trimmed(source.journalName)},`,
+        trimmed(source.volume) && `vol. ${trimmed(source.volume)},`,
+        trimmed(source.issue) && `no. ${trimmed(source.issue)},`,
+        year && `${year},`,
+        trimmed(source.pages) && `pp. ${trimmed(source.pages)}.`,
+      ]);
+    default:
+      return join([authors && endSentence(authors), title && `${title}.`, year && `${year}.`]);
+  }
+}
+
+function formatChicago(source: Source): string {
+  const authors = formatAuthorsChicago(namedAuthors(source));
+  const year = trimmed(source.year);
+  const title = trimmed(source.title);
+
+  switch (source.type) {
+    case 'book':
+      return join([
+        authors && endSentence(authors),
+        year && `${year}.`,
+        title && `${title}.`,
+        trimmed(source.publisher) && `${trimmed(source.publisher)}.`,
+      ]);
+    case 'website':
+      return join([
+        authors && endSentence(authors),
+        year && `${year}.`,
+        title && `"${title}."`,
+        trimmed(source.siteName) && `${trimmed(source.siteName)}.`,
+        trimmed(source.url) && `${trimmed(source.url)}.`,
+      ]);
+    case 'journal': {
+      const volIssue = trimmed(source.volume)
+        ? `${trimmed(source.volume)}${trimmed(source.issue) ? ` (${trimmed(source.issue)})` : ''}`
+        : '';
+      return join([
+        authors && endSentence(authors),
+        year && `${year}.`,
+        title && `"${title}."`,
+        trimmed(source.journalName) &&
+          `${trimmed(source.journalName)}${volIssue ? ` ${volIssue}` : ''}${
+            trimmed(source.pages) ? `: ${trimmed(source.pages)}` : ''
+          }.`,
+      ]);
+    }
+    default:
+      return join([authors && endSentence(authors), year && `${year}.`, title && `${title}.`]);
+  }
+}
+
+export function formatCitation(source: Source, style: CitationStyle): string {
+  switch (style) {
+    case 'apa':
+      return formatAPA(source);
+    case 'mla':
+      return formatMLA(source);
+    case 'chicago':
+      return formatChicago(source);
+  }
+}
+
+/**
+ * Alphabetizes sources by first author's last name (falling back to title
+ * when a source has no author), matching how each supported style's
+ * works-cited page sorts. Shared by the on-screen list and the copied
+ * bibliography so the two never disagree on order.
+ */
+export function sortSources(sources: Source[]): Source[] {
+  const sortKey = (s: Source): string => {
+    const first = namedAuthors(s)[0];
+    return (
+      first ? trimmed(first.lastName) || trimmed(first.firstName) : trimmed(s.title)
+    ).toLowerCase();
+  };
+  return sources.slice().sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+}
+
+/** A copy-pasteable bibliography: every source formatted in the given style. */
+export function formatBibliography(sources: Source[], style: CitationStyle): string {
+  return sortSources(sources)
+    .map((s) => formatCitation(s, style))
+    .join('\n\n');
+}

--- a/src/lib/courses/__tests__/materials.test.ts
+++ b/src/lib/courses/__tests__/materials.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMaterials, sumMaterialCosts, sumAllCourseMaterialCosts } from '../materials';
+import type { Course } from '@/types/schedule';
+
+describe('normalizeMaterials', () => {
+  it('wraps legacy plain strings into MaterialItem objects', () => {
+    expect(normalizeMaterials(['Lab goggles'])).toEqual([{ name: 'Lab goggles' }]);
+  });
+
+  it('passes MaterialItem objects through unchanged', () => {
+    const item = { name: 'Textbook', cost: 89.99 };
+    expect(normalizeMaterials([item])).toEqual([item]);
+  });
+
+  it('handles a mix of legacy strings and new objects in the same list', () => {
+    expect(normalizeMaterials(['Lab goggles', { name: 'Textbook', cost: 89.99 }])).toEqual([
+      { name: 'Lab goggles' },
+      { name: 'Textbook', cost: 89.99 },
+    ]);
+  });
+
+  it('returns an empty array for undefined or non-array input', () => {
+    expect(normalizeMaterials(undefined)).toEqual([]);
+    expect(normalizeMaterials(null)).toEqual([]);
+  });
+});
+
+describe('sumMaterialCosts', () => {
+  it('sums only materials that have a cost recorded', () => {
+    const materials = [
+      { name: 'Textbook', cost: 89.99 },
+      { name: 'Lab goggles', cost: 12.5 },
+      { name: 'Free syllabus PDF' },
+    ];
+    expect(sumMaterialCosts(materials)).toBeCloseTo(102.49);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(sumMaterialCosts([])).toBe(0);
+  });
+});
+
+describe('sumAllCourseMaterialCosts', () => {
+  it('sums costs across multiple courses, normalizing legacy strings along the way', () => {
+    // Deliberately simulates a pre-cost-field Firestore document still
+    // holding a plain string entry - normalizeMaterials() is what makes
+    // this safe to read despite the stricter MaterialItem[] type.
+    const courses = [
+      { materials: [{ name: 'Textbook', cost: 89.99 }, 'Lab goggles'] },
+      { materials: [{ name: 'Calculator', cost: 120 }] },
+      { materials: undefined },
+    ] as unknown as Pick<Course, 'materials'>[];
+    expect(sumAllCourseMaterialCosts(courses)).toBeCloseTo(209.99);
+  });
+});

--- a/src/lib/courses/materials.ts
+++ b/src/lib/courses/materials.ts
@@ -1,0 +1,25 @@
+import type { Course, MaterialItem } from '@/types/schedule';
+
+/**
+ * Reads a course's materials safely regardless of whether they're the
+ * current `MaterialItem` shape or a plain string left over from before the
+ * `cost` field existed. Every call site should read materials through this
+ * rather than assuming `course.materials` is already normalized.
+ */
+export function normalizeMaterials(materials: unknown): MaterialItem[] {
+  if (!Array.isArray(materials)) return [];
+  return materials.map((m) => (typeof m === 'string' ? { name: m } : (m as MaterialItem)));
+}
+
+/** Sums the recorded costs for one course's materials, skipping any without a cost. */
+export function sumMaterialCosts(materials: MaterialItem[]): number {
+  return materials.reduce((sum, m) => sum + (m.cost ?? 0), 0);
+}
+
+/** Sums material costs across every given course - the "semester total". */
+export function sumAllCourseMaterialCosts(courses: Pick<Course, 'materials'>[]): number {
+  return courses.reduce(
+    (sum, course) => sum + sumMaterialCosts(normalizeMaterials(course.materials)),
+    0,
+  );
+}

--- a/src/lib/firebase/client.ts
+++ b/src/lib/firebase/client.ts
@@ -1,6 +1,6 @@
 import { initializeApp, getApps, getApp, FirebaseApp } from 'firebase/app';
 import { getAuth, Auth, connectAuthEmulator } from 'firebase/auth';
-import { getFirestore, Firestore, connectFirestoreEmulator } from 'firebase/firestore';
+import { initializeFirestore, Firestore, connectFirestoreEmulator } from 'firebase/firestore';
 import { getStorage, FirebaseStorage, connectStorageEmulator } from 'firebase/storage';
 
 const firebaseConfig = {
@@ -29,7 +29,12 @@ if (firebaseConfig.apiKey) {
   auth = getAuth(app);
 
   const databaseId = getFirestoreDatabaseId(process.env.NEXT_PUBLIC_FIRESTORE_DATABASE_ID);
-  db = databaseId ? getFirestore(app, databaseId) : getFirestore(app);
+  // Auto-detect long polling: some networks (corporate proxies, sandboxed
+  // containers) silently break Firestore's default streaming WebChannel
+  // connection, surfacing as a hung "Could not reach Cloud Firestore
+  // backend" with no application-visible error. This only changes behavior
+  // when streaming actually fails, falling back to plain long-polling.
+  db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true }, databaseId);
 
   storage = getStorage(app);
 

--- a/src/lib/firestore/__tests__/rules.spec.ts
+++ b/src/lib/firestore/__tests__/rules.spec.ts
@@ -68,6 +68,10 @@ const ownedDocPaths: Array<{ label: string; path: (uid: string) => string }> = [
     label: 'contact (users/{uid}/contacts/{id})',
     path: (uid) => `users/${uid}/contacts/contact-1`,
   },
+  {
+    label: 'flashcard (users/{uid}/flashcards/{id})',
+    path: (uid) => `users/${uid}/flashcards/card-1`,
+  },
 ];
 
 describe('firestore.rules: owner-only access', () => {
@@ -123,6 +127,7 @@ describe('firestore.rules: cross-user collection queries', () => {
     { label: 'courses', path: (uid) => `users/${uid}/courses` },
     { label: 'scheduleItems', path: (uid) => `users/${uid}/scheduleItems` },
     { label: 'contacts', path: (uid) => `users/${uid}/contacts` },
+    { label: 'flashcards', path: (uid) => `users/${uid}/flashcards` },
   ];
 
   describe.each(collectionPaths)("listing another user's $label", ({ path: collectionPath }) => {

--- a/src/lib/firestore/__tests__/rules.spec.ts
+++ b/src/lib/firestore/__tests__/rules.spec.ts
@@ -72,6 +72,14 @@ const ownedDocPaths: Array<{ label: string; path: (uid: string) => string }> = [
     label: 'flashcard (users/{uid}/flashcards/{id})',
     path: (uid) => `users/${uid}/flashcards/card-1`,
   },
+  {
+    label: 'quiz (users/{uid}/quizzes/{id})',
+    path: (uid) => `users/${uid}/quizzes/quiz-1`,
+  },
+  {
+    label: 'quiz attempt (users/{uid}/quizAttempts/{id})',
+    path: (uid) => `users/${uid}/quizAttempts/attempt-1`,
+  },
 ];
 
 describe('firestore.rules: owner-only access', () => {
@@ -128,6 +136,8 @@ describe('firestore.rules: cross-user collection queries', () => {
     { label: 'scheduleItems', path: (uid) => `users/${uid}/scheduleItems` },
     { label: 'contacts', path: (uid) => `users/${uid}/contacts` },
     { label: 'flashcards', path: (uid) => `users/${uid}/flashcards` },
+    { label: 'quizzes', path: (uid) => `users/${uid}/quizzes` },
+    { label: 'quizAttempts', path: (uid) => `users/${uid}/quizAttempts` },
   ];
 
   describe.each(collectionPaths)("listing another user's $label", ({ path: collectionPath }) => {

--- a/src/lib/firestore/flashcards.ts
+++ b/src/lib/firestore/flashcards.ts
@@ -1,0 +1,74 @@
+import { doc, setDoc, deleteDoc, writeBatch } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { AppAction } from '@/context/AppStateContext';
+import type { Flashcard } from '@/types/flashcard';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+export async function createFlashcard(
+  userId: string,
+  card: Flashcard,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'ADD_FLASHCARD', payload: card });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'flashcards', card.id), card);
+  } catch (err) {
+    dispatch({ type: 'REMOVE_FLASHCARD', payload: card.id });
+    throw err;
+  }
+}
+
+/** Writes an AI-generated deck in one atomic batch - a partial network
+ * failure can't leave half a deck saved. */
+export async function createFlashcards(
+  userId: string,
+  cards: Flashcard[],
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  if (cards.length === 0) return;
+  dispatch({ type: 'ADD_FLASHCARDS', payload: cards });
+  try {
+    const database = requireDb();
+    const batch = writeBatch(database);
+    cards.forEach((card) => {
+      batch.set(doc(database, 'users', userId, 'flashcards', card.id), card);
+    });
+    await batch.commit();
+  } catch (err) {
+    cards.forEach((card) => dispatch({ type: 'REMOVE_FLASHCARD', payload: card.id }));
+    throw err;
+  }
+}
+
+export async function updateFlashcard(
+  userId: string,
+  previousCard: Flashcard,
+  updatedCard: Flashcard,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'UPDATE_FLASHCARD', payload: updatedCard });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'flashcards', updatedCard.id), updatedCard);
+  } catch (err) {
+    dispatch({ type: 'UPDATE_FLASHCARD', payload: previousCard });
+    throw err;
+  }
+}
+
+export async function deleteFlashcard(
+  userId: string,
+  card: Flashcard,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'REMOVE_FLASHCARD', payload: card.id });
+  try {
+    await deleteDoc(doc(requireDb(), 'users', userId, 'flashcards', card.id));
+  } catch (err) {
+    dispatch({ type: 'ADD_FLASHCARD', payload: card });
+    throw err;
+  }
+}

--- a/src/lib/firestore/quizzes.ts
+++ b/src/lib/firestore/quizzes.ts
@@ -1,0 +1,51 @@
+import { doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { AppAction } from '@/context/AppStateContext';
+import type { Quiz, QuizAttempt } from '@/types/quiz';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+export async function createQuiz(
+  userId: string,
+  quiz: Quiz,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'ADD_QUIZ', payload: quiz });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'quizzes', quiz.id), quiz);
+  } catch (err) {
+    dispatch({ type: 'REMOVE_QUIZ', payload: quiz.id });
+    throw err;
+  }
+}
+
+export async function deleteQuiz(
+  userId: string,
+  quiz: Quiz,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'REMOVE_QUIZ', payload: quiz.id });
+  try {
+    await deleteDoc(doc(requireDb(), 'users', userId, 'quizzes', quiz.id));
+  } catch (err) {
+    dispatch({ type: 'ADD_QUIZ', payload: quiz });
+    throw err;
+  }
+}
+
+export async function createQuizAttempt(
+  userId: string,
+  attempt: QuizAttempt,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'ADD_QUIZ_ATTEMPT', payload: attempt });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'quizAttempts', attempt.id), attempt);
+  } catch (err) {
+    dispatch({ type: 'REMOVE_QUIZ_ATTEMPT', payload: attempt.id });
+    throw err;
+  }
+}

--- a/src/lib/firestore/sources.ts
+++ b/src/lib/firestore/sources.ts
@@ -1,0 +1,56 @@
+import { doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { AppAction } from '@/context/AppStateContext';
+import type { Source } from '@/types/source';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+/**
+ * Same optimistic-dispatch-then-write, rollback-on-failure pattern as
+ * lib/firestore/contacts.ts.
+ */
+export async function createSource(
+  userId: string,
+  source: Source,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'ADD_SOURCE', payload: source });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'sources', source.id), source);
+  } catch (err) {
+    dispatch({ type: 'REMOVE_SOURCE', payload: source.id });
+    throw err;
+  }
+}
+
+export async function updateSource(
+  userId: string,
+  previousSource: Source,
+  updatedSource: Source,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'UPDATE_SOURCE', payload: updatedSource });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'sources', updatedSource.id), updatedSource);
+  } catch (err) {
+    dispatch({ type: 'UPDATE_SOURCE', payload: previousSource });
+    throw err;
+  }
+}
+
+export async function deleteSource(
+  userId: string,
+  source: Source,
+  dispatch: React.Dispatch<AppAction>,
+): Promise<void> {
+  dispatch({ type: 'REMOVE_SOURCE', payload: source.id });
+  try {
+    await deleteDoc(doc(requireDb(), 'users', userId, 'sources', source.id));
+  } catch (err) {
+    dispatch({ type: 'ADD_SOURCE', payload: source });
+    throw err;
+  }
+}

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -11,6 +11,7 @@ import { reconcileScheduleItems } from '@/lib/firestore/scheduleItems';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
 import type { Flashcard } from '@/types/flashcard';
+import type { Quiz, QuizAttempt } from '@/types/quiz';
 import { mockCourses, mockScheduleItems } from '@/lib/mock-data';
 
 /**
@@ -93,6 +94,23 @@ export function useFirestoreSync() {
       },
       onSyncError('flashcards'),
     );
+    const unsubQuizzes = onSnapshot(
+      collection(db, 'users', user.uid, 'quizzes'),
+      (snapshot) => {
+        dispatch({ type: 'SET_QUIZZES', payload: snapshot.docs.map((d) => d.data() as Quiz) });
+      },
+      onSyncError('quizzes'),
+    );
+    const unsubQuizAttempts = onSnapshot(
+      collection(db, 'users', user.uid, 'quizAttempts'),
+      (snapshot) => {
+        dispatch({
+          type: 'SET_QUIZ_ATTEMPTS',
+          payload: snapshot.docs.map((d) => d.data() as QuizAttempt),
+        });
+      },
+      onSyncError('quiz attempts'),
+    );
     // Same doc ProfileView writes to via updateUserPreferences - kept here
     // instead of a separate listener per consumer, so a change (from this
     // device or another) reaches every view that reads state.preferences
@@ -112,6 +130,8 @@ export function useFirestoreSync() {
       unsubContacts();
       unsubSources();
       unsubFlashcards();
+      unsubQuizzes();
+      unsubQuizAttempts();
       unsubPreferences();
     };
   }, [user, dispatch, showError]);

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -9,6 +9,7 @@ import { useToast } from '@/components/ui/Toast';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 import { reconcileScheduleItems } from '@/lib/firestore/scheduleItems';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
+import type { Source } from '@/types/source';
 import { mockCourses, mockScheduleItems } from '@/lib/mock-data';
 
 /**
@@ -74,6 +75,13 @@ export function useFirestoreSync() {
       },
       onSyncError('contacts'),
     );
+    const unsubSources = onSnapshot(
+      collection(db, 'users', user.uid, 'sources'),
+      (snapshot) => {
+        dispatch({ type: 'SET_SOURCES', payload: snapshot.docs.map((d) => d.data() as Source) });
+      },
+      onSyncError('sources'),
+    );
     // Same doc ProfileView writes to via updateUserPreferences - kept here
     // instead of a separate listener per consumer, so a change (from this
     // device or another) reaches every view that reads state.preferences
@@ -91,6 +99,7 @@ export function useFirestoreSync() {
       unsubCourses();
       unsubItems();
       unsubContacts();
+      unsubSources();
       unsubPreferences();
     };
   }, [user, dispatch, showError]);

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -10,6 +10,7 @@ import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/prefe
 import { reconcileScheduleItems } from '@/lib/firestore/scheduleItems';
 import type { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
+import type { Flashcard } from '@/types/flashcard';
 import { mockCourses, mockScheduleItems } from '@/lib/mock-data';
 
 /**
@@ -82,6 +83,16 @@ export function useFirestoreSync() {
       },
       onSyncError('sources'),
     );
+    const unsubFlashcards = onSnapshot(
+      collection(db, 'users', user.uid, 'flashcards'),
+      (snapshot) => {
+        dispatch({
+          type: 'SET_FLASHCARDS',
+          payload: snapshot.docs.map((d) => d.data() as Flashcard),
+        });
+      },
+      onSyncError('flashcards'),
+    );
     // Same doc ProfileView writes to via updateUserPreferences - kept here
     // instead of a separate listener per consumer, so a change (from this
     // device or another) reaches every view that reads state.preferences
@@ -100,6 +111,7 @@ export function useFirestoreSync() {
       unsubItems();
       unsubContacts();
       unsubSources();
+      unsubFlashcards();
       unsubPreferences();
     };
   }, [user, dispatch, showError]);

--- a/src/lib/flashcards/__tests__/sm2.test.ts
+++ b/src/lib/flashcards/__tests__/sm2.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { applySM2, isCardDue, SM2_DEFAULTS, type SM2State } from '../sm2';
+
+describe('applySM2', () => {
+  it('sets a 1-day interval on the first "good" review', () => {
+    const result = applySM2(SM2_DEFAULTS, 'good', new Date('2026-09-03'));
+    expect(result.interval).toBe(1);
+    expect(result.repetitions).toBe(1);
+    expect(result.dueDate).toBe('2026-09-04');
+  });
+
+  it('sets a 6-day interval on the second consecutive "good" review', () => {
+    const first = applySM2(SM2_DEFAULTS, 'good', new Date('2026-09-03'));
+    const second = applySM2(first, 'good', new Date('2026-09-04'));
+    expect(second.interval).toBe(6);
+    expect(second.repetitions).toBe(2);
+    expect(second.dueDate).toBe('2026-09-10');
+  });
+
+  it('multiplies the interval by the ease factor from the third review onward', () => {
+    const first = applySM2(SM2_DEFAULTS, 'good', new Date('2026-09-03'));
+    const second = applySM2(first, 'good', new Date('2026-09-04'));
+    const third = applySM2(second, 'good', new Date('2026-09-10'));
+    expect(third.interval).toBe(Math.round(6 * second.easeFactor));
+    expect(third.repetitions).toBe(3);
+  });
+
+  it('resets repetitions and interval to 1 day on "again" (a lapse)', () => {
+    const first = applySM2(SM2_DEFAULTS, 'good', new Date('2026-09-03'));
+    const second = applySM2(first, 'good', new Date('2026-09-04'));
+    const lapsed = applySM2(second, 'again', new Date('2026-09-10'));
+    expect(lapsed.repetitions).toBe(0);
+    expect(lapsed.interval).toBe(1);
+    expect(lapsed.dueDate).toBe('2026-09-11');
+  });
+
+  it('treats "hard" as a lapse too (quality below the SM-2 pass threshold)', () => {
+    const result = applySM2(SM2_DEFAULTS, 'hard', new Date('2026-09-03'));
+    expect(result.repetitions).toBe(0);
+    expect(result.interval).toBe(1);
+  });
+
+  it('increases the ease factor on "easy" reviews', () => {
+    const result = applySM2(SM2_DEFAULTS, 'easy', new Date('2026-09-03'));
+    expect(result.easeFactor).toBeCloseTo(2.6);
+  });
+
+  it('keeps the ease factor unchanged on "good" reviews', () => {
+    const result = applySM2(SM2_DEFAULTS, 'good', new Date('2026-09-03'));
+    expect(result.easeFactor).toBeCloseTo(2.5);
+  });
+
+  it('never lets the ease factor drop below 1.3, even after repeated lapses', () => {
+    let state: SM2State = SM2_DEFAULTS;
+    for (let i = 0; i < 5; i++) {
+      state = applySM2(state, 'again', new Date('2026-09-03'));
+    }
+    expect(state.easeFactor).toBeGreaterThanOrEqual(1.3);
+  });
+});
+
+describe('isCardDue', () => {
+  it('is due when the due date is today', () => {
+    expect(isCardDue({ dueDate: '2026-09-03' }, new Date('2026-09-03'))).toBe(true);
+  });
+
+  it('is due when the due date is in the past', () => {
+    expect(isCardDue({ dueDate: '2026-09-01' }, new Date('2026-09-03'))).toBe(true);
+  });
+
+  it('is not due when the due date is in the future', () => {
+    expect(isCardDue({ dueDate: '2026-09-10' }, new Date('2026-09-03'))).toBe(false);
+  });
+});

--- a/src/lib/flashcards/sm2.ts
+++ b/src/lib/flashcards/sm2.ts
@@ -1,0 +1,70 @@
+import type { Flashcard } from '@/types/flashcard';
+import { toDayKey } from '@/lib/calendar/dates';
+
+/** The four self-rating buttons a review session shows, mapped to the
+ * quality scores (0-5) the classic SM-2 algorithm expects. "Again" and
+ * "Hard" both count as a lapse (quality < 3) - only "Good" and "Easy" grow
+ * the interval. */
+export type ReviewRating = 'again' | 'hard' | 'good' | 'easy';
+
+const RATING_QUALITY: Record<ReviewRating, number> = {
+  again: 0,
+  hard: 2,
+  good: 4,
+  easy: 5,
+};
+
+export const SM2_DEFAULTS = {
+  interval: 0,
+  repetitions: 0,
+  easeFactor: 2.5,
+} as const;
+
+export interface SM2State {
+  interval: number;
+  repetitions: number;
+  easeFactor: number;
+}
+
+/**
+ * Applies one review to a card's SM-2 state, returning the next interval,
+ * repetition count, ease factor, and due date. Reference implementation:
+ * https://en.wikipedia.org/wiki/SuperMemo#Description_of_SM-2_algorithm
+ */
+export function applySM2(
+  state: SM2State,
+  rating: ReviewRating,
+  reviewedOn: Date = new Date(),
+): SM2State & { dueDate: string } {
+  const quality = RATING_QUALITY[rating];
+  let { repetitions, easeFactor } = state;
+  let interval: number;
+
+  if (quality < 3) {
+    repetitions = 0;
+    interval = 1;
+  } else {
+    if (repetitions === 0) {
+      interval = 1;
+    } else if (repetitions === 1) {
+      interval = 6;
+    } else {
+      interval = Math.round(state.interval * easeFactor);
+    }
+    repetitions += 1;
+  }
+
+  easeFactor = easeFactor + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
+  easeFactor = Math.max(easeFactor, 1.3);
+
+  const due = new Date(reviewedOn);
+  due.setDate(due.getDate() + interval);
+
+  return { interval, repetitions, easeFactor, dueDate: toDayKey(due) };
+}
+
+/** A card is due once its dueDate is today or earlier (never created without
+ * ever being reviewed and not yet due). */
+export function isCardDue(card: Pick<Flashcard, 'dueDate'>, today: Date = new Date()): boolean {
+  return card.dueDate <= toDayKey(today);
+}

--- a/src/lib/focus/__tests__/studyStreak.test.ts
+++ b/src/lib/focus/__tests__/studyStreak.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { getSessionDateSet, computeCurrentStreak, computeHeatmapDays } from '../studyStreak';
+import type { PomodoroSession } from '../pomodoroSessions';
+
+function session(dateKey: string): PomodoroSession {
+  return { startedAt: `${dateKey}T14:30:00.000Z`, duration: 1500 };
+}
+
+describe('getSessionDateSet', () => {
+  it('collapses multiple sessions on the same day to one entry', () => {
+    const sessions = [session('2026-09-01'), session('2026-09-01'), session('2026-09-02')];
+    const set = getSessionDateSet(sessions);
+    expect(set.size).toBe(2);
+    expect(set.has('2026-09-01')).toBe(true);
+    expect(set.has('2026-09-02')).toBe(true);
+  });
+
+  it('returns an empty set for no sessions', () => {
+    expect(getSessionDateSet([]).size).toBe(0);
+  });
+});
+
+describe('computeCurrentStreak', () => {
+  it('counts consecutive days ending today', () => {
+    const dateSet = new Set(['2026-09-01', '2026-09-02', '2026-09-03']);
+    const today = new Date(2026, 8, 3); // Sep 3 2026, local
+    expect(computeCurrentStreak(dateSet, today)).toBe(3);
+  });
+
+  it('does not reset the streak just because today has no session yet', () => {
+    const dateSet = new Set(['2026-09-01', '2026-09-02']);
+    const today = new Date(2026, 8, 3); // today itself has no session
+    expect(computeCurrentStreak(dateSet, today)).toBe(2);
+  });
+
+  it('stops counting at the first gap', () => {
+    const dateSet = new Set(['2026-08-28', '2026-09-01', '2026-09-02', '2026-09-03']);
+    const today = new Date(2026, 8, 3);
+    // Aug 30/31 are missing, so the streak only reaches back to Sep 1
+    expect(computeCurrentStreak(dateSet, today)).toBe(3);
+  });
+
+  it('returns 0 when there is no session today or yesterday', () => {
+    const dateSet = new Set(['2026-08-20']);
+    const today = new Date(2026, 8, 3);
+    expect(computeCurrentStreak(dateSet, today)).toBe(0);
+  });
+
+  it('returns 0 for an empty history', () => {
+    expect(computeCurrentStreak(new Set(), new Date(2026, 8, 3))).toBe(0);
+  });
+});
+
+describe('computeHeatmapDays', () => {
+  it('returns the requested number of days, oldest first, ending today', () => {
+    const dateSet = new Set(['2026-09-03']);
+    const today = new Date(2026, 8, 3);
+    const days = computeHeatmapDays(dateSet, today, 5);
+    expect(days).toHaveLength(5);
+    expect(days.map((d) => d.dateKey)).toEqual([
+      '2026-08-30',
+      '2026-08-31',
+      '2026-09-01',
+      '2026-09-02',
+      '2026-09-03',
+    ]);
+    expect(days[days.length - 1].isToday).toBe(true);
+    expect(days[days.length - 1].active).toBe(true);
+    expect(days[0].active).toBe(false);
+  });
+
+  it('marks only days present in the date set as active', () => {
+    const dateSet = new Set(['2026-09-01', '2026-09-03']);
+    const today = new Date(2026, 8, 3);
+    const days = computeHeatmapDays(dateSet, today, 3);
+    expect(days.map((d) => d.active)).toEqual([true, false, true]);
+  });
+});

--- a/src/lib/focus/pomodoroSessions.ts
+++ b/src/lib/focus/pomodoroSessions.ts
@@ -1,0 +1,26 @@
+export interface PomodoroSession {
+  startedAt: string;
+  duration: number; // seconds
+  taskId?: string;
+}
+
+export const POMODORO_SESSIONS_STORAGE_KEY = 'syllabus-sense:pomodoro-sessions';
+
+export function loadSessions(): PomodoroSession[] {
+  try {
+    const raw =
+      typeof window !== 'undefined' ? localStorage.getItem(POMODORO_SESSIONS_STORAGE_KEY) : null;
+    return raw ? (JSON.parse(raw) as PomodoroSession[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveSession(session: PomodoroSession): void {
+  try {
+    const existing = loadSessions();
+    localStorage.setItem(POMODORO_SESSIONS_STORAGE_KEY, JSON.stringify([...existing, session]));
+  } catch {
+    // Silently ignore — localStorage may be unavailable (SSR, privacy mode).
+  }
+}

--- a/src/lib/focus/studyStreak.ts
+++ b/src/lib/focus/studyStreak.ts
@@ -1,0 +1,58 @@
+import { toDayKey, parseDayKey } from '@/lib/calendar/dates';
+import type { PomodoroSession } from '@/lib/focus/pomodoroSessions';
+
+/** Distinct local calendar days on which at least one focus session was
+ * completed - a day with three sessions still only counts once toward a
+ * streak. */
+export function getSessionDateSet(sessions: PomodoroSession[]): Set<string> {
+  return new Set(sessions.map((s) => toDayKey(s.startedAt)));
+}
+
+function addDays(dayKey: string, delta: number): string {
+  const d = parseDayKey(dayKey);
+  d.setDate(d.getDate() + delta);
+  return toDayKey(d);
+}
+
+/**
+ * Current consecutive-day streak of completed focus sessions, ending today.
+ *
+ * If today has no session yet, the streak isn't broken until the day is
+ * actually over - counting starts from yesterday instead, so a student who
+ * hasn't opened the timer yet this morning doesn't see their streak reset
+ * to 0 before they've had a chance to study.
+ */
+export function computeCurrentStreak(dateSet: Set<string>, today: Date = new Date()): number {
+  let cursor = toDayKey(today);
+  if (!dateSet.has(cursor)) {
+    cursor = addDays(cursor, -1);
+  }
+  let streak = 0;
+  while (dateSet.has(cursor)) {
+    streak += 1;
+    cursor = addDays(cursor, -1);
+  }
+  return streak;
+}
+
+export interface HeatmapDay {
+  dateKey: string;
+  active: boolean;
+  isToday: boolean;
+}
+
+/** The last `days` calendar days (oldest first, ending today) with whether
+ * each had a completed session - feeds a small calendar-heatmap grid. */
+export function computeHeatmapDays(
+  dateSet: Set<string>,
+  today: Date = new Date(),
+  days = 28,
+): HeatmapDay[] {
+  const todayKey = toDayKey(today);
+  const result: HeatmapDay[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const dateKey = addDays(todayKey, -i);
+    result.push({ dateKey, active: dateSet.has(dateKey), isToday: dateKey === todayKey });
+  }
+  return result;
+}

--- a/src/lib/planner/__tests__/semesterHeatmap.test.ts
+++ b/src/lib/planner/__tests__/semesterHeatmap.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { computeSemesterHeatmap } from '../semesterHeatmap';
+import type { ScheduleItem } from '@/types/schedule';
+
+function item(overrides: Partial<ScheduleItem> & Pick<ScheduleItem, 'dueDate'>): ScheduleItem {
+  return {
+    id: overrides.id ?? `item-${Math.random()}`,
+    courseId: 'course-1',
+    title: 'Test item',
+    type: 'assignment',
+    completed: false,
+    ...overrides,
+  };
+}
+
+describe('computeSemesterHeatmap', () => {
+  it('returns an empty array when there are no dated items', () => {
+    expect(computeSemesterHeatmap([])).toEqual([]);
+  });
+
+  it('spans from the earliest to the latest due date, filling gap days with zero hours', () => {
+    const days = computeSemesterHeatmap([
+      item({ dueDate: '2026-09-01', estimatedHours: 1 }),
+      item({ dueDate: '2026-09-04', estimatedHours: 1 }),
+    ]);
+    expect(days.map((d) => d.dateKey)).toEqual([
+      '2026-09-01',
+      '2026-09-02',
+      '2026-09-03',
+      '2026-09-04',
+    ]);
+    expect(days[1].hours).toBe(0);
+    expect(days[1].level).toBe('low');
+  });
+
+  it('sums multiple items due the same day', () => {
+    const days = computeSemesterHeatmap([
+      item({ dueDate: '2026-09-01', estimatedHours: 2 }),
+      item({ dueDate: '2026-09-01', estimatedHours: 3 }),
+    ]);
+    expect(days).toHaveLength(1);
+    expect(days[0].hours).toBe(5);
+    expect(days[0].level).toBe('medium');
+  });
+
+  it('defaults an exam with no estimatedHours to 2 hours and everything else to 1', () => {
+    const days = computeSemesterHeatmap([
+      item({ dueDate: '2026-09-01', type: 'exam' }),
+      item({ dueDate: '2026-09-02', type: 'assignment' }),
+    ]);
+    expect(days[0].hours).toBe(2);
+    expect(days[1].hours).toBe(1);
+  });
+
+  it('counts a completed item toward its due date the same as an incomplete one', () => {
+    const days = computeSemesterHeatmap([
+      item({ dueDate: '2026-09-01', estimatedHours: 4, completed: true }),
+    ]);
+    expect(days[0].hours).toBe(4);
+  });
+
+  it('ignores items with no due date', () => {
+    const days = computeSemesterHeatmap([
+      item({ dueDate: '', estimatedHours: 4 }),
+      item({ dueDate: '2026-09-01', estimatedHours: 1 }),
+    ]);
+    expect(days).toHaveLength(1);
+    expect(days[0].dateKey).toBe('2026-09-01');
+  });
+});

--- a/src/lib/planner/semesterHeatmap.ts
+++ b/src/lib/planner/semesterHeatmap.ts
@@ -1,0 +1,56 @@
+import { toDayKey, parseDayKey } from '@/lib/calendar/dates';
+import { getWorkloadLevel } from '@/lib/workload/dailyLoad';
+import type { WorkloadLevel } from '@/types/schedule';
+import type { ScheduleItem } from '@/types/schedule';
+
+export interface SemesterHeatmapDay {
+  dateKey: string;
+  hours: number;
+  level: WorkloadLevel;
+}
+
+/** Same estimate `calculateWorkloadBreakdown` uses for an item with no
+ * explicit `estimatedHours`: exams default to 2 hours, everything else to 1 -
+ * kept in sync intentionally so a day's heatmap color matches what the rest
+ * of the planner already implies about that day's load. */
+function estimateHours(item: ScheduleItem): number {
+  if (item.estimatedHours) return item.estimatedHours;
+  return item.type === 'exam' ? 2 : 1;
+}
+
+/**
+ * A day-by-day workload heatmap spanning every due date the student has on
+ * record, from the earliest to the latest - not scoped to a "current term"
+ * (ScheduleItem carries no term of its own; Course.term is free text with no
+ * parseable start/end date to bound a range by). In practice a student's due
+ * dates cluster tightly around the courses they're actually taking, so the
+ * unscoped range still reads as "this semester" for the common case.
+ *
+ * Every item due on a day counts toward that day's total regardless of
+ * completion status - the heatmap answers "how loaded was/is this day",
+ * which doesn't change once the deadline passes.
+ */
+export function computeSemesterHeatmap(scheduleItems: ScheduleItem[]): SemesterHeatmapDay[] {
+  const dayTotals = new Map<string, number>();
+  for (const item of scheduleItems) {
+    if (!item.dueDate) continue;
+    const key = toDayKey(item.dueDate);
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + estimateHours(item));
+  }
+
+  const sortedKeys = Array.from(dayTotals.keys()).sort();
+  if (sortedKeys.length === 0) return [];
+
+  const start = parseDayKey(sortedKeys[0]);
+  const end = parseDayKey(sortedKeys[sortedKeys.length - 1]);
+
+  const days: SemesterHeatmapDay[] = [];
+  const cursor = new Date(start);
+  while (cursor.getTime() <= end.getTime()) {
+    const dateKey = toDayKey(cursor);
+    const hours = dayTotals.get(dateKey) ?? 0;
+    days.push({ dateKey, hours, level: getWorkloadLevel(hours) });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return days;
+}

--- a/src/lib/validation/course.ts
+++ b/src/lib/validation/course.ts
@@ -27,6 +27,7 @@ export const courseFormSchema = z.object({
   icon: z.string().min(1),
   modality: z.union([z.literal('in-person'), z.literal('online'), z.literal('hybrid')]).optional(),
   meetingTimes: z.array(meetingTimeSchema).optional(),
+  skipDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use YYYY-MM-DD')).optional(),
 });
 
 export type CourseFormValues = z.infer<typeof courseFormSchema>;

--- a/src/lib/validation/scheduleItem.ts
+++ b/src/lib/validation/scheduleItem.ts
@@ -18,6 +18,14 @@ export const scheduleItemFormSchema = z.object({
       (v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0 && Number(v) <= 100),
       'Enter 0-100',
     ),
+  gradeWeight: z
+    .string()
+    .optional()
+    .refine(
+      (v) => !v || (!Number.isNaN(Number(v)) && Number(v) >= 0 && Number(v) <= 100),
+      'Enter 0-100',
+    ),
+  gradeCategory: z.string().max(60, 'Keep it under 60 characters').optional(),
 });
 
 export type ScheduleItemFormValues = z.infer<typeof scheduleItemFormSchema>;

--- a/src/lib/validation/scheduleItem.ts
+++ b/src/lib/validation/scheduleItem.ts
@@ -26,6 +26,7 @@ export const scheduleItemFormSchema = z.object({
       'Enter 0-100',
     ),
   gradeCategory: z.string().max(60, 'Keep it under 60 characters').optional(),
+  assignedTo: z.string().max(60, 'Keep it under 60 characters').optional(),
 });
 
 export type ScheduleItemFormValues = z.infer<typeof scheduleItemFormSchema>;

--- a/src/types/flashcard.ts
+++ b/src/types/flashcard.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * A single front/back study card, scheduled with the SM-2 spaced-repetition
+ * algorithm (lib/flashcards/sm2.ts). `interval`/`repetitions`/`easeFactor`
+ * are SM-2's own state, persisted so a review session picks up exactly
+ * where the student left off.
+ */
+export interface Flashcard {
+  id: string;
+  courseId: string;
+  front: string;
+  back: string;
+  /** Days until the next review, per SM-2. */
+  interval: number;
+  /** Consecutive correct ("Hard" or better) reviews in a row. */
+  repetitions: number;
+  /** SM-2 ease factor, starts at 2.5 and never drops below 1.3. */
+  easeFactor: number;
+  /** ISO date (YYYY-MM-DD) - the card is due for review on or after this date. */
+  dueDate: string;
+  lastReviewedAt?: string;
+  createdAt: string;
+  /** Which syllabus this card was generated from, if AI-generated. */
+  sourceFileName?: string;
+}
+
+/** One card as returned by the flashcard-generation API, before SM-2 state
+ * or IDs are attached. */
+export const generatedFlashcardSchema = z.object({
+  front: z.string().min(1),
+  back: z.string().min(1),
+});
+
+export const generatedFlashcardsSchema = z.array(generatedFlashcardSchema).min(1);
+
+export type GeneratedFlashcard = z.infer<typeof generatedFlashcardSchema>;

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+/**
+ * A single AI-generated multiple-choice question. `correctIndex` points into
+ * `choices` (always length 4) - kept as an index rather than the answer text
+ * so shuffling/re-rendering never has to re-match strings.
+ */
+export interface QuizQuestion {
+  question: string;
+  choices: string[];
+  correctIndex: number;
+  explanation: string;
+}
+
+export interface Quiz {
+  id: string;
+  courseId: string;
+  questions: QuizQuestion[];
+  createdAt: string;
+  sourceFileName?: string;
+}
+
+/** One completed run through a quiz - kept even after the quiz itself is
+ * regenerated/deleted, so a course's score history survives a "make me a
+ * fresh quiz" click. */
+export interface QuizAttempt {
+  id: string;
+  quizId: string;
+  courseId: string;
+  score: number;
+  total: number;
+  completedAt: string;
+}
+
+export const generatedQuizQuestionSchema = z.object({
+  question: z.string().min(1),
+  choices: z.array(z.string().min(1)).length(4),
+  correctIndex: z.number().int().min(0).max(3),
+  explanation: z.string().min(1),
+});
+
+export const generatedQuizQuestionsSchema = z.array(generatedQuizQuestionSchema).min(1);
+
+export type GeneratedQuizQuestion = z.infer<typeof generatedQuizQuestionSchema>;

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -171,6 +171,12 @@ export interface ScheduleItem {
   gradeWeight?: number;
   /** Grading category this item falls under, e.g. 'Homework', 'Exam' */
   gradeCategory?: string;
+  /** Free-text name of who owns this sub-task on a group project - a
+   * private label only the signed-in user sees, not a shared assignment
+   * system. Lets a chunked group project ("Literature review", "Data
+   * collection", ...) show who's doing what without any new sharing
+   * infrastructure. */
+  assignedTo?: string;
   /** Whether this item was entered manually or created from AI syllabus extraction. Defaults to 'manual' when absent. */
   source?: DataSource;
   /** How confident the AI extractor was in `dueDate`, when `source` is 'ai'.

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -20,6 +20,16 @@ export interface MeetingTime {
 }
 
 /**
+ * A required/optional course material (textbook, calculator, supplies),
+ * with an optional cost so a semester's spending can be totaled up.
+ */
+export interface MaterialItem {
+  name: string;
+  /** Price in whole currency units (e.g. 89.99), not cents. */
+  cost?: number;
+}
+
+/**
  * Represents a student's course.
  */
 export interface Course {
@@ -48,8 +58,11 @@ export interface Course {
   /** Recurring weekly meeting times, e.g. "MWF 9:00-10:15" */
   meetingTimes?: MeetingTime[];
   /** General required/optional materials from the syllabus (textbook,
-   * calculator, supplies) that aren't tied to a specific due date. */
-  materials?: string[];
+   * calculator, supplies) that aren't tied to a specific due date. Older
+   * records may still hold plain strings from before the `cost` field
+   * existed - always read through normalizeMaterials() (lib/courses/
+   * materials.ts) rather than assuming every entry is a MaterialItem. */
+  materials?: MaterialItem[];
   /** ISO dates (YYYY-MM-DD) on which recurring meetings should NOT render -
    * holidays and breaks called out in the syllabus (e.g. "1/19 - HOLIDAY").
    * Only suppresses `meetingTimes` occurrences; never affects `ScheduleItem`

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -83,7 +83,7 @@ export interface Course {
 }
 
 /** Whether a contact is the instructor of record or a teaching assistant. */
-export type ContactRole = 'professor' | 'ta';
+export type ContactRole = 'professor' | 'ta' | 'classmate';
 
 /**
  * A course-affiliated professor or TA, usually populated from syllabus

--- a/src/types/source.ts
+++ b/src/types/source.ts
@@ -1,0 +1,43 @@
+/**
+ * A research source a student is tracking for a course, formatted into a
+ * bibliography on demand. Deliberately scoped to the fields the three
+ * supported citation styles actually need - not a general-purpose
+ * bibliographic record.
+ */
+export type SourceType = 'book' | 'website' | 'journal' | 'other';
+
+export interface SourceAuthor {
+  firstName: string;
+  lastName: string;
+}
+
+export interface Source {
+  id: string;
+  courseId: string;
+  type: SourceType;
+  title: string;
+  authors: SourceAuthor[];
+  /** Publication year, kept as free text to allow "n.d." or a range. */
+  year?: string;
+  /** Book only. */
+  publisher?: string;
+  /** Journal article only. */
+  journalName?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  /** Website only. */
+  siteName?: string;
+  url?: string;
+  /** Website only, ISO date string (YYYY-MM-DD). */
+  accessedDate?: string;
+  notes?: string;
+}
+
+export type CitationStyle = 'apa' | 'mla' | 'chicago';
+
+export const CITATION_STYLE_LABEL: Record<CitationStyle, string> = {
+  apa: 'APA',
+  mla: 'MLA',
+  chicago: 'Chicago',
+};


### PR DESCRIPTION
## What this adds

Second of the three AI-pipeline features from the Phase 2 audit (Flashcards shipped as #225). A new **Practice Quizzes** section (`/quizzes`, in the sidebar and command palette) that:

- Generates 8-15 multiple-choice questions per course from that course's most recently uploaded syllabus, via the same Anthropic tool-call pipeline as `/api/syllabus/summarize` and `/api/syllabus/flashcards` (auth-checked storage path, PDF/docx handling, zod-validated tool output).
- Each question ships with 4 choices, exactly one correct, and a short explanation shown after answering — written to teach, not just confirm.
- Score history persists per course (`QuizAttempt`, keyed by `courseId` as well as `quizId`) so a "best score" survives regenerating the quiz, shown on the course's quiz card alongside the last attempt.
- Persists to `users/{uid}/quizzes` and `users/{uid}/quizAttempts` in Firestore, wired into `AppStateContext`/`useFirestoreSync` the same way `flashcards` is, with matching security rules exercised by `rules.spec.ts`'s parameterized owner-only/cross-user test suites from the start (not added after the fact, unlike #225).

`QuizCard`'s delete-quiz action uses the confirm/cancel pattern from the start too, rather than repeating the missing-confirmation bug #225 found and fixed in `FlashcardDeckCard`.

## Verification

- `tsc --noEmit` — clean.
- `npm run lint` — clean (0 warnings/errors).
- `npx vitest run` — **707 passed, 0 failed** across the full suite.
- `rules.spec.ts` against a real Firebase Firestore emulator — **85/85 passing**, including the new `quizzes`/`quizAttempts` rules.
- Same sandbox limitation as #225 applies here: I could not complete a live upload → generate → take-quiz click-through, for the same reason documented there (this specific sandbox's Chromium cannot sustain a long-lived Firestore WebChannel connection — confirmed independently, not something specific to this app's code). The data-layer path (security rules, Firestore CRUD helpers) is fully covered by the passing automated tests above. Did not re-attempt live browser verification given that root cause is already established and unrelated to this PR's code.

## Note on branch stacking

Stacked on `feature/flashcards-spaced-repetition`'s tip (PR #225, unmerged) — includes its commits (and everything ahead of it in the chain) until #225 merges. Targeting `main` directly, per the corrected convention from #225 (see that PR for why #219–225 briefly targeted the wrong base).

Not merging without your go-ahead.
