### PR TITLE
Fix syllabus delete + wire AttendanceGauge persistence

### DIFF
--- a/src/components/courses/AttendanceGauge.tsx
+++ b/src/components/courses/AttendanceGauge.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Card } from '@/components/ui/Card';
+import type { AbsenceRecord } from '@/types/schedule';
 
-export interface AbsenceRecord {
-  id: string;
-  date: string; // YYYY-MM-DD
-  type: 'excused' | 'unexcused';
-  reason?: string;
-  note?: string;
-}
+export type { AbsenceRecord };
 
 export interface AttendanceGaugeProps {
   courseCode?: string;
@@ -21,33 +16,24 @@ export interface AttendanceGaugeProps {
   onAbsenceDeleted?: (id: string) => void;
 }
 
-const DEFAULT_ABSENCES: AbsenceRecord[] = [
-  {
-    id: 'abs-1',
-    date: '2026-09-14',
-    type: 'unexcused',
-    reason: 'Overslept / Traffic',
-    note: 'Missed Lecture 4',
-  },
-  {
-    id: 'abs-2',
-    date: '2026-10-02',
-    type: 'excused',
-    reason: 'Doctor Appointment',
-    note: 'Doctor note submitted to professor',
-  },
-];
-
 export function AttendanceGauge({
   courseCode = 'CS 301',
   courseTitle = 'Data Structures & Algorithms',
   maxAllowedAbsences = 3,
   penaltyDescription = 'Each unexcused absence beyond 3 incurs a 3% deduction from the final grade.',
-  initialAbsences = DEFAULT_ABSENCES,
+  initialAbsences = [],
   onAbsenceLogged,
   onAbsenceDeleted,
 }: AttendanceGaugeProps) {
   const [absences, setAbsences] = useState<AbsenceRecord[]>(initialAbsences);
+
+  // Course switches re-mount this component under a different key in
+  // CourseDetailView, but keep this in sync if that ever changes -
+  // otherwise switching courses without a remount would show stale data.
+  useEffect(() => {
+    setAbsences(initialAbsences);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialAbsences]);
   const [isLoggingModalOpen, setIsLoggingModalOpen] = useState(false);
   const [newDate, setNewDate] = useState('2026-10-15');
   const [newType, setNewType] = useState<'excused' | 'unexcused'>('unexcused');
@@ -85,8 +71,13 @@ export function AttendanceGauge({
       id: `abs-${Date.now()}`,
       date: newDate,
       type: newType,
-      reason: newReason.trim() || undefined,
-      note: newNote.trim() || undefined,
+      // Omit reason/note entirely when blank rather than setting them to
+      // `undefined` - Firestore's setDoc/updateDoc rejects a field whose
+      // value is literally `undefined` (this record used to be local-only
+      // React state, so that never mattered until it started getting
+      // persisted via onAbsenceLogged).
+      ...(newReason.trim() ? { reason: newReason.trim() } : {}),
+      ...(newNote.trim() ? { note: newNote.trim() } : {}),
     };
 
     setAbsences((prev) => [record, ...prev]);

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -34,7 +34,7 @@ import { normalizeMaterials, sumMaterialCosts } from '@/lib/courses/materials';
 import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
-import type { Course, ScheduleItem, Contact, ContactRole } from '@/types/schedule';
+import type { Course, ScheduleItem, Contact, ContactRole, AbsenceRecord } from '@/types/schedule';
 
 const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -567,6 +567,26 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     setAddingMaterial(false);
   };
 
+  const handleLogAbsence = async (record: AbsenceRecord) => {
+    if (!user) return;
+    const current = [record, ...(course.absences ?? [])];
+    try {
+      await updateCourse(user.uid, course, { ...course, absences: current }, dispatch);
+    } catch (err) {
+      showError('Could not save that absence', err instanceof Error ? err.message : undefined);
+    }
+  };
+
+  const handleDeleteAbsence = async (id: string) => {
+    if (!user) return;
+    const current = (course.absences ?? []).filter((a) => a.id !== id);
+    try {
+      await updateCourse(user.uid, course, { ...course, absences: current }, dispatch);
+    } catch (err) {
+      showError('Could not remove that absence', err instanceof Error ? err.message : undefined);
+    }
+  };
+
   const handleExportICS = () => {
     const ics = generateICS(items, [course], new Date());
     const blob = createICSBlob(ics);
@@ -742,6 +762,9 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
           courseCode={course.code}
           courseTitle={course.title}
           maxAllowedAbsences={course.notes?.toLowerCase().includes('attendance') ? 3 : 4}
+          initialAbsences={course.absences ?? []}
+          onAbsenceLogged={handleLogAbsence}
+          onAbsenceDeleted={handleDeleteAbsence}
         />
 
         <Card className="rounded-2xl p-6 space-y-4">

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
 import { deleteSyllabusUpload } from '@/lib/firestore/syllabi';
 import { DocumentViewerModal } from '@/components/syllabus/DocumentViewerModal';
+import { useToast } from '@/components/ui/Toast';
 import type { SyllabusUpload } from '@/types/syllabus';
 
 export interface SyllabusListProps {
@@ -32,8 +33,24 @@ function FileTypeIcon({ fileName }: { fileName: string }) {
 
 export function SyllabusList({ userId, courseId }: SyllabusListProps) {
   const syllabi = useSyllabi(userId, courseId);
+  const { showSuccess, showError } = useToast();
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewingSyllabus, setViewingSyllabus] = useState<SyllabusUpload | null>(null);
+
+  const handleDelete = async (syllabus: SyllabusUpload) => {
+    if (!userId) return;
+    setDeletingId(syllabus.id);
+    try {
+      await deleteSyllabusUpload(userId, syllabus);
+      setConfirmingDeleteId(null);
+      showSuccess('Syllabus deleted', `${syllabus.fileName} was removed.`);
+    } catch (err) {
+      showError('Could not delete this syllabus', err instanceof Error ? err.message : undefined);
+    } finally {
+      setDeletingId(null);
+    }
+  };
 
   if (syllabi.length === 0) return null;
 
@@ -57,17 +74,16 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
           {confirmingDeleteId === syllabus.id ? (
             <div className="flex items-center gap-1.5 text-xs shrink-0">
               <button
-                onClick={() => {
-                  if (userId) deleteSyllabusUpload(userId, syllabus);
-                  setConfirmingDeleteId(null);
-                }}
-                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20"
+                onClick={() => handleDelete(syllabus)}
+                disabled={deletingId === syllabus.id}
+                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                Confirm
+                {deletingId === syllabus.id ? 'Deleting…' : 'Confirm'}
               </button>
               <button
                 onClick={() => setConfirmingDeleteId(null)}
-                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent"
+                disabled={deletingId === syllabus.id}
+                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -29,6 +29,16 @@ export interface MaterialItem {
   cost?: number;
 }
 
+/** A single logged absence for AttendanceGauge's per-course tracker. */
+export interface AbsenceRecord {
+  id: string;
+  /** ISO date (YYYY-MM-DD) */
+  date: string;
+  type: 'excused' | 'unexcused';
+  reason?: string;
+  note?: string;
+}
+
 /**
  * Represents a student's course.
  */
@@ -80,6 +90,8 @@ export interface Course {
    * an AI extraction - mirrors the review step every other AI-sourced
    * field goes through, so objectives are never silently trusted. */
   learningObjectivesApproved?: boolean;
+  /** Manually-logged absences for the attendance tracker (AttendanceGauge). */
+  absences?: AbsenceRecord[];
 }
 
 /** Whether a contact is the instructor of record or a teaching assistant. */


### PR DESCRIPTION
## What changed

`SyllabusList`'s delete button called `deleteSyllabusUpload` fire-and-forget — no `await`, no try/catch. An unhandled rejection on failure, and the confirm UI closed as if it worked either way. Now awaited, wrapped, and toasted both ways.

`AttendanceGauge` was pure local state with two hardcoded fake absence records shown as if real by default, and its `onAbsenceLogged`/`onAbsenceDeleted` callbacks were never wired at the only call site (`CourseDetailView`) — logging an absence looked like it worked, then vanished on refresh. Added `Course.absences`, wired both callbacks through `updateCourse` with error toasts, and dropped the fake default data for an empty starting state.

While verifying live, the new error toast caught a real bug this PR itself introduced: the absence record builder set `reason`/`note` to explicit `undefined` when blank, which Firestore's `setDoc` rejects outright. Fixed to omit the keys instead, matching the conditional-spread pattern already used elsewhere in `CourseDetailView` (materials, objectives).

## Why

Found during the toast-notification audit. The `AttendanceGauge` issue is worse than a missing toast — it's a fully-built feature that silently doesn't save anything.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec): 72 files / 643 tests passing
- **Live-verified** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form: deleted a syllabus (success toast fired), logged an absence, reloaded the page, and confirmed the absence persisted (`ABSENCE HISTORY (1)`).
