### PR TITLE
Fix delete feedback across Course/Contact/Task views (success + error)

### DIFF
--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -207,8 +207,12 @@ export function ContactsListView() {
 
   const handleDelete = async (contact: Contact) => {
     if (!user) return;
-    await deleteContact(user.uid, contact, dispatch);
-    setConfirmingDeleteId(null);
+    try {
+      await deleteContact(user.uid, contact, dispatch);
+      setConfirmingDeleteId(null);
+    } catch (err) {
+      showError('Could not delete contact', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleScheduleVisit = async (contact: Contact, dateKey: string) => {

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -210,6 +210,7 @@ export function ContactsListView() {
     try {
       await deleteContact(user.uid, contact, dispatch);
       setConfirmingDeleteId(null);
+      showSuccess('Contact deleted', `${contact.fullName} was removed.`);
     } catch (err) {
       showError('Could not delete contact', err instanceof Error ? err.message : undefined);
     }

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -196,7 +196,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
   const router = useRouter();
-  const { showError } = useToast();
+  const { showSuccess, showError } = useToast();
 
   const [editCourseOpen, setEditCourseOpen] = useState(false);
   const [addTaskOpen, setAddTaskOpen] = useState(false);
@@ -288,6 +288,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     setIsDeletingCourse(true);
     try {
       await deleteCourse(user.uid, course, items, dispatch, courseContacts);
+      showSuccess('Course deleted', `${course.code} and its tasks were removed.`);
       router.push('/dashboard');
     } catch (err) {
       showError('Could not delete course', err instanceof Error ? err.message : undefined);
@@ -352,6 +353,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     try {
       await deleteScheduleItem(user.uid, item, dispatch);
       setConfirmingDeleteItemId(null);
+      showSuccess('Task deleted', `"${item.title}" was removed.`);
     } catch (err) {
       showError('Could not delete task', err instanceof Error ? err.message : undefined);
     } finally {
@@ -435,6 +437,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     try {
       await deleteContact(user.uid, contact, dispatch);
       setConfirmingDeleteContactId(null);
+      showSuccess('Contact deleted', `${contact.fullName} was removed.`);
     } catch (err) {
       showError('Could not delete contact', err instanceof Error ? err.message : undefined);
     } finally {

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -8,6 +8,7 @@ import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { TaskRow } from '@/components/ui/TaskRow';
+import { useToast } from '@/components/ui/Toast';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateCourse, deleteCourse } from '@/lib/firestore/courses';
@@ -195,6 +196,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
   const router = useRouter();
+  const { showError } = useToast();
 
   const [editCourseOpen, setEditCourseOpen] = useState(false);
   const [addTaskOpen, setAddTaskOpen] = useState(false);
@@ -287,6 +289,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     try {
       await deleteCourse(user.uid, course, items, dispatch, courseContacts);
       router.push('/dashboard');
+    } catch (err) {
+      showError('Could not delete course', err instanceof Error ? err.message : undefined);
     } finally {
       setIsDeletingCourse(false);
     }
@@ -348,6 +352,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     try {
       await deleteScheduleItem(user.uid, item, dispatch);
       setConfirmingDeleteItemId(null);
+    } catch (err) {
+      showError('Could not delete task', err instanceof Error ? err.message : undefined);
     } finally {
       setDeletingItemId(null);
     }
@@ -429,6 +435,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     try {
       await deleteContact(user.uid, contact, dispatch);
       setConfirmingDeleteContactId(null);
+    } catch (err) {
+      showError('Could not delete contact', err instanceof Error ? err.message : undefined);
     } finally {
       setDeletingContactId(null);
     }

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -208,7 +208,7 @@ function ExpandableItemList({
 export function PlannerView() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
-  const { showError } = useToast();
+  const { showSuccess, showError } = useToast();
   const { courses, scheduleItems } = state;
 
   const [courseFilter, setCourseFilter] = useState('all');
@@ -404,6 +404,7 @@ export function PlannerView() {
     try {
       await deleteScheduleItem(user.uid, item, dispatch);
       setConfirmingDeleteId(null);
+      showSuccess('Task deleted', `"${item.title}" was removed.`);
     } catch (err) {
       showError('Could not delete task', err instanceof Error ? err.message : undefined);
     }

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import { TaskRow } from '@/components/ui/TaskRow';
+import { useToast } from '@/components/ui/Toast';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
@@ -207,6 +208,7 @@ function ExpandableItemList({
 export function PlannerView() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const { courses, scheduleItems } = state;
 
   const [courseFilter, setCourseFilter] = useState('all');
@@ -399,8 +401,12 @@ export function PlannerView() {
 
   const handleDeleteTask = async (item: ScheduleItem) => {
     if (!user) return;
-    await deleteScheduleItem(user.uid, item, dispatch);
-    setConfirmingDeleteId(null);
+    try {
+      await deleteScheduleItem(user.uid, item, dispatch);
+      setConfirmingDeleteId(null);
+    } catch (err) {
+      showError('Could not delete task', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const selectClass =

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -172,7 +172,7 @@ const destructiveButtonClass =
 export function TaskDetailView({ taskId }: { taskId: string }) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
-  const { showError } = useToast();
+  const { showSuccess, showError } = useToast();
   const router = useRouter();
 
   const [editOpen, setEditOpen] = useState(false);
@@ -296,6 +296,7 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
     if (!user) return;
     try {
       await deleteScheduleItem(user.uid, item, dispatch);
+      showSuccess('Task deleted', `"${item.title}" was removed.`);
       router.push('/tasks');
     } catch (err) {
       showError('Could not delete task', err instanceof Error ? err.message : undefined);

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { BackLink } from '@/components/ui/BackLink';
 import { Card } from '@/components/ui/Card';
+import { useToast } from '@/components/ui/Toast';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { updateScheduleItem, deleteScheduleItem } from '@/lib/firestore/scheduleItems';
@@ -171,6 +172,7 @@ const destructiveButtonClass =
 export function TaskDetailView({ taskId }: { taskId: string }) {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const router = useRouter();
 
   const [editOpen, setEditOpen] = useState(false);
@@ -292,8 +294,12 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   const handleDelete = async () => {
     if (!user) return;
-    await deleteScheduleItem(user.uid, item, dispatch);
-    router.push('/tasks');
+    try {
+      await deleteScheduleItem(user.uid, item, dispatch);
+      router.push('/tasks');
+    } catch (err) {
+      showError('Could not delete task', err instanceof Error ? err.message : undefined);
+    }
   };
 
   return (

--- a/src/components/tasks/__tests__/TaskDetailView.test.tsx
+++ b/src/components/tasks/__tests__/TaskDetailView.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { TaskDetailView } from '../TaskDetailView';
 import { AppStateProvider } from '@/context/AppStateContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { ScheduleItem, Course } from '@/types/schedule';
 
 vi.mock('next/navigation', () => ({
@@ -43,14 +44,16 @@ const mockItem: ScheduleItem = {
 
 function renderTaskDetail(item?: ScheduleItem, course?: Course) {
   return render(
-    <AppStateProvider
-      initialState={{
-        courses: course ? [course] : [],
-        scheduleItems: item ? [item] : [],
-      }}
-    >
-      <TaskDetailView taskId={item?.id ?? 'non-existent'} />
-    </AppStateProvider>,
+    <ToastProvider>
+      <AppStateProvider
+        initialState={{
+          courses: course ? [course] : [],
+          scheduleItems: item ? [item] : [],
+        }}
+      >
+        <TaskDetailView taskId={item?.id ?? 'non-existent'} />
+      </AppStateProvider>
+    </ToastProvider>,
   );
 }
 


### PR DESCRIPTION
## What changed

`deleteCourse`/`deleteContact`/`deleteScheduleItem` already roll back their optimistic state update on failure, but five call sites had no feedback of any kind — success or failure:

- `CourseDetailView.tsx`: `handleDeleteCourse`, `handleDeleteTask`, `handleDeleteContact`
- `ContactsListView.tsx`: `handleDelete`
- `PlannerView.tsx`: `handleDeleteTask`
- `TaskDetailView.tsx`: `handleDelete`

A failed delete silently reverted with zero signal. A **successful** delete was just as silent — the item disappeared with no confirmation either. This wires all five call sites to the existing `ToastProvider`'s `showSuccess` and `showError`, matching the pattern `ContactsListView.tsx` already uses for its office-hours scheduling flow.

## Why

Confirmed during a component-library/scalability audit pass — this is a real correctness/UX gap, not a style nit, so it's shipped as its own small PR ahead of the larger consolidation work.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec): 72 files / 643 tests passing
- **Live-verified** against the real Firebase Local Emulator Suite (Auth/Firestore/Storage) + a live browser session, signed in through the real `/login` form with the repo's `test-credentials.md` fixture account:
  - Normal delete, real permissions → succeeds, shows a **"Task deleted"** success toast.
  - Forced failure (temporarily denied `scheduleItems` writes in `firestore.rules`, reverted immediately after — `git diff firestore.rules` is empty) → shows the **"Could not delete task"** error toast, item rolled back.
