### PR TITLE
Fix silent failures in mark-task-complete (6 duplicated copies)

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -8,6 +8,7 @@ import { TaskRow } from '@/components/ui/TaskRow';
 import { WeekView } from '@/components/calendar/WeekView';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import {
   addDays,
@@ -245,6 +246,7 @@ type ViewMode = 'month' | 'week' | 'agenda';
 export function MonthCalendar() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const searchParams = useSearchParams();
   // A deep link from the semester heatmap (or any other day-grid) lands here
   // pre-selected and scrolled to that day, instead of the plain "today"
@@ -392,7 +394,12 @@ export function MonthCalendar() {
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   // Exports every currently-visible (filter-respecting) item as a single

--- a/src/components/calendar/__tests__/MonthCalendarAriaGrid.test.tsx
+++ b/src/components/calendar/__tests__/MonthCalendarAriaGrid.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { MonthCalendar } from '@/components/calendar/MonthCalendar';
 import { AppStateProvider } from '@/context/AppStateContext';
 import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Course, ScheduleItem } from '@/types/schedule';
 
 vi.hoisted(() => {
@@ -59,11 +60,13 @@ const mockItems: ScheduleItem[] = [
 
 function renderCalendar() {
   return render(
-    <AuthProvider>
-      <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
-        <MonthCalendar />
-      </AppStateProvider>
-    </AuthProvider>,
+    <ToastProvider>
+      <AuthProvider>
+        <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
+          <MonthCalendar />
+        </AppStateProvider>
+      </AuthProvider>
+    </ToastProvider>,
   );
 }
 

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -344,7 +344,12 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   const handleDeleteTask = async (item: ScheduleItem) => {

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -9,6 +9,7 @@ import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import { TaskRow } from '@/components/ui/TaskRow';
+import { useToast } from '@/components/ui/Toast';
 import { resolveActiveTerm, useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
 import { createCourse } from '@/lib/firestore/courses';
@@ -68,6 +69,7 @@ function QuietLink({ href, children }: { href: string; children: ReactNode }) {
 export function DashboardView() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const [addCourseOpen, setAddCourseOpen] = useState(false);
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [autofillOpen, setAutofillOpen] = useState(false);
@@ -194,7 +196,12 @@ export function DashboardView() {
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   return (

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { useAppState } from '@/context/AppStateContext';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
 import { updateScheduleItem } from '@/lib/firestore/scheduleItems';
 import {
   getWorkloadLevel,
@@ -96,6 +97,7 @@ function ExpandableTaskList<T>({
 export function SmartPlanner() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
+  const { showError } = useToast();
   const { courses, scheduleItems } = state;
 
   const referenceDate = useMemo(() => getLocalReferenceDate(), []);
@@ -143,7 +145,12 @@ export function SmartPlanner() {
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   return (

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -373,7 +373,12 @@ export function PlannerView() {
 
   const handleToggleComplete = async (item: ScheduleItem) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   const handleEditTask = async (values: ScheduleItemFormValues) => {

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -215,12 +215,27 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   const handleToggleComplete = async () => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, completed: !item.completed }, dispatch);
+    } catch (err) {
+      console.error('Failed to toggle task:', err);
+      showError("Couldn't update that task. Try again in a moment.");
+    }
   };
 
   const handleSetProgress = async (value: number) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, progress: clampProgress(value) }, dispatch);
+    try {
+      await updateScheduleItem(
+        user.uid,
+        item,
+        { ...item, progress: clampProgress(value) },
+        dispatch,
+      );
+    } catch (err) {
+      console.error('Failed to update progress:', err);
+      showError("Couldn't save your progress update. Try again in a moment.");
+    }
   };
 
   const handleSliderChange = (value: number) => {
@@ -235,7 +250,12 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
 
   const handleSetEstimatedHours = async (value: number) => {
     if (!user) return;
-    await updateScheduleItem(user.uid, item, { ...item, estimatedHours: value }, dispatch);
+    try {
+      await updateScheduleItem(user.uid, item, { ...item, estimatedHours: value }, dispatch);
+    } catch (err) {
+      console.error('Failed to update estimated hours:', err);
+      showError("Couldn't save that estimate. Try again in a moment.");
+    }
   };
 
   const handleHoursInputChange = (raw: string) => {

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -214,11 +214,13 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
 
   it('MonthCalendar PeriodNav, export, and view switcher satisfy 44x44px touch targets', () => {
     render(
-      <AuthProvider>
-        <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
-          <MonthCalendar />
-        </AppStateProvider>
-      </AuthProvider>,
+      <ToastProvider>
+        <AuthProvider>
+          <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
+            <MonthCalendar />
+          </AppStateProvider>
+        </AuthProvider>
+      </ToastProvider>,
     );
 
     const prevBtn = screen.getByRole('button', { name: /Previous month/i });


### PR DESCRIPTION
## What changed

`handleToggleComplete` (the "mark task done" checkbox) is duplicated 6 times across the app — `DashboardView.tsx`, `CourseDetailView.tsx`, `PlannerView.tsx`, `TaskDetailView.tsx`, `MonthCalendar.tsx`, `SmartPlanner.tsx` — and none of them had a try/catch. `updateScheduleItem` dispatches optimistically, rolls back on failure, and rethrows, so a failed write meant the checkbox silently flipped back with zero explanation, on what is likely the single most-used mutation in the app.

Also fixed while in `TaskDetailView.tsx` (same file, same gap): `handleSetProgress` and `handleSetEstimatedHours`, both invoked from inside a debounced `setTimeout` with no `await`/`.catch` — a rejection there was even more invisible than the checkbox case.

All six now match the one place this was already done correctly (`WorkloadOverviewDashboard.handleToggleTask`) — same try/catch shape, same error copy: *"Couldn't update that task. Try again in a moment."* No success toast (matches the existing correct reference implementation — an instant optimistic UI flip is adequate feedback for a frequent, low-stakes action; only the failure case was silent).

Two test files needed a `ToastProvider` wrapper added since `MonthCalendar` now calls `useToast`.

## Why

Found during a full toast-notification-coverage audit across the entire app (every component file, every route, every API handler, read end-to-end). This was the single highest-severity, highest-traffic gap found.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec): 72 files / 643 tests passing
- **Live-verified** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form with the repo's `test-credentials.md` fixture account: temporarily denied `scheduleItems` writes in `firestore.rules` (reverted immediately after — `git diff firestore.rules` is empty), clicked the Dashboard checkbox, and confirmed the error toast renders.
