### PR TITLE
Add wellness check-in and mood recap

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,10 @@ service cloud.firestore {
       match /quizAttempts/{attemptId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /moodEntries/{entryId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "pdfjs-dist": "^6.2.108",
         "react": "^18",
         "react-dom": "^18",
+        "recharts": "^3.10.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -3055,6 +3056,32 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
@@ -3348,7 +3375,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -3511,6 +3543,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3577,14 +3672,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3626,6 +3721,12 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6039,6 +6140,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -6615,7 +6725,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -6624,6 +6734,127 @@
       "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6731,6 +6962,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-extend": {
@@ -7277,6 +7514,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -7833,7 +8082,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -9939,6 +10187,16 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.18.tgz",
+      "integrity": "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10047,6 +10305,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -14313,8 +14580,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -14387,6 +14676,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -14399,6 +14718,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14489,6 +14823,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
@@ -16128,6 +16468,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -16701,6 +17047,15 @@
       "dev": true,
       "license": "BSD"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16746,6 +17101,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pdfjs-dist": "^6.2.108",
     "react": "^18",
     "react-dom": "^18",
+    "recharts": "^3.10.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/app/(app)/calendar/page.tsx
+++ b/src/app/(app)/calendar/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { MonthCalendar } from '@/components/calendar/MonthCalendar';
 
 export const metadata: Metadata = {
@@ -15,7 +16,9 @@ export default function CalendarPage() {
           See your workload build before it hits — not just what&apos;s due.
         </p>
       </div>
-      <MonthCalendar />
+      <Suspense fallback={null}>
+        <MonthCalendar />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/(app)/mood/page.tsx
+++ b/src/app/(app)/mood/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { MoodRecapView } from '@/components/mood/MoodRecapView';
+
+export const metadata: Metadata = {
+  title: 'Mood Recap | Syllabus Sense',
+  description: 'Your daily check-ins, how they trend, and how they line up with your workload.',
+};
+
+export default function MoodPage() {
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground tracking-tight">Mood Recap</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Every check-in, how it trends, and how it lines up with your workload.
+        </p>
+      </div>
+      <MoodRecapView />
+    </div>
+  );
+}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { TaskRow } from '@/components/ui/TaskRow';
@@ -244,10 +245,21 @@ type ViewMode = 'month' | 'week' | 'agenda';
 export function MonthCalendar() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const searchParams = useSearchParams();
+  // A deep link from the semester heatmap (or any other day-grid) lands here
+  // pre-selected and scrolled to that day, instead of the plain "today"
+  // view - only honored on first mount, so navigating the calendar around
+  // afterward doesn't keep snapping back to the link's date.
+  const linkedDate = useMemo(() => {
+    const raw = searchParams.get('date');
+    if (!raw || !/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null;
+    return parseDayKey(raw);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [viewMode, setViewMode] = useState<ViewMode>('month');
-  const [viewMonth, setViewMonth] = useState(() => startOfDay(new Date()));
-  const [weekAnchor, setWeekAnchor] = useState(() => startOfDay(new Date()));
-  const [selectedDay, setSelectedDay] = useState<Date | null>(null);
+  const [viewMonth, setViewMonth] = useState(() => linkedDate ?? startOfDay(new Date()));
+  const [weekAnchor, setWeekAnchor] = useState(() => linkedDate ?? startOfDay(new Date()));
+  const [selectedDay, setSelectedDay] = useState<Date | null>(() => linkedDate);
   const [focusedDateKey, setFocusedDateKey] = useState<string | null>(null);
   const dayButtonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [hiddenCourseIds, setHiddenCourseIds] = useState<Set<string>>(new Set());

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -251,7 +251,7 @@ export function MonthCalendar() {
   // view - only honored on first mount, so navigating the calendar around
   // afterward doesn't keep snapping back to the link's date.
   const linkedDate = useMemo(() => {
-    const raw = searchParams.get('date');
+    const raw = searchParams?.get('date');
     if (!raw || !/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null;
     return parseDayKey(raw);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -158,6 +158,17 @@ export function CommandPalette({
         },
       },
       {
+        id: 'nav-mood',
+        title: 'Mood Recap',
+        subtitle: 'Daily check-ins, trends, and how they line up with your workload',
+        category: 'Navigation',
+        badge: `${state.moodEntries.length} check-ins`,
+        perform: () => {
+          router.push('/mood');
+          closePalette();
+        },
+      },
+      {
         id: 'nav-calendar',
         title: 'Calendar',
         subtitle: 'Month & week views, class schedules, and deadlines',
@@ -336,6 +347,7 @@ export function CommandPalette({
     state.contacts,
     state.flashcards,
     state.quizzes,
+    state.moodEntries,
     resolvedTheme,
     setTheme,
     router,

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -18,6 +18,7 @@ import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
 import { MaterialsBudgetCard } from '@/components/dashboard/MaterialsBudgetCard';
+import { MoodCheckInCard } from '@/components/dashboard/MoodCheckInCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
@@ -241,6 +242,8 @@ export function DashboardView() {
             </button>
           </div>
         </div>
+
+        <MoodCheckInCard />
 
         <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
 

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -243,8 +243,6 @@ export function DashboardView() {
           </div>
         </div>
 
-        <MoodCheckInCard />
-
         <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
 
         <MaterialsBudgetCard courses={state.courses} />
@@ -527,6 +525,8 @@ export function DashboardView() {
             })}
           </div>
         </Card>
+
+        <MoodCheckInCard />
 
         <Card className="rounded-2xl p-6">
           <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">

--- a/src/components/dashboard/MoodCheckInCard.tsx
+++ b/src/components/dashboard/MoodCheckInCard.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/Card';
+import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
+import { upsertMoodEntry } from '@/lib/firestore/moodEntries';
+import { toDayKey } from '@/lib/calendar/dates';
+import { MOOD_OPTIONS } from '@/lib/mood/moodScale';
+import { computeMoodStreak } from '@/lib/mood/moodStats';
+import { cn } from '@/lib/utils';
+import type { MoodValue } from '@/types/mood';
+
+/**
+ * The "Option A" design from the Wellness Check-in audit item: the lowest
+ * possible friction, a single emoji tap on the Dashboard each day, chosen
+ * over a richer weekly form specifically because a tiny daily habit
+ * survives finals week and a form people mean to fill out later doesn't.
+ */
+export function MoodCheckInCard() {
+  const { state, dispatch } = useAppState();
+  const { user } = useAuth();
+  const { showError } = useToast();
+  const [saving, setSaving] = useState<MoodValue | null>(null);
+
+  const todayKey = toDayKey(new Date());
+  const todayEntry = state.moodEntries.find((e) => e.dateKey === todayKey);
+  const streak = computeMoodStreak(state.moodEntries);
+
+  const handleTap = async (mood: MoodValue) => {
+    if (!user) return;
+    setSaving(mood);
+    const previousEntry = todayEntry;
+    try {
+      await upsertMoodEntry(
+        user.uid,
+        { id: todayKey, dateKey: todayKey, mood, createdAt: new Date().toISOString() },
+        dispatch,
+        previousEntry,
+      );
+    } catch {
+      showError("Couldn't save your check-in", 'Try tapping again in a moment.');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <Card className="rounded-2xl p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">How&apos;s today going?</h2>
+          {streak > 1 && (
+            <p className="mt-0.5 text-xs text-muted-foreground">🔥 {streak}-day check-in streak</p>
+          )}
+        </div>
+        <Link
+          href="/mood"
+          className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+        >
+          See your recap →
+        </Link>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2">
+        {MOOD_OPTIONS.map((option) => {
+          const isSelected = todayEntry?.mood === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => handleTap(option.value)}
+              disabled={saving !== null}
+              aria-pressed={isSelected}
+              aria-label={option.label}
+              title={option.label}
+              className={cn(
+                'flex h-12 w-12 items-center justify-center rounded-2xl text-2xl transition-all disabled:cursor-not-allowed disabled:opacity-60',
+                isSelected
+                  ? 'bg-primary/10 ring-2 ring-primary scale-110'
+                  : 'hover:bg-accent hover:scale-105',
+              )}
+            >
+              {option.emoji}
+            </button>
+          );
+        })}
+      </div>
+
+      {todayEntry && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Logged as {getMoodOptionLabel(todayEntry.mood)} today - tap another face to change it.
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function getMoodOptionLabel(mood: MoodValue): string {
+  return MOOD_OPTIONS[mood - 1].label;
+}

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -63,15 +63,21 @@ export function PomodoroTimer({ taskId, openSignal }: PomodoroTimerProps = {}) {
   const sessionStartRef = useRef<Date | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // External open trigger (CommandPalette's "Start Pomodoro" action) - skips
-  // the initial mount so passing openSignal={0} doesn't force it open.
-  const isFirstOpenSignal = useRef(true);
+  // External open trigger (CommandPalette's "Start Pomodoro" action) - opens
+  // only when the signal actually changes value, not on every effect run.
+  // A "skip the first run" ref is not enough here: React Strict Mode's dev-
+  // only double-invoke of effects re-fires this effect once immediately
+  // after mount with the ref already flipped, which read `openSignal={0}`
+  // (always defined, never `undefined`) as a real trigger and force-opened
+  // the widget on every page load. Comparing against the previous value
+  // instead only opens on a genuine increment, which a duplicate effect run
+  // with an unchanged value can't produce.
+  const previousOpenSignal = useRef(openSignal);
   useEffect(() => {
-    if (isFirstOpenSignal.current) {
-      isFirstOpenSignal.current = false;
-      return;
+    if (openSignal !== undefined && openSignal !== previousOpenSignal.current) {
+      setVisible(true);
     }
-    if (openSignal !== undefined) setVisible(true);
+    previousOpenSignal.current = openSignal;
   }, [openSignal]);
 
   // Alt+P keyboard shortcut to toggle the widget

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -145,6 +145,25 @@ const moreItems: TabItem[] = [
     ),
   },
   {
+    name: 'Mood',
+    href: '/mood',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    ),
+  },
+  {
     name: 'Profile',
     href: '/profile',
     icon: (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -164,6 +164,25 @@ export default function Sidebar() {
       ),
     },
     {
+      name: 'Mood',
+      href: '/mood',
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+    },
+    {
       name: 'Profile',
       href: '/profile',
       icon: (

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useAppState } from '@/context/AppStateContext';
+import {
+  computeMoodStreak,
+  computeAverageMood,
+  computeMoodByWorkloadLevel,
+  computeMoodTrend,
+  computeBestAndWorstDay,
+} from '@/lib/mood/moodStats';
+import { MOOD_OPTIONS, MOOD_SWATCH_CLASS, getMoodOption } from '@/lib/mood/moodScale';
+import { parseDayKey } from '@/lib/calendar/dates';
+import { cn } from '@/lib/utils';
+import type { WorkloadLevel } from '@/types/schedule';
+import type { MoodValue } from '@/types/mood';
+
+const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+const FULL_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+
+const WORKLOAD_LEVEL_LABEL: Record<WorkloadLevel, string> = {
+  low: 'Light',
+  medium: 'Moderate',
+  high: 'Heavy',
+  critical: 'Extreme',
+};
+
+/** Same 4-step palette as MOOD_SWATCH_CLASS/WORKLOAD_SWATCH_CLASS, as raw
+ * CSS color strings - recharts draws its own SVG and can't consume
+ * Tailwind's utility classes, but reading the same `--load-*` custom
+ * properties keeps every chart on this page and the workload heatmap
+ * drawing from one shared palette. */
+const CHART_COLOR: Record<WorkloadLevel, string> = {
+  low: 'hsl(var(--load-low))',
+  medium: 'hsl(var(--load-medium))',
+  high: 'hsl(var(--load-high))',
+  critical: 'hsl(var(--load-critical))',
+};
+function StatTile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <Card className="rounded-2xl p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold text-foreground">{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p>}
+    </Card>
+  );
+}
+
+export function MoodRecapView() {
+  const { state } = useAppState();
+  const entries = state.moodEntries;
+
+  const streak = computeMoodStreak(entries);
+  const average = computeAverageMood(entries);
+  const trend = useMemo(() => computeMoodTrend(entries), [entries]);
+  const byWorkload = useMemo(
+    () => computeMoodByWorkloadLevel(entries, state.scheduleItems),
+    [entries, state.scheduleItems],
+  );
+  const { best, worst } = useMemo(() => computeBestAndWorstDay(entries), [entries]);
+
+  const calendarCells = useMemo(() => {
+    if (trend.length === 0) return [];
+    const byDate = new Map(trend.map((p) => [p.dateKey, p.mood]));
+    const start = parseDayKey(trend[0].dateKey);
+    const end = parseDayKey(trend[trend.length - 1].dateKey);
+    const leadingBlanks = start.getDay();
+    const cells: { dateKey: string; mood: MoodValue | null }[] = Array.from(
+      { length: leadingBlanks },
+      () => ({ dateKey: '', mood: null }),
+    );
+    const cursor = new Date(start);
+    while (cursor.getTime() <= end.getTime()) {
+      const dateKey = cursor.toISOString().slice(0, 10);
+      cells.push({ dateKey, mood: (byDate.get(dateKey) as MoodValue | undefined) ?? null });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return cells;
+  }, [trend]);
+  const columnCount = Math.ceil(calendarCells.length / 7);
+
+  if (entries.length === 0) {
+    return (
+      <Card className="rounded-2xl p-6">
+        <EmptyState
+          icon={
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          }
+          title="No check-ins yet"
+          description="Tap a mood on your dashboard each day - your recap builds up from there."
+          action={{
+            label: 'Go to Dashboard',
+            onClick: () => (window.location.href = '/dashboard'),
+          }}
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatTile label="Check-ins" value={String(entries.length)} />
+        <StatTile
+          label="Average mood"
+          value={average ? getMoodOption(Math.round(average) as MoodValue).emoji : '—'}
+          sub={average ? average.toFixed(1) : undefined}
+        />
+        <StatTile label="Current streak" value={`${streak}d`} />
+        <StatTile
+          label="Best day"
+          value={best ? getMoodOption(best.mood as MoodValue).emoji : '—'}
+          sub={best ? SHORT_DATE_FORMATTER.format(parseDayKey(best.dateKey)) : undefined}
+        />
+      </div>
+
+      <Card className="rounded-2xl p-6">
+        <h2 className="text-base font-semibold text-foreground">Your mood over time</h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">Every check-in, in order.</p>
+        <div className="mt-4" style={{ height: 220 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={trend.map((p) => ({
+                ...p,
+                label: SHORT_DATE_FORMATTER.format(parseDayKey(p.dateKey)),
+              }))}
+            >
+              <defs>
+                <linearGradient id="moodTrendFill" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="hsl(var(--load-low))" stopOpacity={0.35} />
+                  <stop offset="95%" stopColor="hsl(var(--load-low))" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                axisLine={{ stroke: 'hsl(var(--border))' }}
+                tickLine={false}
+                minTickGap={24}
+              />
+              <YAxis
+                domain={[1, 4]}
+                ticks={[1, 2, 3, 4]}
+                tickFormatter={(v: number) => MOOD_OPTIONS[v - 1]?.emoji ?? ''}
+                width={28}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 14 }}
+              />
+              <Tooltip
+                formatter={(value) => {
+                  const mood = getMoodOption(Number(value) as MoodValue);
+                  return [`${mood.emoji} ${mood.label}`, 'Mood'];
+                }}
+                contentStyle={{
+                  background: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: 8,
+                  fontSize: 12,
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="mood"
+                stroke="hsl(var(--load-low))"
+                strokeWidth={2}
+                fill="url(#moodTrendFill)"
+                dot={{ r: 3, fill: 'hsl(var(--load-low))', strokeWidth: 0 }}
+                activeDot={{ r: 5 }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card className="rounded-2xl p-6">
+        <h2 className="text-base font-semibold text-foreground">Mood by workload level</h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Does a heavier day actually feel worse? The colors match your semester heatmap.
+        </p>
+        <div className="mt-4" style={{ height: 200 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={byWorkload.map((b) => ({ ...b, label: WORKLOAD_LEVEL_LABEL[b.level] }))}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                axisLine={{ stroke: 'hsl(var(--border))' }}
+                tickLine={false}
+              />
+              <YAxis
+                domain={[0, 4]}
+                ticks={[0, 1, 2, 3, 4]}
+                tickFormatter={(v: number) => (v === 0 ? '' : (MOOD_OPTIONS[v - 1]?.emoji ?? ''))}
+                width={28}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 14 }}
+              />
+              <Tooltip
+                formatter={(value, _name, ctx) => {
+                  const count = (ctx.payload as { count: number }).count;
+                  if (!count) return ['No check-ins yet', ''];
+                  const numeric = Number(value);
+                  const mood = getMoodOption(Math.round(numeric) as MoodValue);
+                  return [
+                    `${mood.emoji} ${numeric.toFixed(1)} avg (${count} day${count === 1 ? '' : 's'})`,
+                    'Mood',
+                  ];
+                }}
+                contentStyle={{
+                  background: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: 8,
+                  fontSize: 12,
+                }}
+              />
+              <Bar dataKey="averageMood" radius={[6, 6, 0, 0]} maxBarSize={56}>
+                {byWorkload.map((b) => (
+                  <Cell
+                    key={b.level}
+                    fill={CHART_COLOR[b.level]}
+                    fillOpacity={b.count ? 1 : 0.15}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card className="rounded-2xl p-6">
+        <h2 className="text-base font-semibold text-foreground">Your check-in history</h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Click a day to open it in Calendar and see what was going on.
+        </p>
+        <div className="mt-4 overflow-x-auto pb-1">
+          <div
+            className="grid gap-1"
+            style={{
+              gridTemplateRows: 'repeat(7, 0.75rem)',
+              gridAutoFlow: 'column',
+              gridTemplateColumns: `repeat(${columnCount}, 0.75rem)`,
+            }}
+          >
+            {calendarCells.map((cell, i) =>
+              cell.dateKey && cell.mood ? (
+                <Link
+                  key={cell.dateKey}
+                  href={`/calendar?date=${cell.dateKey}`}
+                  title={`${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} · ${getMoodOption(cell.mood).label}`}
+                  aria-label={`Open ${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - felt ${getMoodOption(cell.mood).label.toLowerCase()}`}
+                  className={cn(
+                    'h-full w-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
+                    MOOD_SWATCH_CLASS[cell.mood],
+                  )}
+                />
+              ) : (
+                <div
+                  key={cell.dateKey || `blank-${i}`}
+                  className="h-full w-full rounded-[2px] bg-border"
+                />
+              ),
+            )}
+          </div>
+        </div>
+        <div className="mt-3 flex items-center justify-end gap-1.5 text-[10px] text-muted-foreground">
+          <span>Rough</span>
+          {MOOD_OPTIONS.map((o) => (
+            <span
+              key={o.value}
+              className={cn('h-2.5 w-2.5 rounded-[2px]', MOOD_SWATCH_CLASS[o.value])}
+            />
+          ))}
+          <span>Great</span>
+        </div>
+      </Card>
+
+      {(best || worst) && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {best && (
+            <Card className="rounded-2xl border-load-low/30 bg-load-low/5 p-5">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-load-low">
+                Your best day
+              </p>
+              <p className="mt-1 text-3xl">{getMoodOption(best.mood as MoodValue).emoji}</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">
+                {FULL_DATE_FORMATTER.format(parseDayKey(best.dateKey))}
+              </p>
+            </Card>
+          )}
+          {worst && (
+            <Card className="rounded-2xl border-load-critical/30 bg-load-critical/5 p-5">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-load-critical">
+                Your toughest day
+              </p>
+              <p className="mt-1 text-3xl">{getMoodOption(worst.mood as MoodValue).emoji}</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">
+                {FULL_DATE_FORMATTER.format(parseDayKey(worst.dateKey))}
+              </p>
+            </Card>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -25,6 +25,7 @@ import {
   computeBestAndWorstDay,
 } from '@/lib/mood/moodStats';
 import { MOOD_OPTIONS, MOOD_SWATCH_CLASS, getMoodOption } from '@/lib/mood/moodScale';
+import { computeSemesterHeatmap } from '@/lib/planner/semesterHeatmap';
 import { parseDayKey } from '@/lib/calendar/dates';
 import { cn } from '@/lib/utils';
 import type { WorkloadLevel } from '@/types/schedule';
@@ -86,11 +87,24 @@ export function MoodRecapView() {
   );
   const { best, worst } = useMemo(() => computeBestAndWorstDay(entries), [entries]);
 
+  // The full span of the term's due dates - the same range the semester
+  // heatmap draws - unioned with the mood entries' own range, so a student
+  // who only started checking in partway through the term still sees the
+  // whole term laid out, not just the weeks they happened to check in.
+  const termDays = useMemo(
+    () => computeSemesterHeatmap(state.scheduleItems),
+    [state.scheduleItems],
+  );
+
   const calendarCells = useMemo(() => {
-    if (trend.length === 0) return [];
+    if (trend.length === 0 && termDays.length === 0) return [];
     const byDate = new Map(trend.map((p) => [p.dateKey, p.mood]));
-    const start = parseDayKey(trend[0].dateKey);
-    const end = parseDayKey(trend[trend.length - 1].dateKey);
+    const candidateKeys = [
+      ...(trend.length > 0 ? [trend[0].dateKey, trend[trend.length - 1].dateKey] : []),
+      ...(termDays.length > 0 ? [termDays[0].dateKey, termDays[termDays.length - 1].dateKey] : []),
+    ].sort();
+    const start = parseDayKey(candidateKeys[0]);
+    const end = parseDayKey(candidateKeys[candidateKeys.length - 1]);
     const leadingBlanks = start.getDay();
     const cells: { dateKey: string; mood: MoodValue | null }[] = Array.from(
       { length: leadingBlanks },
@@ -103,7 +117,7 @@ export function MoodRecapView() {
       cursor.setDate(cursor.getDate() + 1);
     }
     return cells;
-  }, [trend]);
+  }, [trend, termDays]);
   const columnCount = Math.ceil(calendarCells.length / 7);
 
   // Month labels, positioned above the week-column where that month's first

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -257,7 +257,20 @@ export function MoodRecapView() {
         <div className="mt-4" style={{ height: 200 }}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
-              data={byWorkload.map((b) => ({ ...b, label: WORKLOAD_LEVEL_LABEL[b.level] }))}
+              data={byWorkload.map((b) => ({
+                ...b,
+                label: WORKLOAD_LEVEL_LABEL[b.level],
+                // Recharts treats a `null` dataKey value as "nothing to
+                // render" for a category - no bar, and no `background`
+                // hit-area either - so a zero-count bucket became
+                // completely unhoverable (the "No check-ins yet" message
+                // below never got a chance to show). A numeric 0 still
+                // renders (as a zero-height bar plus its hoverable
+                // background); `count` is what actually drives the
+                // zero-vs-real-zero-average distinction in both the
+                // formatter and the fill opacity below.
+                averageMood: b.averageMood ?? 0,
+              }))}
             >
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
               <XAxis
@@ -292,8 +305,21 @@ export function MoodRecapView() {
                   borderRadius: 8,
                   fontSize: 12,
                 }}
+                cursor={{ fill: 'hsl(var(--accent))', opacity: 0.5 }}
               />
-              <Bar dataKey="averageMood" radius={[6, 6, 0, 0]} maxBarSize={56}>
+              <Bar
+                dataKey="averageMood"
+                radius={[6, 6, 0, 0]}
+                maxBarSize={56}
+                // A bucket with zero check-ins has a zero-height bar - nothing
+                // there to hover, so the "No check-ins yet" message the
+                // formatter above already writes for that case never had a
+                // chance to show. `background` gives every category a full-
+                // height (invisible) hit area regardless of its bar's value,
+                // so hovering an empty bucket's column still activates the
+                // tooltip.
+                background={{ fill: 'transparent' }}
+              >
                 {byWorkload.map((b) => (
                   <Cell
                     key={b.level}

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -271,33 +271,42 @@ export function MoodRecapView() {
           Click a day to open it in Calendar and see what was going on.
         </p>
         <div className="mt-4 overflow-x-auto pb-1">
-          <div
-            className="grid gap-1"
-            style={{
-              gridTemplateRows: 'repeat(7, 0.75rem)',
-              gridAutoFlow: 'column',
-              gridTemplateColumns: `repeat(${columnCount}, 0.75rem)`,
-            }}
-          >
-            {calendarCells.map((cell, i) =>
-              cell.dateKey && cell.mood ? (
-                <Link
-                  key={cell.dateKey}
-                  href={`/calendar?date=${cell.dateKey}`}
-                  title={`${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} · ${getMoodOption(cell.mood).label}`}
-                  aria-label={`Open ${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - felt ${getMoodOption(cell.mood).label.toLowerCase()}`}
-                  className={cn(
-                    'h-full w-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
-                    MOOD_SWATCH_CLASS[cell.mood],
-                  )}
-                />
-              ) : (
-                <div
-                  key={cell.dateKey || `blank-${i}`}
-                  className="h-full w-full rounded-[2px] bg-border"
-                />
-              ),
-            )}
+          <div className="flex min-w-full justify-center">
+            {/* Same square-by-construction trick as the semester heatmap:
+             * a fixed-height parent divides evenly into 7 `1fr` row tracks,
+             * every cell stretches to that row height and carries
+             * `aspect-square`, and the `auto` column tracks size themselves
+             * to match - so the grid fills the card's height and stays
+             * square instead of shrinking to tiny fixed-size squares. */}
+            <div
+              className="grid gap-1"
+              style={{
+                height: '10rem',
+                gridTemplateRows: 'repeat(7, 1fr)',
+                gridAutoFlow: 'column',
+                gridTemplateColumns: `repeat(${columnCount}, auto)`,
+              }}
+            >
+              {calendarCells.map((cell, i) =>
+                cell.dateKey && cell.mood ? (
+                  <Link
+                    key={cell.dateKey}
+                    href={`/calendar?date=${cell.dateKey}`}
+                    title={`${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} · ${getMoodOption(cell.mood).label}`}
+                    aria-label={`Open ${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - felt ${getMoodOption(cell.mood).label.toLowerCase()}`}
+                    className={cn(
+                      'aspect-square h-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
+                      MOOD_SWATCH_CLASS[cell.mood],
+                    )}
+                  />
+                ) : (
+                  <div
+                    key={cell.dateKey || `blank-${i}`}
+                    className="aspect-square h-full rounded-[2px] bg-border"
+                  />
+                ),
+              )}
+            </div>
           </div>
         </div>
         <div className="mt-3 flex items-center justify-end gap-1.5 text-[10px] text-muted-foreground">

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -36,6 +36,12 @@ const FULL_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 });
+const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short' });
+
+// Same GitHub-contribution-graph convention as the semester heatmap: only
+// every other weekday row gets a label, so the gutter doesn't crowd the
+// cells themselves.
+const ROW_LABELS: Record<number, string> = { 1: 'Mon', 3: 'Wed', 5: 'Fri' };
 
 const WORKLOAD_LEVEL_LABEL: Record<WorkloadLevel, string> = {
   low: 'Light',
@@ -99,6 +105,28 @@ export function MoodRecapView() {
     return cells;
   }, [trend]);
   const columnCount = Math.ceil(calendarCells.length / 7);
+
+  // Month labels, positioned above the week-column where that month's first
+  // visible cell falls - identical logic to the semester heatmap, so both
+  // grids read the same way.
+  const monthLabels = useMemo(() => {
+    const raw: { label: string; columnIndex: number }[] = [];
+    let lastMonth = '';
+    calendarCells.forEach((cell, i) => {
+      if (!cell.dateKey) return;
+      const columnIndex = Math.floor(i / 7);
+      const month = MONTH_FORMATTER.format(parseDayKey(cell.dateKey));
+      if (month !== lastMonth) {
+        raw.push({ label: month, columnIndex });
+        lastMonth = month;
+      }
+    });
+    const MIN_LABEL_GAP_COLUMNS = 2;
+    return raw.filter((entry, i) => {
+      const next = raw[i + 1];
+      return !next || next.columnIndex - entry.columnIndex >= MIN_LABEL_GAP_COLUMNS;
+    });
+  }, [calendarCells]);
 
   if (entries.length === 0) {
     return (
@@ -173,7 +201,7 @@ export function MoodRecapView() {
                 minTickGap={24}
               />
               <YAxis
-                domain={[1, 4]}
+                domain={[0.5, 4.5]}
                 ticks={[1, 2, 3, 4]}
                 tickFormatter={(v: number) => MOOD_OPTIONS[v - 1]?.emoji ?? ''}
                 width={28}
@@ -272,40 +300,62 @@ export function MoodRecapView() {
         </p>
         <div className="mt-4 overflow-x-auto pb-1">
           <div className="flex min-w-full justify-center">
-            {/* Same square-by-construction trick as the semester heatmap:
-             * a fixed-height parent divides evenly into 7 `1fr` row tracks,
-             * every cell stretches to that row height and carries
-             * `aspect-square`, and the `auto` column tracks size themselves
-             * to match - so the grid fills the card's height and stays
-             * square instead of shrinking to tiny fixed-size squares. */}
-            <div
-              className="grid gap-1"
-              style={{
-                height: '10rem',
-                gridTemplateRows: 'repeat(7, 1fr)',
-                gridAutoFlow: 'column',
-                gridTemplateColumns: `repeat(${columnCount}, auto)`,
-              }}
-            >
-              {calendarCells.map((cell, i) =>
-                cell.dateKey && cell.mood ? (
-                  <Link
-                    key={cell.dateKey}
-                    href={`/calendar?date=${cell.dateKey}`}
-                    title={`${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} · ${getMoodOption(cell.mood).label}`}
-                    aria-label={`Open ${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - felt ${getMoodOption(cell.mood).label.toLowerCase()}`}
-                    className={cn(
-                      'aspect-square h-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
-                      MOOD_SWATCH_CLASS[cell.mood],
-                    )}
-                  />
-                ) : (
-                  <div
-                    key={cell.dateKey || `blank-${i}`}
-                    className="aspect-square h-full rounded-[2px] bg-border"
-                  />
-                ),
-              )}
+            <div className="flex gap-2" style={{ height: '10rem' }}>
+              <div
+                className="grid shrink-0 pt-4 text-[10px] text-muted-foreground"
+                style={{ gridTemplateRows: 'repeat(7, 1fr)' }}
+              >
+                {Array.from({ length: 7 }, (_, row) => (
+                  <span key={row} className="flex items-center">
+                    {ROW_LABELS[row] ?? ''}
+                  </span>
+                ))}
+              </div>
+
+              {/* Same square-by-construction trick as the semester heatmap:
+               * a fixed-height parent divides evenly into 7 `1fr` row
+               * tracks, every cell stretches to that row height and carries
+               * `aspect-square`, and the `auto` column tracks size
+               * themselves to match - so the grid fills the card's height
+               * and stays square instead of shrinking to tiny fixed-size
+               * squares. */}
+              <div
+                className="relative grid gap-1 pt-4"
+                style={{
+                  gridTemplateRows: 'repeat(7, 1fr)',
+                  gridAutoFlow: 'column',
+                  gridTemplateColumns: `repeat(${columnCount}, auto)`,
+                }}
+              >
+                {monthLabels.map(({ label, columnIndex }) => (
+                  <span
+                    key={`${label}-${columnIndex}`}
+                    className="absolute top-0 text-[10px] font-medium text-muted-foreground"
+                    style={{ left: `${(columnIndex / columnCount) * 100}%` }}
+                  >
+                    {label}
+                  </span>
+                ))}
+                {calendarCells.map((cell, i) =>
+                  cell.dateKey && cell.mood ? (
+                    <Link
+                      key={cell.dateKey}
+                      href={`/calendar?date=${cell.dateKey}`}
+                      title={`${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} · ${getMoodOption(cell.mood).label}`}
+                      aria-label={`Open ${FULL_DATE_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - felt ${getMoodOption(cell.mood).label.toLowerCase()}`}
+                      className={cn(
+                        'aspect-square h-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
+                        MOOD_SWATCH_CLASS[cell.mood],
+                      )}
+                    />
+                  ) : (
+                    <div
+                      key={cell.dateKey || `blank-${i}`}
+                      className="aspect-square h-full rounded-[2px] bg-muted-foreground/15"
+                    />
+                  ),
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/planner/SemesterHeatmapCard.tsx
+++ b/src/components/planner/SemesterHeatmapCard.tsx
@@ -80,56 +80,63 @@ export function SemesterHeatmapCard() {
       </div>
 
       <div className="mt-5 overflow-x-auto pb-1">
-        <div className="flex gap-2">
-          <div
-            className="grid shrink-0 text-[10px] text-muted-foreground"
-            style={{ gridTemplateRows: 'repeat(7, minmax(0, 1fr))', rowGap: '0.25rem' }}
-          >
-            {Array.from({ length: 7 }, (_, row) => (
-              <span key={row} className="flex h-3 items-center">
-                {ROW_LABELS[row] ?? ''}
-              </span>
-            ))}
-          </div>
+        <div className="flex min-w-full justify-center">
+          <div className="flex gap-2" style={{ height: '10rem' }}>
+            <div
+              className="grid shrink-0 pt-4 text-[10px] text-muted-foreground"
+              style={{ gridTemplateRows: 'repeat(7, 1fr)' }}
+            >
+              {Array.from({ length: 7 }, (_, row) => (
+                <span key={row} className="flex items-center">
+                  {ROW_LABELS[row] ?? ''}
+                </span>
+              ))}
+            </div>
 
-          <div
-            className="relative grid w-full min-w-0 flex-1 gap-1 pt-4"
-            style={{
-              gridTemplateRows: 'repeat(7, 0.75rem)',
-              gridAutoFlow: 'column',
-              // A floor on column width (not just `1fr`) keeps cells from
-              // going illegibly thin over a full year's worth of weeks -
-              // below that floor the card scrolls horizontally instead.
-              // Above it, columns stretch to fill the card's full width
-              // rather than shrinking to their own natural content size.
-              gridTemplateColumns: `repeat(${columnCount}, minmax(0.5rem, 1fr))`,
-            }}
-          >
-            {monthLabels.map(({ label, columnIndex }) => (
-              <span
-                key={`${label}-${columnIndex}`}
-                className="absolute top-0 text-[10px] font-medium text-muted-foreground"
-                style={{ left: `${(columnIndex / columnCount) * 100}%` }}
-              >
-                {label}
-              </span>
-            ))}
-            {cells.map((cell, i) =>
-              cell ? (
-                <Link
-                  key={cell.dateKey}
-                  href={`/calendar?date=${cell.dateKey}`}
-                  title={`${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} · ${cell.hours}h due`}
-                  aria-label={`Open ${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - ${cell.hours}h due`}
-                  className={cn(
-                    'h-full w-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
-                    cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-border',
-                  )}
-                />
-              ) : (
-                <div key={`blank-${i}`} className="h-full w-full rounded-[2px] bg-border" />
-              ),
-            )}
+            {/* Cells are square by construction, not by measured pixels:
+             * each row track resolves to a definite height (1fr slices of
+             * the fixed-height parent above), every cell stretches to that
+             * height and carries `aspect-square`, and the `auto` column
+             * tracks then size themselves to match - so the grid is exactly
+             * as tall as its card and only as wide as it needs to be,
+             * instead of stretching cells to fill the card's width. */}
+            <div
+              className="relative grid gap-1 pt-4"
+              style={{
+                gridTemplateRows: 'repeat(7, 1fr)',
+                gridAutoFlow: 'column',
+                gridTemplateColumns: `repeat(${columnCount}, auto)`,
+              }}
+            >
+              {monthLabels.map(({ label, columnIndex }) => (
+                <span
+                  key={`${label}-${columnIndex}`}
+                  className="absolute top-0 text-[10px] font-medium text-muted-foreground"
+                  style={{ left: `${(columnIndex / columnCount) * 100}%` }}
+                >
+                  {label}
+                </span>
+              ))}
+              {cells.map((cell, i) =>
+                cell ? (
+                  <Link
+                    key={cell.dateKey}
+                    href={`/calendar?date=${cell.dateKey}`}
+                    title={`${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} · ${cell.hours}h due`}
+                    aria-label={`Open ${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - ${cell.hours}h due`}
+                    className={cn(
+                      'aspect-square h-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
+                      cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-border',
+                    )}
+                  />
+                ) : (
+                  <div
+                    key={`blank-${i}`}
+                    className="aspect-square h-full rounded-[2px] bg-border"
+                  />
+                ),
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/components/planner/SemesterHeatmapCard.tsx
+++ b/src/components/planner/SemesterHeatmapCard.tsx
@@ -126,13 +126,13 @@ export function SemesterHeatmapCard() {
                     aria-label={`Open ${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - ${cell.hours}h due`}
                     className={cn(
                       'aspect-square h-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
-                      cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-border',
+                      cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-muted-foreground/15',
                     )}
                   />
                 ) : (
                   <div
                     key={`blank-${i}`}
-                    className="aspect-square h-full rounded-[2px] bg-border"
+                    className="aspect-square h-full rounded-[2px] bg-muted-foreground/15"
                   />
                 ),
               )}
@@ -144,7 +144,7 @@ export function SemesterHeatmapCard() {
           <span>Click a day to open it in Calendar</span>
           <div className="flex shrink-0 items-center gap-1.5">
             <span>Less</span>
-            <span className="h-2.5 w-2.5 rounded-[2px] bg-border" />
+            <span className="h-2.5 w-2.5 rounded-[2px] bg-muted-foreground/15" />
             <span className={cn('h-2.5 w-2.5 rounded-[2px]', WORKLOAD_SWATCH_CLASS.low)} />
             <span className={cn('h-2.5 w-2.5 rounded-[2px]', WORKLOAD_SWATCH_CLASS.medium)} />
             <span className={cn('h-2.5 w-2.5 rounded-[2px]', WORKLOAD_SWATCH_CLASS.high)} />

--- a/src/components/planner/SemesterHeatmapCard.tsx
+++ b/src/components/planner/SemesterHeatmapCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { useAppState } from '@/context/AppStateContext';
 import { computeSemesterHeatmap, type SemesterHeatmapDay } from '@/lib/planner/semesterHeatmap';
@@ -92,41 +93,48 @@ export function SemesterHeatmapCard() {
           </div>
 
           <div
-            className="relative grid gap-1 pt-4"
+            className="relative grid w-full min-w-0 flex-1 gap-1 pt-4"
             style={{
-              gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
+              gridTemplateRows: 'repeat(7, 0.75rem)',
               gridAutoFlow: 'column',
-              gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+              // A floor on column width (not just `1fr`) keeps cells from
+              // going illegibly thin over a full year's worth of weeks -
+              // below that floor the card scrolls horizontally instead.
+              // Above it, columns stretch to fill the card's full width
+              // rather than shrinking to their own natural content size.
+              gridTemplateColumns: `repeat(${columnCount}, minmax(0.5rem, 1fr))`,
             }}
           >
             {monthLabels.map(({ label, columnIndex }) => (
               <span
                 key={`${label}-${columnIndex}`}
                 className="absolute top-0 text-[10px] font-medium text-muted-foreground"
-                style={{ left: `calc(${columnIndex} * (0.75rem + 0.25rem))` }}
+                style={{ left: `${(columnIndex / columnCount) * 100}%` }}
               >
                 {label}
               </span>
             ))}
             {cells.map((cell, i) =>
               cell ? (
-                <div
+                <Link
                   key={cell.dateKey}
+                  href={`/calendar?date=${cell.dateKey}`}
                   title={`${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} · ${cell.hours}h due`}
+                  aria-label={`Open ${DAY_FORMATTER.format(parseDayKey(cell.dateKey))} in Calendar - ${cell.hours}h due`}
                   className={cn(
-                    'h-3 w-3 rounded-[2px]',
+                    'h-full w-full rounded-[2px] transition-transform hover:scale-125 hover:ring-1 hover:ring-foreground/40 focus-visible:scale-125 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/40',
                     cell.hours > 0 ? WORKLOAD_SWATCH_CLASS[cell.level] : 'bg-border',
                   )}
                 />
               ) : (
-                <div key={`blank-${i}`} className="h-3 w-3 rounded-[2px] bg-border" />
+                <div key={`blank-${i}`} className="h-full w-full rounded-[2px] bg-border" />
               ),
             )}
           </div>
         </div>
 
         <div className="mt-3 flex items-center justify-between text-[10px] text-muted-foreground">
-          <span>Hover a day for its due-date total</span>
+          <span>Click a day to open it in Calendar</span>
           <div className="flex shrink-0 items-center gap-1.5">
             <span>Less</span>
             <span className="h-2.5 w-2.5 rounded-[2px] bg-border" />

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -5,6 +5,7 @@ import { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
 import type { Flashcard } from '@/types/flashcard';
 import type { Quiz, QuizAttempt } from '@/types/quiz';
+import type { MoodEntry } from '@/types/mood';
 import { DEFAULT_PREFERENCES, type UserPreferences } from '@/lib/firestore/preferences';
 
 export interface AppState {
@@ -15,6 +16,9 @@ export interface AppState {
   flashcards: Flashcard[];
   quizzes: Quiz[];
   quizAttempts: QuizAttempt[];
+  /** One check-in per day at most - see `moodEntries.ts`'s upsert-by-dateKey
+   * write. Whole-account, not scoped to any one course. */
+  moodEntries: MoodEntry[];
   selectedCourseId: string | null;
   /** #101 semester switcher. `null` means "no explicit choice made yet" -
    * consumers should fall back to `inferCurrentTerm`. The literal string
@@ -60,6 +64,8 @@ export type AppAction =
   | { type: 'SET_QUIZ_ATTEMPTS'; payload: QuizAttempt[] }
   | { type: 'ADD_QUIZ_ATTEMPT'; payload: QuizAttempt }
   | { type: 'REMOVE_QUIZ_ATTEMPT'; payload: string }
+  | { type: 'SET_MOOD_ENTRIES'; payload: MoodEntry[] }
+  | { type: 'UPSERT_MOOD_ENTRY'; payload: MoodEntry }
   | { type: 'SELECT_COURSE'; payload: string | null }
   | { type: 'SELECT_TERM'; payload: string | null }
   | { type: 'SET_PREFERENCES'; payload: UserPreferences };
@@ -72,6 +78,7 @@ export const initialAppState: AppState = {
   flashcards: [],
   quizzes: [],
   quizAttempts: [],
+  moodEntries: [],
   selectedCourseId: null,
   selectedTerm: null,
   preferences: DEFAULT_PREFERENCES,

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -66,6 +66,7 @@ export type AppAction =
   | { type: 'REMOVE_QUIZ_ATTEMPT'; payload: string }
   | { type: 'SET_MOOD_ENTRIES'; payload: MoodEntry[] }
   | { type: 'UPSERT_MOOD_ENTRY'; payload: MoodEntry }
+  | { type: 'REMOVE_MOOD_ENTRY'; payload: string }
   | { type: 'SELECT_COURSE'; payload: string | null }
   | { type: 'SELECT_TERM'; payload: string | null }
   | { type: 'SET_PREFERENCES'; payload: UserPreferences };
@@ -186,6 +187,18 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
         ...state,
         quizAttempts: state.quizAttempts.filter((a) => a.id !== action.payload),
       };
+    case 'SET_MOOD_ENTRIES':
+      return { ...state, moodEntries: action.payload };
+    case 'UPSERT_MOOD_ENTRY':
+      return {
+        ...state,
+        moodEntries: [
+          ...state.moodEntries.filter((m) => m.id !== action.payload.id),
+          action.payload,
+        ],
+      };
+    case 'REMOVE_MOOD_ENTRY':
+      return { ...state, moodEntries: state.moodEntries.filter((m) => m.id !== action.payload) };
     case 'SELECT_COURSE':
       return { ...state, selectedCourseId: action.payload };
     case 'SELECT_TERM':

--- a/src/lib/__tests__/AppStateContext.test.tsx
+++ b/src/lib/__tests__/AppStateContext.test.tsx
@@ -185,6 +185,7 @@ describe('AppStateContext Reducer & Selectors', () => {
       flashcards: [],
       quizzes: [],
       quizAttempts: [],
+      moodEntries: [],
       selectedCourseId: 'c1',
       selectedTerm: null,
       preferences: DEFAULT_PREFERENCES,

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -73,6 +73,7 @@ vi.mock('next/navigation', () => ({
     prefetch: vi.fn(),
   }),
   usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 const mockCourses: Course[] = [

--- a/src/lib/firestore/__tests__/rules.spec.ts
+++ b/src/lib/firestore/__tests__/rules.spec.ts
@@ -80,6 +80,10 @@ const ownedDocPaths: Array<{ label: string; path: (uid: string) => string }> = [
     label: 'quiz attempt (users/{uid}/quizAttempts/{id})',
     path: (uid) => `users/${uid}/quizAttempts/attempt-1`,
   },
+  {
+    label: 'mood entry (users/{uid}/moodEntries/{id})',
+    path: (uid) => `users/${uid}/moodEntries/2026-09-03`,
+  },
 ];
 
 describe('firestore.rules: owner-only access', () => {
@@ -138,6 +142,7 @@ describe('firestore.rules: cross-user collection queries', () => {
     { label: 'flashcards', path: (uid) => `users/${uid}/flashcards` },
     { label: 'quizzes', path: (uid) => `users/${uid}/quizzes` },
     { label: 'quizAttempts', path: (uid) => `users/${uid}/quizAttempts` },
+    { label: 'moodEntries', path: (uid) => `users/${uid}/moodEntries` },
   ];
 
   describe.each(collectionPaths)("listing another user's $label", ({ path: collectionPath }) => {

--- a/src/lib/firestore/moodEntries.ts
+++ b/src/lib/firestore/moodEntries.ts
@@ -1,0 +1,34 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { AppAction } from '@/context/AppStateContext';
+import type { MoodEntry } from '@/types/mood';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+/**
+ * One check-in per day - re-tapping the same day overwrites the previous
+ * value (doc id is the day key itself), so this is always a plain upsert,
+ * never an add-alongside-existing-entries. Same optimistic-dispatch-then-
+ * write, rollback-on-failure pattern as lib/firestore/contacts.ts.
+ */
+export async function upsertMoodEntry(
+  userId: string,
+  entry: MoodEntry,
+  dispatch: React.Dispatch<AppAction>,
+  previousEntry?: MoodEntry,
+): Promise<void> {
+  dispatch({ type: 'UPSERT_MOOD_ENTRY', payload: entry });
+  try {
+    await setDoc(doc(requireDb(), 'users', userId, 'moodEntries', entry.id), entry);
+  } catch (err) {
+    if (previousEntry) {
+      dispatch({ type: 'UPSERT_MOOD_ENTRY', payload: previousEntry });
+    } else {
+      dispatch({ type: 'REMOVE_MOOD_ENTRY', payload: entry.id });
+    }
+    throw err;
+  }
+}

--- a/src/lib/firestore/useFirestoreSync.ts
+++ b/src/lib/firestore/useFirestoreSync.ts
@@ -12,6 +12,7 @@ import type { Contact, Course, ScheduleItem } from '@/types/schedule';
 import type { Source } from '@/types/source';
 import type { Flashcard } from '@/types/flashcard';
 import type { Quiz, QuizAttempt } from '@/types/quiz';
+import type { MoodEntry } from '@/types/mood';
 import { mockCourses, mockScheduleItems } from '@/lib/mock-data';
 
 /**
@@ -111,6 +112,16 @@ export function useFirestoreSync() {
       },
       onSyncError('quiz attempts'),
     );
+    const unsubMoodEntries = onSnapshot(
+      collection(db, 'users', user.uid, 'moodEntries'),
+      (snapshot) => {
+        dispatch({
+          type: 'SET_MOOD_ENTRIES',
+          payload: snapshot.docs.map((d) => d.data() as MoodEntry),
+        });
+      },
+      onSyncError('mood entries'),
+    );
     // Same doc ProfileView writes to via updateUserPreferences - kept here
     // instead of a separate listener per consumer, so a change (from this
     // device or another) reaches every view that reads state.preferences
@@ -132,6 +143,7 @@ export function useFirestoreSync() {
       unsubFlashcards();
       unsubQuizzes();
       unsubQuizAttempts();
+      unsubMoodEntries();
       unsubPreferences();
     };
   }, [user, dispatch, showError]);

--- a/src/lib/mood/__tests__/moodStats.test.ts
+++ b/src/lib/mood/__tests__/moodStats.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeMoodStreak,
+  computeAverageMood,
+  computeMoodByWorkloadLevel,
+  computeMoodTrend,
+  computeBestAndWorstDay,
+  sortMoodEntries,
+} from '../moodStats';
+import type { MoodEntry, MoodValue } from '@/types/mood';
+import type { ScheduleItem } from '@/types/schedule';
+
+function entry(dateKey: string, mood: MoodValue): MoodEntry {
+  return { id: dateKey, dateKey, mood, createdAt: `${dateKey}T12:00:00.000Z` };
+}
+
+function item(dueDate: string, hours: number): ScheduleItem {
+  return {
+    id: `${dueDate}-${hours}`,
+    courseId: 'c1',
+    title: 'Test item',
+    type: 'assignment',
+    dueDate,
+    estimatedHours: hours,
+    completed: false,
+  } as ScheduleItem;
+}
+
+describe('sortMoodEntries', () => {
+  it('sorts oldest to newest', () => {
+    const sorted = sortMoodEntries([entry('2026-09-03', 3), entry('2026-09-01', 2)]);
+    expect(sorted.map((e) => e.dateKey)).toEqual(['2026-09-01', '2026-09-03']);
+  });
+});
+
+describe('computeMoodStreak', () => {
+  it('counts consecutive check-ins ending today', () => {
+    const entries = [entry('2026-09-01', 3), entry('2026-09-02', 4), entry('2026-09-03', 3)];
+    expect(computeMoodStreak(entries, new Date(2026, 8, 3))).toBe(3);
+  });
+
+  it('does not reset just because today has no check-in yet', () => {
+    const entries = [entry('2026-09-01', 3), entry('2026-09-02', 4)];
+    expect(computeMoodStreak(entries, new Date(2026, 8, 3))).toBe(2);
+  });
+
+  it('stops at the first gap', () => {
+    const entries = [entry('2026-08-30', 2), entry('2026-09-02', 4), entry('2026-09-03', 3)];
+    expect(computeMoodStreak(entries, new Date(2026, 8, 3))).toBe(2);
+  });
+
+  it('is zero with no check-ins at all', () => {
+    expect(computeMoodStreak([], new Date(2026, 8, 3))).toBe(0);
+  });
+});
+
+describe('computeAverageMood', () => {
+  it('averages mood values', () => {
+    expect(computeAverageMood([entry('2026-09-01', 2), entry('2026-09-02', 4)])).toBe(3);
+  });
+
+  it('returns null with no entries, not NaN or 0', () => {
+    expect(computeAverageMood([])).toBeNull();
+  });
+});
+
+describe('computeMoodByWorkloadLevel', () => {
+  it('buckets check-ins by that day due-hours level and averages mood within each', () => {
+    const entries = [
+      entry('2026-09-01', 4), // 0h due -> low
+      entry('2026-09-02', 1), // 8h due -> critical
+      entry('2026-09-03', 3), // 2h due -> low
+    ];
+    const items = [item('2026-09-02', 8)];
+    const buckets = computeMoodByWorkloadLevel(entries, items);
+
+    const low = buckets.find((b) => b.level === 'low')!;
+    expect(low.count).toBe(2);
+    expect(low.averageMood).toBe(3.5);
+
+    const critical = buckets.find((b) => b.level === 'critical')!;
+    expect(critical.count).toBe(1);
+    expect(critical.averageMood).toBe(1);
+
+    const medium = buckets.find((b) => b.level === 'medium')!;
+    expect(medium.count).toBe(0);
+    expect(medium.averageMood).toBeNull();
+  });
+
+  it('always returns all four levels even with zero entries', () => {
+    const buckets = computeMoodByWorkloadLevel([], []);
+    expect(buckets.map((b) => b.level)).toEqual(['low', 'medium', 'high', 'critical']);
+    expect(buckets.every((b) => b.count === 0 && b.averageMood === null)).toBe(true);
+  });
+});
+
+describe('computeMoodTrend', () => {
+  it('returns a sorted, chart-ready series', () => {
+    const trend = computeMoodTrend([entry('2026-09-02', 4), entry('2026-09-01', 2)]);
+    expect(trend).toEqual([
+      { dateKey: '2026-09-01', mood: 2 },
+      { dateKey: '2026-09-02', mood: 4 },
+    ]);
+  });
+});
+
+describe('computeBestAndWorstDay', () => {
+  it('finds the highest and lowest mood day', () => {
+    const entries = [entry('2026-09-01', 2), entry('2026-09-02', 4), entry('2026-09-03', 1)];
+    const { best, worst } = computeBestAndWorstDay(entries);
+    expect(best).toEqual({ dateKey: '2026-09-02', mood: 4 });
+    expect(worst).toEqual({ dateKey: '2026-09-03', mood: 1 });
+  });
+
+  it('breaks ties toward the more recent day', () => {
+    const entries = [entry('2026-09-01', 4), entry('2026-09-05', 4)];
+    const { best } = computeBestAndWorstDay(entries);
+    expect(best).toEqual({ dateKey: '2026-09-05', mood: 4 });
+  });
+
+  it('returns nulls with no entries', () => {
+    expect(computeBestAndWorstDay([])).toEqual({ best: null, worst: null });
+  });
+});

--- a/src/lib/mood/moodScale.ts
+++ b/src/lib/mood/moodScale.ts
@@ -1,0 +1,49 @@
+import type { MoodValue } from '@/types/mood';
+
+export interface MoodOption {
+  value: MoodValue;
+  emoji: string;
+  label: string;
+}
+
+/** Same left-to-right order as the check-in row: worst to best. */
+export const MOOD_OPTIONS: MoodOption[] = [
+  { value: 1, emoji: '😫', label: 'Rough' },
+  { value: 2, emoji: '😐', label: 'Okay' },
+  { value: 3, emoji: '🙂', label: 'Good' },
+  { value: 4, emoji: '😄', label: 'Great' },
+];
+
+export function getMoodOption(mood: MoodValue): MoodOption {
+  return MOOD_OPTIONS[mood - 1];
+}
+
+/**
+ * Mood shares the exact same 4-step color language as WorkloadLevel
+ * (low/medium/high/critical), deliberately inverted end-for-end: a great
+ * day (mood 4) gets the "low load" green, a rough day (mood 1) gets the
+ * "critical load" red. That's what makes the mood-vs-workload correlation
+ * chart legible at a glance - if heavy (red) workload days trend toward
+ * red mood bars too, the colors themselves show the correlation before you
+ * even read a number.
+ */
+export const MOOD_SWATCH_CLASS: Record<MoodValue, string> = {
+  1: 'bg-load-critical',
+  2: 'bg-load-high',
+  3: 'bg-load-medium',
+  4: 'bg-load-low',
+};
+
+export const MOOD_TEXT_CLASS: Record<MoodValue, string> = {
+  1: 'text-load-critical',
+  2: 'text-load-high',
+  3: 'text-load-medium',
+  4: 'text-load-low',
+};
+
+export const MOOD_CHIP_CLASS: Record<MoodValue, string> = {
+  1: 'border-load-critical/30 bg-load-critical/10',
+  2: 'border-load-high/30 bg-load-high/10',
+  3: 'border-load-medium/30 bg-load-medium/10',
+  4: 'border-load-low/30 bg-load-low/10',
+};

--- a/src/lib/mood/moodStats.ts
+++ b/src/lib/mood/moodStats.ts
@@ -1,0 +1,112 @@
+import { toDayKey, parseDayKey } from '@/lib/calendar/dates';
+import { computeDayHoursMap, getDayWorkloadLevel } from '@/lib/planner/semesterHeatmap';
+import type { MoodEntry } from '@/types/mood';
+import type { ScheduleItem, WorkloadLevel } from '@/types/schedule';
+
+function addDays(dayKey: string, delta: number): string {
+  const d = parseDayKey(dayKey);
+  d.setDate(d.getDate() + delta);
+  return toDayKey(d);
+}
+
+/** Sorted oldest-to-newest by dateKey - most of the stats below (streak,
+ * trend line) read more naturally walking forward through time. */
+export function sortMoodEntries(entries: MoodEntry[]): MoodEntry[] {
+  return [...entries].sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+}
+
+/**
+ * Current consecutive-day check-in streak, ending today. Same "today not
+ * checked in yet doesn't reset it" grace as the Pomodoro study streak - a
+ * student who hasn't opened the app yet this morning shouldn't see their
+ * streak already broken.
+ */
+export function computeMoodStreak(entries: MoodEntry[], today: Date = new Date()): number {
+  const dateSet = new Set(entries.map((e) => e.dateKey));
+  let cursor = toDayKey(today);
+  if (!dateSet.has(cursor)) {
+    cursor = addDays(cursor, -1);
+  }
+  let streak = 0;
+  while (dateSet.has(cursor)) {
+    streak += 1;
+    cursor = addDays(cursor, -1);
+  }
+  return streak;
+}
+
+export function computeAverageMood(entries: MoodEntry[]): number | null {
+  if (entries.length === 0) return null;
+  return entries.reduce((sum, e) => sum + e.mood, 0) / entries.length;
+}
+
+export interface MoodByWorkloadBucket {
+  level: WorkloadLevel;
+  count: number;
+  averageMood: number | null;
+}
+
+const LEVEL_ORDER: WorkloadLevel[] = ['low', 'medium', 'high', 'critical'];
+
+/**
+ * Groups check-ins by that day's workload level and averages mood within
+ * each group - the actual "does a heavier day correlate with a worse mood"
+ * answer. A level with zero check-ins still appears (averageMood: null)
+ * rather than being silently dropped, so the chart's x-axis is always the
+ * same four bars regardless of what data happens to exist yet.
+ */
+export function computeMoodByWorkloadLevel(
+  entries: MoodEntry[],
+  scheduleItems: ScheduleItem[],
+): MoodByWorkloadBucket[] {
+  const dayHours = computeDayHoursMap(scheduleItems);
+  const buckets = new Map<WorkloadLevel, number[]>(LEVEL_ORDER.map((l) => [l, []]));
+  for (const entry of entries) {
+    const level = getDayWorkloadLevel(entry.dateKey, dayHours);
+    buckets.get(level)!.push(entry.mood);
+  }
+  return LEVEL_ORDER.map((level) => {
+    const moods = buckets.get(level)!;
+    return {
+      level,
+      count: moods.length,
+      averageMood: moods.length ? moods.reduce((sum, m) => sum + m, 0) / moods.length : null,
+    };
+  });
+}
+
+export interface MoodTrendPoint {
+  dateKey: string;
+  mood: number;
+}
+
+/** The check-in history as a plain, chart-ready series - already sorted,
+ * already just the two fields a trend line needs. */
+export function computeMoodTrend(entries: MoodEntry[]): MoodTrendPoint[] {
+  return sortMoodEntries(entries).map((e) => ({ dateKey: e.dateKey, mood: e.mood }));
+}
+
+export interface BestWorstDay {
+  dateKey: string;
+  mood: number;
+}
+
+/** The single highest and lowest-mood day on record, ties broken toward
+ * the more recent one (a fresher "your best day" story beats a stale one). */
+export function computeBestAndWorstDay(entries: MoodEntry[]): {
+  best: BestWorstDay | null;
+  worst: BestWorstDay | null;
+} {
+  if (entries.length === 0) return { best: null, worst: null };
+  const sorted = sortMoodEntries(entries);
+  let best = sorted[0];
+  let worst = sorted[0];
+  for (const entry of sorted) {
+    if (entry.mood >= best.mood) best = entry;
+    if (entry.mood <= worst.mood) worst = entry;
+  }
+  return {
+    best: { dateKey: best.dateKey, mood: best.mood },
+    worst: { dateKey: worst.dateKey, mood: worst.mood },
+  };
+}

--- a/src/lib/planner/semesterHeatmap.ts
+++ b/src/lib/planner/semesterHeatmap.ts
@@ -18,6 +18,28 @@ function estimateHours(item: ScheduleItem): number {
   return item.type === 'exam' ? 2 : 1;
 }
 
+/** Total due-date hours per day key, across every item that has a due date -
+ * the same lookup `computeSemesterHeatmap` builds internally, exported so
+ * other features (e.g. mood-vs-workload correlation) can look up a specific
+ * day's load without recomputing the whole semester range. */
+export function computeDayHoursMap(scheduleItems: ScheduleItem[]): Map<string, number> {
+  const dayTotals = new Map<string, number>();
+  for (const item of scheduleItems) {
+    if (!item.dueDate) continue;
+    const key = toDayKey(item.dueDate);
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + estimateHours(item));
+  }
+  return dayTotals;
+}
+
+/** The WorkloadLevel for one specific day, given a due-hours lookup from
+ * `computeDayHoursMap`. A day with nothing due at all is 'low' (light), the
+ * same as `getWorkloadLevel(0)` - genuinely nothing due is the lightest
+ * case, not an unknown one. */
+export function getDayWorkloadLevel(dateKey: string, dayHours: Map<string, number>): WorkloadLevel {
+  return getWorkloadLevel(dayHours.get(dateKey) ?? 0);
+}
+
 /**
  * A day-by-day workload heatmap spanning every due date the student has on
  * record, from the earliest to the latest - not scoped to a "current term"
@@ -31,12 +53,7 @@ function estimateHours(item: ScheduleItem): number {
  * which doesn't change once the deadline passes.
  */
 export function computeSemesterHeatmap(scheduleItems: ScheduleItem[]): SemesterHeatmapDay[] {
-  const dayTotals = new Map<string, number>();
-  for (const item of scheduleItems) {
-    if (!item.dueDate) continue;
-    const key = toDayKey(item.dueDate);
-    dayTotals.set(key, (dayTotals.get(key) ?? 0) + estimateHours(item));
-  }
+  const dayTotals = computeDayHoursMap(scheduleItems);
 
   const sortedKeys = Array.from(dayTotals.keys()).sort();
   if (sortedKeys.length === 0) return [];

--- a/src/types/mood.ts
+++ b/src/types/mood.ts
@@ -1,0 +1,19 @@
+/**
+ * A 1-4 daily mood scale, matching the four faces on the check-in button row
+ * (rough / okay / good / great). Deliberately the same width as
+ * WorkloadLevel (low/medium/high/critical) so a mood value and a workload
+ * level can sit on the same visual scale when correlating the two.
+ */
+export type MoodValue = 1 | 2 | 3 | 4;
+
+/**
+ * One check-in per calendar day - `id` is the day key itself (YYYY-MM-DD),
+ * so re-tapping the same day overwrites rather than accumulating duplicate
+ * entries.
+ */
+export interface MoodEntry {
+  id: string;
+  dateKey: string;
+  mood: MoodValue;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- Adds a daily 1-tap emoji check-in widget to the Dashboard (streak tracking, optimistic Firestore write with rollback on failure).
- Adds a full `/mood` recap page: check-ins/average mood/current streak/best-day stat tiles, a mood-over-time trend chart, a mood-by-workload-level correlation chart (reusing the existing low/medium/high/critical color scale), a GitHub-style clickable check-in calendar spanning the full term (with the same row/month labels as the semester heatmap), and best/worst-day callouts.
- Makes the semester heatmap's day cells clickable, deep-linking into `/calendar?date=...` with that day pre-selected.
- Both the semester heatmap and the mood check-in calendar render square cells sized to fill their card's height and centered horizontally, with a visible fill for empty cells.
- Fixes a real bug found during verification: the floating Pomodoro focus timer was force-opening fully expanded on every page load instead of staying collapsed, due to its open-signal effect misreading React Strict Mode's dev-only double-invoke of effects as a genuine trigger.
- Fixes the mood-by-workload bar chart so hovering a workload level with zero check-ins shows "No check-ins yet" instead of nothing — Recharts was skipping both the bar and its hoverable area entirely for a `null` value.
- Moves the mood check-in card down the Dashboard, off the top (where it competed with the hero banner) and in with the other secondary widgets, after the primary task/course content.
- Adds "Mood" to the sidebar, mobile "More" tab bar, and command palette navigation.
- Adds `moodEntries` Firestore security rules (already deployed to production) and a `recharts` dependency (first chart library in the codebase).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds, `/mood` route builds correctly
- `npx vitest run` — 643/643 tests passing (against the real production build, including the security test that scans compiled chunks for a dev-only mock UID)
- Manually verified end-to-end against the Firebase Local Emulator Suite + a live browser session: the dashboard check-in card and its new position, the full recap page's stat tiles/trend chart/correlation chart/labeled full-term calendar grid/best-worst callouts with seeded multi-day history, the heatmap-cell → Calendar deep link, the square-cell grid sizing on both grids, the focus-timer fix (collapsed by default on a fresh load), the check-in calendar spanning a full term with sparse check-ins, and both charts' tooltips on hover (including a dataset engineered to leave workload buckets empty, confirming "No check-ins yet" now shows instead of nothing).

A standalone review document with screenshots was published separately before requesting merge approval.