### PR TITLE
Fix form error handling + extend dirty-close guard to 3 modals

### DIFF
--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -19,6 +19,7 @@ import { createContact, updateContact, deleteContact } from '@/lib/firestore/con
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useDirtyClose } from '@/hooks/useDirtyClose';
+import { DiscardConfirmCard } from '@/components/ui/DiscardConfirmCard';
 import type { Contact, ContactRole, Course } from '@/types/schedule';
 import { cn, normalizeContactName } from '@/lib/utils';
 
@@ -600,165 +601,155 @@ function ContactFormModal({
         className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {confirmingDiscard && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
-              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
-              <p className="text-xs text-muted-foreground">
-                You have changes to this contact that haven&apos;t been saved.
-              </p>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelDiscard}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  Keep editing
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmDiscard}
-                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
         <Card accent="none">
-          <CardHeader>
-            <CardTitle id="contact-form-title">
-              {initialContact ? 'Edit Contact' : 'Add Contact'}
-            </CardTitle>
-            <CardDescription>
-              {initialContact
-                ? 'Update this contact’s details.'
-                : 'Add a professor or TA to a course.'}
-            </CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              {submitError && (
-                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
-                  {submitError}
-                </div>
-              )}
+          {confirmingDiscard ? (
+            <DiscardConfirmCard
+              title="Discard unsaved changes?"
+              description="You have changes to this contact that haven't been saved."
+              onCancel={cancelDiscard}
+              onConfirm={confirmDiscard}
+            />
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle id="contact-form-title">
+                  {initialContact ? 'Edit Contact' : 'Add Contact'}
+                </CardTitle>
+                <CardDescription>
+                  {initialContact
+                    ? 'Update this contact’s details.'
+                    : 'Add a professor or TA to a course.'}
+                </CardDescription>
+              </CardHeader>
+              <form onSubmit={handleSubmit}>
+                <CardContent className="space-y-4">
+                  {submitError && (
+                    <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                      {submitError}
+                    </div>
+                  )}
 
-              {initialContact ? (
-                <div className="space-y-1.5">
-                  <span className="text-sm font-medium text-foreground">Course</span>
-                  <p className="text-sm text-muted-foreground">
-                    {courseLabel(courses.find((c) => c.id === initialContact.courseId))}
-                  </p>
-                </div>
-              ) : (
-                <div className="space-y-1.5">
-                  <label htmlFor="contact-course" className="text-sm font-medium text-foreground">
-                    Course
-                  </label>
-                  <select
-                    id="contact-course"
-                    value={values.courseId}
-                    onChange={(e) => updateField('courseId', e.target.value)}
-                    className={cn(
-                      'w-full rounded-lg border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
-                      errors.courseId ? 'border-destructive' : 'border-border',
-                    )}
-                  >
-                    <option value="">Select a course...</option>
-                    {courses.map((course) => (
-                      <option key={course.id} value={course.id}>
-                        {courseLabel(course)}
-                      </option>
-                    ))}
-                  </select>
-                  {errors.courseId && <p className="text-xs text-destructive">{errors.courseId}</p>}
-                </div>
-              )}
-
-              <div className="space-y-1.5">
-                <span className="text-sm font-medium text-foreground">Role</span>
-                <div className="flex gap-2">
-                  {(['professor', 'ta', 'classmate'] as ContactRole[]).map((role) => (
-                    <button
-                      key={role}
-                      type="button"
-                      onClick={() => setValues((s) => ({ ...s, role }))}
-                      className={cn(
-                        'inline-flex min-h-[44px] items-center justify-center rounded-lg border px-4 py-2 text-xs font-medium transition-colors',
-                        values.role === role
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-muted-foreground hover:bg-accent',
+                  {initialContact ? (
+                    <div className="space-y-1.5">
+                      <span className="text-sm font-medium text-foreground">Course</span>
+                      <p className="text-sm text-muted-foreground">
+                        {courseLabel(courses.find((c) => c.id === initialContact.courseId))}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="space-y-1.5">
+                      <label
+                        htmlFor="contact-course"
+                        className="text-sm font-medium text-foreground"
+                      >
+                        Course
+                      </label>
+                      <select
+                        id="contact-course"
+                        value={values.courseId}
+                        onChange={(e) => updateField('courseId', e.target.value)}
+                        className={cn(
+                          'w-full rounded-lg border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
+                          errors.courseId ? 'border-destructive' : 'border-border',
+                        )}
+                      >
+                        <option value="">Select a course...</option>
+                        {courses.map((course) => (
+                          <option key={course.id} value={course.id}>
+                            {courseLabel(course)}
+                          </option>
+                        ))}
+                      </select>
+                      {errors.courseId && (
+                        <p className="text-xs text-destructive">{errors.courseId}</p>
                       )}
-                    >
-                      {ROLE_LABEL[role]}
-                    </button>
-                  ))}
-                </div>
-              </div>
+                    </div>
+                  )}
 
-              <Field
-                id="fullName"
-                label="Full Name"
-                value={values.fullName}
-                error={errors.fullName}
-                onChange={(v) => updateField('fullName', v)}
-                placeholder="Dr. Amara Chen"
-              />
-              <Field
-                id="title"
-                label="Title"
-                value={values.title}
-                onChange={(v) => updateField('title', v)}
-                placeholder="Associate Professor of Computer Science"
-              />
-              <Field
-                id="howToAddress"
-                label="Address As"
-                value={values.howToAddress}
-                onChange={(v) => updateField('howToAddress', v)}
-                placeholder="Dr. Chen"
-              />
-              <Field
-                id="email"
-                label="Email"
-                value={values.email}
-                onChange={(v) => updateField('email', v)}
-                placeholder="a.chen@university.edu"
-              />
-              <Field
-                id="officeHours"
-                label="Office Hours"
-                value={values.officeHours}
-                onChange={(v) => updateField('officeHours', v)}
-                placeholder="Tue/Thu 2-3pm, or by appointment"
-              />
-              <Field
-                id="officeLocation"
-                label="Office Location"
-                value={values.officeLocation}
-                onChange={(v) => updateField('officeLocation', v)}
-                placeholder="Science Hall 214"
-              />
-            </CardContent>
-            <CardFooter className="justify-end gap-2">
-              <button
-                type="button"
-                onClick={requestClose}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
-              >
-                {submitting ? 'Saving...' : initialContact ? 'Save Changes' : 'Add Contact'}
-              </button>
-            </CardFooter>
-          </form>
+                  <div className="space-y-1.5">
+                    <span className="text-sm font-medium text-foreground">Role</span>
+                    <div className="flex gap-2">
+                      {(['professor', 'ta', 'classmate'] as ContactRole[]).map((role) => (
+                        <button
+                          key={role}
+                          type="button"
+                          onClick={() => setValues((s) => ({ ...s, role }))}
+                          className={cn(
+                            'inline-flex min-h-[44px] items-center justify-center rounded-lg border px-4 py-2 text-xs font-medium transition-colors',
+                            values.role === role
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border text-muted-foreground hover:bg-accent',
+                          )}
+                        >
+                          {ROLE_LABEL[role]}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <Field
+                    id="fullName"
+                    label="Full Name"
+                    value={values.fullName}
+                    error={errors.fullName}
+                    onChange={(v) => updateField('fullName', v)}
+                    placeholder="Dr. Amara Chen"
+                  />
+                  <Field
+                    id="title"
+                    label="Title"
+                    value={values.title}
+                    onChange={(v) => updateField('title', v)}
+                    placeholder="Associate Professor of Computer Science"
+                  />
+                  <Field
+                    id="howToAddress"
+                    label="Address As"
+                    value={values.howToAddress}
+                    onChange={(v) => updateField('howToAddress', v)}
+                    placeholder="Dr. Chen"
+                  />
+                  <Field
+                    id="email"
+                    label="Email"
+                    value={values.email}
+                    onChange={(v) => updateField('email', v)}
+                    placeholder="a.chen@university.edu"
+                  />
+                  <Field
+                    id="officeHours"
+                    label="Office Hours"
+                    value={values.officeHours}
+                    onChange={(v) => updateField('officeHours', v)}
+                    placeholder="Tue/Thu 2-3pm, or by appointment"
+                  />
+                  <Field
+                    id="officeLocation"
+                    label="Office Location"
+                    value={values.officeLocation}
+                    onChange={(v) => updateField('officeLocation', v)}
+                    placeholder="Science Hall 214"
+                  />
+                </CardContent>
+                <CardFooter className="justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+                  >
+                    {submitting ? 'Saving...' : initialContact ? 'Save Changes' : 'Add Contact'}
+                  </button>
+                </CardFooter>
+              </form>
+            </>
+          )}
         </Card>
       </div>
     </div>

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '@/context/AuthContext';
 import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
 import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 import type { Contact, ContactRole, Course } from '@/types/schedule';
 import { cn, normalizeContactName } from '@/lib/utils';
 
@@ -518,31 +519,39 @@ function ContactFormModal({
   initialContact,
 }: ContactFormModalProps) {
   const [values, setValues] = useState<ContactFormValues>(emptyFormValues(courses[0]?.id ?? ''));
+  const [baseline, setBaseline] = useState<ContactFormValues>(
+    emptyFormValues(courses[0]?.id ?? ''),
+  );
   const [errors, setErrors] = useState<Partial<Record<keyof ContactFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    setValues(
-      initialContact
-        ? {
-            courseId: initialContact.courseId,
-            role: initialContact.role,
-            fullName: initialContact.fullName,
-            title: initialContact.title ?? '',
-            howToAddress: initialContact.howToAddress ?? '',
-            email: initialContact.email ?? '',
-            officeHours: initialContact.officeHours ?? '',
-            officeLocation: initialContact.officeLocation ?? '',
-          }
-        : emptyFormValues(courses[0]?.id ?? ''),
-    );
+    const initial = initialContact
+      ? {
+          courseId: initialContact.courseId,
+          role: initialContact.role,
+          fullName: initialContact.fullName,
+          title: initialContact.title ?? '',
+          howToAddress: initialContact.howToAddress ?? '',
+          email: initialContact.email ?? '',
+          officeHours: initialContact.officeHours ?? '',
+          officeLocation: initialContact.officeLocation ?? '',
+        }
+      : emptyFormValues(courses[0]?.id ?? '');
+    setValues(initial);
+    setBaseline(initial);
     setErrors({});
     setSubmitError(null);
   }, [open, initialContact, courses]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -583,14 +592,40 @@ function ContactFormModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="contact-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this contact that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="contact-form-title">
@@ -710,7 +745,7 @@ function ContactFormModal({
             <CardFooter className="justify-end gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel

--- a/src/components/contacts/ScheduleOfficeVisitModal.tsx
+++ b/src/components/contacts/ScheduleOfficeVisitModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 import { toDayKey } from '@/lib/calendar/dates';
 import type { Contact } from '@/types/schedule';
 
@@ -22,15 +23,22 @@ export function ScheduleOfficeVisitModal({
 }: ScheduleOfficeVisitModalProps) {
   const today = toDayKey(new Date());
   const [date, setDate] = useState(today);
+  const [baseline, setBaseline] = useState(today);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const open = !!contact;
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    date,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   useEffect(() => {
     if (!open) return;
     setDate(today);
+    setBaseline(today);
     setSubmitError(null);
     // `today` intentionally excluded - it should only reset when a new
     // contact opens the modal, not tick over if the modal is left open
@@ -62,14 +70,40 @@ export function ScheduleOfficeVisitModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="schedule-visit-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-md outline-none"
+        className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard the date you picked?</p>
+              <p className="text-xs text-muted-foreground">
+                You changed the date for this visit but haven&apos;t scheduled it yet.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="schedule-visit-title">
@@ -119,7 +153,7 @@ export function ScheduleOfficeVisitModal({
             <div className="flex items-center justify-end gap-2 border-t border-border p-4">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel

--- a/src/components/contacts/ScheduleOfficeVisitModal.tsx
+++ b/src/components/contacts/ScheduleOfficeVisitModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useDirtyClose } from '@/hooks/useDirtyClose';
+import { DiscardConfirmCard } from '@/components/ui/DiscardConfirmCard';
 import { toDayKey } from '@/lib/calendar/dates';
 import type { Contact } from '@/types/schedule';
 
@@ -78,99 +79,84 @@ export function ScheduleOfficeVisitModal({
         className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {confirmingDiscard && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
-              <p className="text-sm font-medium text-foreground">Discard the date you picked?</p>
-              <p className="text-xs text-muted-foreground">
-                You changed the date for this visit but haven&apos;t scheduled it yet.
-              </p>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelDiscard}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  Keep editing
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmDiscard}
-                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
         <Card accent="none">
-          <CardHeader>
-            <CardTitle id="schedule-visit-title">
-              {isClassmate ? 'Schedule a Study Session' : 'Schedule a Visit'}
-            </CardTitle>
-            <CardDescription>Adds a reminder task to your Tasks list.</CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              {submitError && (
-                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
-                  {submitError}
-                </div>
-              )}
+          {confirmingDiscard ? (
+            <DiscardConfirmCard
+              title="Discard the date you picked?"
+              description="You changed the date for this visit but haven't scheduled it yet."
+              onCancel={cancelDiscard}
+              onConfirm={confirmDiscard}
+            />
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle id="schedule-visit-title">
+                  {isClassmate ? 'Schedule a Study Session' : 'Schedule a Visit'}
+                </CardTitle>
+                <CardDescription>Adds a reminder task to your Tasks list.</CardDescription>
+              </CardHeader>
+              <form onSubmit={handleSubmit}>
+                <CardContent className="space-y-4">
+                  {submitError && (
+                    <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                      {submitError}
+                    </div>
+                  )}
 
-              <div className="rounded-xl border border-border bg-muted/50 p-3 text-sm">
-                <div className="font-semibold text-foreground">{contact.fullName}</div>
-                {contact.officeHours && (
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    Office hours: {contact.officeHours}
+                  <div className="rounded-xl border border-border bg-muted/50 p-3 text-sm">
+                    <div className="font-semibold text-foreground">{contact.fullName}</div>
+                    {contact.officeHours && (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        Office hours: {contact.officeHours}
+                      </div>
+                    )}
+                    {contact.officeLocation && (
+                      <div className="text-xs text-muted-foreground">{contact.officeLocation}</div>
+                    )}
                   </div>
-                )}
-                {contact.officeLocation && (
-                  <div className="text-xs text-muted-foreground">{contact.officeLocation}</div>
-                )}
-              </div>
 
-              <div>
-                <label
-                  htmlFor="visit-date"
-                  className="block text-xs font-semibold text-muted-foreground mb-1"
-                >
-                  {isClassmate ? 'Which day are you meeting?' : 'Which day are you going?'}
-                </label>
-                <input
-                  id="visit-date"
-                  type="date"
-                  value={date}
-                  min={today}
-                  onChange={(e) => setDate(e.target.value)}
-                  required
-                  className="w-full min-h-[44px] rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                />
-              </div>
-            </CardContent>
+                  <div>
+                    <label
+                      htmlFor="visit-date"
+                      className="block text-xs font-semibold text-muted-foreground mb-1"
+                    >
+                      {isClassmate ? 'Which day are you meeting?' : 'Which day are you going?'}
+                    </label>
+                    <input
+                      id="visit-date"
+                      type="date"
+                      value={date}
+                      min={today}
+                      onChange={(e) => setDate(e.target.value)}
+                      required
+                      className="w-full min-h-[44px] rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    />
+                  </div>
+                </CardContent>
 
-            <div className="flex items-center justify-end gap-2 border-t border-border p-4">
-              <button
-                type="button"
-                onClick={requestClose}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {submitting
-                  ? 'Scheduling...'
-                  : isClassmate
-                    ? 'Schedule Study Session'
-                    : 'Schedule Visit'}
-              </button>
-            </div>
-          </form>
+                <div className="flex items-center justify-end gap-2 border-t border-border p-4">
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {submitting
+                      ? 'Scheduling...'
+                      : isClassmate
+                        ? 'Schedule Study Session'
+                        : 'Schedule Visit'}
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
         </Card>
       </div>
     </div>

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -394,6 +394,8 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       );
       setNewContact(EMPTY_CONTACT_FORM);
       setAddContactOpen(false);
+    } catch (err) {
+      showError('Could not add contact', err instanceof Error ? err.message : undefined);
     } finally {
       setSavingContact(false);
     }
@@ -414,26 +416,32 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
   const handleSaveContact = async (contact: Contact) => {
     if (!user || !editContact.fullName.trim()) return;
-    await updateContact(
-      user.uid,
-      contact,
-      {
-        ...contact,
-        role: editContact.role,
-        fullName: editContact.fullName.trim(),
-        ...(editContact.title.trim() ? { title: editContact.title.trim() } : {}),
-        ...(editContact.howToAddress.trim()
-          ? { howToAddress: editContact.howToAddress.trim() }
-          : {}),
-        ...(editContact.email.trim() ? { email: editContact.email.trim() } : {}),
-        ...(editContact.officeHours.trim() ? { officeHours: editContact.officeHours.trim() } : {}),
-        ...(editContact.officeLocation.trim()
-          ? { officeLocation: editContact.officeLocation.trim() }
-          : {}),
-      },
-      dispatch,
-    );
-    setEditingContactId(null);
+    try {
+      await updateContact(
+        user.uid,
+        contact,
+        {
+          ...contact,
+          role: editContact.role,
+          fullName: editContact.fullName.trim(),
+          ...(editContact.title.trim() ? { title: editContact.title.trim() } : {}),
+          ...(editContact.howToAddress.trim()
+            ? { howToAddress: editContact.howToAddress.trim() }
+            : {}),
+          ...(editContact.email.trim() ? { email: editContact.email.trim() } : {}),
+          ...(editContact.officeHours.trim()
+            ? { officeHours: editContact.officeHours.trim() }
+            : {}),
+          ...(editContact.officeLocation.trim()
+            ? { officeLocation: editContact.officeLocation.trim() }
+            : {}),
+        },
+        dispatch,
+      );
+      setEditingContactId(null);
+    } catch (err) {
+      showError('Could not save contact', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleDeleteContact = async (contact: Contact) => {
@@ -464,13 +472,17 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     } else {
       current.splice(index, 1);
     }
-    await updateCourse(
-      user.uid,
-      course,
-      { ...course, learningObjectives: current, learningObjectivesApproved: true },
-      dispatch,
-    );
-    setEditingObjectiveIndex(null);
+    try {
+      await updateCourse(
+        user.uid,
+        course,
+        { ...course, learningObjectives: current, learningObjectivesApproved: true },
+        dispatch,
+      );
+      setEditingObjectiveIndex(null);
+    } catch (err) {
+      showError('Could not save that objective', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleDeleteObjective = async (index: number) => {
@@ -499,14 +511,18 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
       return;
     }
     const current = [...(course.learningObjectives ?? []), trimmed];
-    await updateCourse(
-      user.uid,
-      course,
-      { ...course, learningObjectives: current, learningObjectivesApproved: true },
-      dispatch,
-    );
-    setNewObjectiveDraft('');
-    setAddingObjective(false);
+    try {
+      await updateCourse(
+        user.uid,
+        course,
+        { ...course, learningObjectives: current, learningObjectivesApproved: true },
+        dispatch,
+      );
+      setNewObjectiveDraft('');
+      setAddingObjective(false);
+    } catch (err) {
+      showError('Could not add that objective', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleStartEditMaterial = (index: number) => {
@@ -529,8 +545,12 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
     } else {
       current.splice(index, 1);
     }
-    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
-    setEditingMaterialIndex(null);
+    try {
+      await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+      setEditingMaterialIndex(null);
+    } catch (err) {
+      showError('Could not save that material', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleDeleteMaterial = async (index: number) => {
@@ -561,10 +581,14 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         ...(!Number.isNaN(parsedCost) && parsedCost >= 0 ? { cost: parsedCost } : {}),
       },
     ];
-    await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
-    setNewMaterialDraft('');
-    setNewMaterialCostDraft('');
-    setAddingMaterial(false);
+    try {
+      await updateCourse(user.uid, course, { ...course, materials: current }, dispatch);
+      setNewMaterialDraft('');
+      setNewMaterialCostDraft('');
+      setAddingMaterial(false);
+    } catch (err) {
+      showError('Could not add that material', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleLogAbsence = async (record: AbsenceRecord) => {

--- a/src/components/courses/CourseFormModal.tsx
+++ b/src/components/courses/CourseFormModal.tsx
@@ -15,6 +15,7 @@ import type { Course, CourseModality, MeetingTime } from '@/types/schedule';
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useDirtyClose } from '@/hooks/useDirtyClose';
+import { DiscardConfirmCard } from '@/components/ui/DiscardConfirmCard';
 import { useAppState } from '@/context/AppStateContext';
 import { COURSE_COLOR_PRESETS, pickNextCourseColor } from '@/lib/courseColors';
 import { COURSE_ICON_PRESETS, DEFAULT_COURSE_ICON } from '@/lib/courseIcons';
@@ -210,344 +211,336 @@ export function CourseFormModal({ open, onClose, onSubmit, initialCourse }: Cour
         className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {confirmingDiscard && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
-              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
-              <p className="text-xs text-muted-foreground">
-                You have changes to this course that haven&apos;t been saved.
-              </p>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelDiscard}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  Keep editing
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmDiscard}
-                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
         <Card accent="none">
-          <CardHeader>
-            <CardTitle id="course-form-title">
-              {initialCourse ? 'Edit Course' : 'Add Course'}
-            </CardTitle>
-            <CardDescription>
-              {initialCourse ? 'Update this course’s details.' : 'Add a course to track its work.'}
-            </CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              {submitError && (
-                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
-                  {submitError}
-                </div>
-              )}
+          {confirmingDiscard ? (
+            <DiscardConfirmCard
+              title="Discard unsaved changes?"
+              description="You have changes to this course that haven't been saved."
+              onCancel={cancelDiscard}
+              onConfirm={confirmDiscard}
+            />
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle id="course-form-title">
+                  {initialCourse ? 'Edit Course' : 'Add Course'}
+                </CardTitle>
+                <CardDescription>
+                  {initialCourse
+                    ? 'Update this course’s details.'
+                    : 'Add a course to track its work.'}
+                </CardDescription>
+              </CardHeader>
+              <form onSubmit={handleSubmit}>
+                <CardContent className="space-y-4">
+                  {submitError && (
+                    <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                      {submitError}
+                    </div>
+                  )}
 
-              <div className="grid grid-cols-2 gap-3">
-                <Field
-                  id="code"
-                  label="Course Code"
-                  value={values.code}
-                  error={errors.code}
-                  onChange={(v) => updateField('code', v)}
-                  placeholder="CSCI 213"
-                />
-                <Field
-                  id="term"
-                  label="Term"
-                  value={values.term ?? ''}
-                  error={errors.term}
-                  onChange={(v) => updateField('term', v)}
-                  placeholder="Fall 2026"
-                />
-              </div>
-
-              <Field
-                id="title"
-                label="Course Title"
-                value={values.title}
-                error={errors.title}
-                onChange={(v) => updateField('title', v)}
-                placeholder="Computer Science I"
-              />
-
-              <Field
-                id="instructor"
-                label="Instructor"
-                value={values.instructor ?? ''}
-                error={errors.instructor}
-                onChange={(v) => updateField('instructor', v)}
-                placeholder="Dr. Ada Lovelace"
-              />
-
-              <div className="space-y-1.5">
-                <span className="text-sm font-medium text-foreground">Color</span>
-                <div className="flex flex-wrap gap-2">
-                  {COURSE_COLOR_PRESETS.map((preset) => (
-                    <button
-                      key={preset.value}
-                      type="button"
-                      aria-label={`Select ${preset.label ?? preset.value} color`}
-                      aria-pressed={values.color === preset.value}
-                      onClick={() => setValues((s) => ({ ...s, color: preset.value }))}
-                      className={cn(
-                        'h-7 w-7 rounded-full transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                        preset.value,
-                        values.color === preset.value
-                          ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
-                          : 'hover:scale-110',
-                      )}
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field
+                      id="code"
+                      label="Course Code"
+                      value={values.code}
+                      error={errors.code}
+                      onChange={(v) => updateField('code', v)}
+                      placeholder="CSCI 213"
                     />
-                  ))}
-                  <label
-                    aria-label="Custom color"
-                    title="Custom color"
-                    className={cn(
-                      'relative flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
-                      isCustomColor(values.color) &&
-                        'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
-                    )}
-                    style={
-                      isCustomColor(values.color)
-                        ? { backgroundColor: values.color, borderStyle: 'solid' }
-                        : undefined
-                    }
-                  >
-                    {!isCustomColor(values.color) && (
-                      <svg
-                        className="h-3.5 w-3.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
+                    <Field
+                      id="term"
+                      label="Term"
+                      value={values.term ?? ''}
+                      error={errors.term}
+                      onChange={(v) => updateField('term', v)}
+                      placeholder="Fall 2026"
+                    />
+                  </div>
+
+                  <Field
+                    id="title"
+                    label="Course Title"
+                    value={values.title}
+                    error={errors.title}
+                    onChange={(v) => updateField('title', v)}
+                    placeholder="Computer Science I"
+                  />
+
+                  <Field
+                    id="instructor"
+                    label="Instructor"
+                    value={values.instructor ?? ''}
+                    error={errors.instructor}
+                    onChange={(v) => updateField('instructor', v)}
+                    placeholder="Dr. Ada Lovelace"
+                  />
+
+                  <div className="space-y-1.5">
+                    <span className="text-sm font-medium text-foreground">Color</span>
+                    <div className="flex flex-wrap gap-2">
+                      {COURSE_COLOR_PRESETS.map((preset) => (
+                        <button
+                          key={preset.value}
+                          type="button"
+                          aria-label={`Select ${preset.label ?? preset.value} color`}
+                          aria-pressed={values.color === preset.value}
+                          onClick={() => setValues((s) => ({ ...s, color: preset.value }))}
+                          className={cn(
+                            'h-7 w-7 rounded-full transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                            preset.value,
+                            values.color === preset.value
+                              ? 'ring-2 ring-offset-2 ring-primary ring-offset-card scale-110'
+                              : 'hover:scale-110',
+                          )}
+                        />
+                      ))}
+                      <label
+                        aria-label="Custom color"
+                        title="Custom color"
+                        className={cn(
+                          'relative flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-transform hover:scale-110',
+                          isCustomColor(values.color) &&
+                            'border-solid ring-2 ring-offset-2 ring-primary ring-offset-card scale-110',
+                        )}
+                        style={
+                          isCustomColor(values.color)
+                            ? { backgroundColor: values.color, borderStyle: 'solid' }
+                            : undefined
+                        }
                       >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                      </svg>
-                    )}
-                    <input
-                      type="color"
-                      className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-                      value={isCustomColor(values.color) ? values.color : '#7c3aed'}
-                      onChange={(e) => setValues((s) => ({ ...s, color: e.target.value }))}
-                    />
-                  </label>
-                </div>
-              </div>
+                        {!isCustomColor(values.color) && (
+                          <svg
+                            className="h-3.5 w-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                          </svg>
+                        )}
+                        <input
+                          type="color"
+                          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                          value={isCustomColor(values.color) ? values.color : '#7c3aed'}
+                          onChange={(e) => setValues((s) => ({ ...s, color: e.target.value }))}
+                        />
+                      </label>
+                    </div>
+                  </div>
 
-              <div className="space-y-1.5">
-                <span className="text-sm font-medium text-foreground">Icon</span>
-                <div className="flex flex-wrap gap-2">
-                  {COURSE_ICON_PRESETS.map((preset) => (
-                    <button
-                      key={preset.value}
-                      type="button"
-                      title={preset.label}
-                      aria-label={preset.label}
-                      onClick={() => setValues((s) => ({ ...s, icon: preset.value }))}
-                      className={cn(
-                        'flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground transition-colors',
-                        values.icon === preset.value
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border hover:bg-accent',
-                      )}
-                    >
-                      <CourseIconGlyph icon={preset.value} className="h-4 w-4" />
-                    </button>
-                  ))}
-                </div>
-              </div>
+                  <div className="space-y-1.5">
+                    <span className="text-sm font-medium text-foreground">Icon</span>
+                    <div className="flex flex-wrap gap-2">
+                      {COURSE_ICON_PRESETS.map((preset) => (
+                        <button
+                          key={preset.value}
+                          type="button"
+                          title={preset.label}
+                          aria-label={preset.label}
+                          onClick={() => setValues((s) => ({ ...s, icon: preset.value }))}
+                          className={cn(
+                            'flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground transition-colors',
+                            values.icon === preset.value
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border hover:bg-accent',
+                          )}
+                        >
+                          <CourseIconGlyph icon={preset.value} className="h-4 w-4" />
+                        </button>
+                      ))}
+                    </div>
+                  </div>
 
-              <div className="space-y-1.5">
-                <span className="text-sm font-medium text-foreground">Modality</span>
-                <div className="flex gap-2">
-                  {MODALITY_OPTIONS.map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() =>
-                        setValues((s) => ({
-                          ...s,
-                          modality: s.modality === opt.value ? undefined : opt.value,
-                        }))
-                      }
-                      className={cn(
-                        'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
-                        values.modality === opt.value
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-muted-foreground hover:bg-accent',
-                      )}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+                  <div className="space-y-1.5">
+                    <span className="text-sm font-medium text-foreground">Modality</span>
+                    <div className="flex gap-2">
+                      {MODALITY_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          onClick={() =>
+                            setValues((s) => ({
+                              ...s,
+                              modality: s.modality === opt.value ? undefined : opt.value,
+                            }))
+                          }
+                          className={cn(
+                            'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
+                            values.modality === opt.value
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border text-muted-foreground hover:bg-accent',
+                          )}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
 
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-foreground">Weekly meetings</span>
-                  <CardActionButton variant="solid" withPlus onClick={addMeetingTime}>
-                    Add meeting time
-                  </CardActionButton>
-                </div>
-                {meetingTimes.length === 0 ? (
-                  <p className="text-xs text-muted-foreground">
-                    No recurring class sessions yet — add one so it shows up on the calendar.
-                  </p>
-                ) : (
                   <div className="space-y-2">
-                    {meetingTimes.map((meeting, index) => {
-                      const timeInvalid =
-                        !!meeting.startTime &&
-                        !!meeting.endTime &&
-                        meeting.endTime <= meeting.startTime;
-                      return (
-                        <div key={index} className="space-y-1">
-                          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border p-2">
-                            <select
-                              aria-label={`Meeting ${index + 1} day of week`}
-                              value={meeting.dayOfWeek}
-                              onChange={(e) =>
-                                updateMeetingTime(index, { dayOfWeek: Number(e.target.value) })
-                              }
-                              className="rounded-md border border-border bg-input px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                            >
-                              {WEEKDAY_OPTIONS.map((d) => (
-                                <option key={d.value} value={d.value}>
-                                  {d.label}
-                                </option>
-                              ))}
-                            </select>
-                            <input
-                              aria-label={`Meeting ${index + 1} start time`}
-                              type="time"
-                              value={meeting.startTime}
-                              onChange={(e) =>
-                                updateMeetingTime(index, { startTime: e.target.value })
-                              }
-                              className={cn(
-                                'rounded-md border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
-                                timeInvalid ? 'border-destructive' : 'border-border',
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-foreground">Weekly meetings</span>
+                      <CardActionButton variant="solid" withPlus onClick={addMeetingTime}>
+                        Add meeting time
+                      </CardActionButton>
+                    </div>
+                    {meetingTimes.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">
+                        No recurring class sessions yet — add one so it shows up on the calendar.
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {meetingTimes.map((meeting, index) => {
+                          const timeInvalid =
+                            !!meeting.startTime &&
+                            !!meeting.endTime &&
+                            meeting.endTime <= meeting.startTime;
+                          return (
+                            <div key={index} className="space-y-1">
+                              <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border p-2">
+                                <select
+                                  aria-label={`Meeting ${index + 1} day of week`}
+                                  value={meeting.dayOfWeek}
+                                  onChange={(e) =>
+                                    updateMeetingTime(index, { dayOfWeek: Number(e.target.value) })
+                                  }
+                                  className="rounded-md border border-border bg-input px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                                >
+                                  {WEEKDAY_OPTIONS.map((d) => (
+                                    <option key={d.value} value={d.value}>
+                                      {d.label}
+                                    </option>
+                                  ))}
+                                </select>
+                                <input
+                                  aria-label={`Meeting ${index + 1} start time`}
+                                  type="time"
+                                  value={meeting.startTime}
+                                  onChange={(e) =>
+                                    updateMeetingTime(index, { startTime: e.target.value })
+                                  }
+                                  className={cn(
+                                    'rounded-md border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
+                                    timeInvalid ? 'border-destructive' : 'border-border',
+                                  )}
+                                />
+                                <span className="text-xs text-muted-foreground">to</span>
+                                <input
+                                  aria-label={`Meeting ${index + 1} end time`}
+                                  type="time"
+                                  value={meeting.endTime}
+                                  onChange={(e) =>
+                                    updateMeetingTime(index, { endTime: e.target.value })
+                                  }
+                                  className={cn(
+                                    'rounded-md border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
+                                    timeInvalid ? 'border-destructive' : 'border-border',
+                                  )}
+                                />
+                                <input
+                                  aria-label={`Meeting ${index + 1} location`}
+                                  value={meeting.location ?? ''}
+                                  onChange={(e) =>
+                                    updateMeetingTime(index, { location: e.target.value })
+                                  }
+                                  placeholder="Location (optional)"
+                                  className="min-w-[9rem] flex-1 rounded-md border border-border bg-input px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                                />
+                                <button
+                                  type="button"
+                                  onClick={() => removeMeetingTime(index)}
+                                  aria-label={`Remove meeting ${index + 1}`}
+                                  className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                                >
+                                  ✕
+                                </button>
+                              </div>
+                              {timeInvalid && (
+                                <p className="text-xs text-destructive" role="alert">
+                                  End time must be after start time.
+                                </p>
                               )}
-                            />
-                            <span className="text-xs text-muted-foreground">to</span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {errors.meetingTimes && (
+                      <p className="text-xs text-destructive">{errors.meetingTimes}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-foreground">
+                        Skip dates (holidays &amp; breaks)
+                      </span>
+                      <CardActionButton variant="solid" withPlus onClick={addSkipDate}>
+                        Add skip date
+                      </CardActionButton>
+                    </div>
+                    {skipDates.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">
+                        No skipped dates yet — add one to hide a weekly meeting on a holiday or
+                        break.
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {skipDates.map((date, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 rounded-lg border border-border p-2"
+                          >
                             <input
-                              aria-label={`Meeting ${index + 1} end time`}
-                              type="time"
-                              value={meeting.endTime}
-                              onChange={(e) =>
-                                updateMeetingTime(index, { endTime: e.target.value })
-                              }
-                              className={cn(
-                                'rounded-md border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
-                                timeInvalid ? 'border-destructive' : 'border-border',
-                              )}
-                            />
-                            <input
-                              aria-label={`Meeting ${index + 1} location`}
-                              value={meeting.location ?? ''}
-                              onChange={(e) =>
-                                updateMeetingTime(index, { location: e.target.value })
-                              }
-                              placeholder="Location (optional)"
-                              className="min-w-[9rem] flex-1 rounded-md border border-border bg-input px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                              aria-label={`Skip date ${index + 1}`}
+                              type="date"
+                              value={date}
+                              onChange={(e) => updateSkipDate(index, e.target.value)}
+                              className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
                             />
                             <button
                               type="button"
-                              onClick={() => removeMeetingTime(index)}
-                              aria-label={`Remove meeting ${index + 1}`}
+                              onClick={() => removeSkipDate(index)}
+                              aria-label={`Remove skip date ${index + 1}`}
                               className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
                             >
                               ✕
                             </button>
                           </div>
-                          {timeInvalid && (
-                            <p className="text-xs text-destructive" role="alert">
-                              End time must be after start time.
-                            </p>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-                {errors.meetingTimes && (
-                  <p className="text-xs text-destructive">{errors.meetingTimes}</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-foreground">
-                    Skip dates (holidays &amp; breaks)
-                  </span>
-                  <CardActionButton variant="solid" withPlus onClick={addSkipDate}>
-                    Add skip date
-                  </CardActionButton>
-                </div>
-                {skipDates.length === 0 ? (
-                  <p className="text-xs text-muted-foreground">
-                    No skipped dates yet — add one to hide a weekly meeting on a holiday or break.
-                  </p>
-                ) : (
-                  <div className="space-y-2">
-                    {skipDates.map((date, index) => (
-                      <div
-                        key={index}
-                        className="flex items-center gap-2 rounded-lg border border-border p-2"
-                      >
-                        <input
-                          aria-label={`Skip date ${index + 1}`}
-                          type="date"
-                          value={date}
-                          onChange={(e) => updateSkipDate(index, e.target.value)}
-                          className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => removeSkipDate(index)}
-                          aria-label={`Remove skip date ${index + 1}`}
-                          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-                        >
-                          ✕
-                        </button>
+                        ))}
                       </div>
-                    ))}
+                    )}
+                    {errors.skipDates && (
+                      <p className="text-xs text-destructive">{errors.skipDates}</p>
+                    )}
                   </div>
-                )}
-                {errors.skipDates && <p className="text-xs text-destructive">{errors.skipDates}</p>}
-              </div>
-            </CardContent>
-            <CardFooter className="justify-end gap-2">
-              <button
-                type="button"
-                onClick={requestClose}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={
-                  submitting ||
-                  meetingTimes.some((m) => !!m.startTime && !!m.endTime && m.endTime <= m.startTime)
-                }
-                className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
-              >
-                {submitting ? 'Saving...' : initialCourse ? 'Save Changes' : 'Add Course'}
-              </button>
-            </CardFooter>
-          </form>
+                </CardContent>
+                <CardFooter className="justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={
+                      submitting ||
+                      meetingTimes.some(
+                        (m) => !!m.startTime && !!m.endTime && m.endTime <= m.startTime,
+                      )
+                    }
+                    className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
+                  >
+                    {submitting ? 'Saving...' : initialCourse ? 'Save Changes' : 'Add Course'}
+                  </button>
+                </CardFooter>
+              </form>
+            </>
+          )}
         </Card>
       </div>
     </div>

--- a/src/components/courses/SourceFormModal.tsx
+++ b/src/components/courses/SourceFormModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import { useModalA11y } from '@/hooks/useModalA11y';
+import { useDirtyClose } from '@/hooks/useDirtyClose';
 import type { Source, SourceAuthor, SourceType } from '@/types/source';
 
 export interface SourceFormValues {
@@ -77,16 +78,24 @@ const labelClass = 'block text-xs font-semibold text-muted-foreground mb-1';
 
 export function SourceFormModal({ open, onClose, onSubmit, initialSource }: SourceFormModalProps) {
   const [values, setValues] = useState<SourceFormValues>(emptyValues());
+  const [baseline, setBaseline] = useState<SourceFormValues>(emptyValues());
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (!open) return;
-    setValues(initialSource ? valuesFromSource(initialSource) : emptyValues());
+    const initial = initialSource ? valuesFromSource(initialSource) : emptyValues();
+    setValues(initial);
+    setBaseline(initial);
     setError(null);
   }, [open, initialSource]);
 
-  const dialogRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const { requestClose, confirmingDiscard, confirmDiscard, cancelDiscard } = useDirtyClose(
+    values,
+    baseline,
+    onClose,
+  );
+  const dialogRef = useModalA11y<HTMLDivElement>(open, requestClose);
 
   if (!open) return null;
 
@@ -133,14 +142,40 @@ export function SourceFormModal({ open, onClose, onSubmit, initialSource }: Sour
       role="dialog"
       aria-modal="true"
       aria-labelledby="source-form-title"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-lg outline-none"
+        className="relative w-full max-w-lg outline-none"
         onClick={(e) => e.stopPropagation()}
       >
+        {confirmingDiscard && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
+              <p className="text-xs text-muted-foreground">
+                You have changes to this source that haven&apos;t been saved.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelDiscard}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmDiscard}
+                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Card accent="none">
           <CardHeader>
             <CardTitle id="source-form-title">
@@ -370,7 +405,7 @@ export function SourceFormModal({ open, onClose, onSubmit, initialSource }: Sour
             <div className="flex items-center justify-end gap-2 border-t border-border p-4">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
               >
                 Cancel

--- a/src/components/courses/SourceFormModal.tsx
+++ b/src/components/courses/SourceFormModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useDirtyClose } from '@/hooks/useDirtyClose';
+import { DiscardConfirmCard } from '@/components/ui/DiscardConfirmCard';
 import type { Source, SourceAuthor, SourceType } from '@/types/source';
 
 export interface SourceFormValues {
@@ -150,275 +151,262 @@ export function SourceFormModal({ open, onClose, onSubmit, initialSource }: Sour
         className="relative w-full max-w-lg outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {confirmingDiscard && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
-              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
-              <p className="text-xs text-muted-foreground">
-                You have changes to this source that haven&apos;t been saved.
-              </p>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelDiscard}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  Keep editing
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmDiscard}
-                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
         <Card accent="none">
-          <CardHeader>
-            <CardTitle id="source-form-title">
-              {initialSource ? 'Edit Source' : 'Add Source'}
-            </CardTitle>
-            <CardDescription>Formatted into APA, MLA, or Chicago automatically.</CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="max-h-[65vh] space-y-4 overflow-y-auto">
-              {error && (
-                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
-                  {error}
-                </div>
-              )}
+          {confirmingDiscard ? (
+            <DiscardConfirmCard
+              title="Discard unsaved changes?"
+              description="You have changes to this source that haven't been saved."
+              onCancel={cancelDiscard}
+              onConfirm={confirmDiscard}
+            />
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle id="source-form-title">
+                  {initialSource ? 'Edit Source' : 'Add Source'}
+                </CardTitle>
+                <CardDescription>
+                  Formatted into APA, MLA, or Chicago automatically.
+                </CardDescription>
+              </CardHeader>
+              <form onSubmit={handleSubmit}>
+                <CardContent className="max-h-[65vh] space-y-4 overflow-y-auto">
+                  {error && (
+                    <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                      {error}
+                    </div>
+                  )}
 
-              <div>
-                <label className={labelClass}>Source type</label>
-                <div className="flex flex-wrap gap-1.5">
-                  {SOURCE_TYPE_OPTIONS.map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => update('type', opt.value)}
-                      className={`min-h-[36px] rounded-full px-3 text-xs font-semibold transition-colors ${
-                        values.type === opt.value
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-muted/50 text-muted-foreground hover:bg-accent'
-                      }`}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div>
-                <label htmlFor="source-title" className={labelClass}>
-                  Title
-                </label>
-                <input
-                  id="source-title"
-                  value={values.title}
-                  onChange={(e) => update('title', e.target.value)}
-                  className={fieldClass}
-                  required
-                />
-              </div>
-
-              <div>
-                <label className={labelClass}>Authors</label>
-                <div className="space-y-2">
-                  {values.authors.map((author, i) => (
-                    <div key={i} className="flex gap-2">
-                      <input
-                        aria-label={`Author ${i + 1} first name`}
-                        placeholder="First name"
-                        value={author.firstName}
-                        onChange={(e) => updateAuthor(i, 'firstName', e.target.value)}
-                        className={fieldClass}
-                      />
-                      <input
-                        aria-label={`Author ${i + 1} last name`}
-                        placeholder="Last name"
-                        value={author.lastName}
-                        onChange={(e) => updateAuthor(i, 'lastName', e.target.value)}
-                        className={fieldClass}
-                      />
-                      {values.authors.length > 1 && (
+                  <div>
+                    <label className={labelClass}>Source type</label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {SOURCE_TYPE_OPTIONS.map((opt) => (
                         <button
+                          key={opt.value}
                           type="button"
-                          onClick={() => removeAuthor(i)}
-                          aria-label={`Remove author ${i + 1}`}
-                          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-destructive"
+                          onClick={() => update('type', opt.value)}
+                          className={`min-h-[36px] rounded-full px-3 text-xs font-semibold transition-colors ${
+                            values.type === opt.value
+                              ? 'bg-primary text-primary-foreground'
+                              : 'bg-muted/50 text-muted-foreground hover:bg-accent'
+                          }`}
                         >
-                          ×
+                          {opt.label}
                         </button>
-                      )}
+                      ))}
                     </div>
-                  ))}
-                </div>
-                <button
-                  type="button"
-                  onClick={addAuthor}
-                  className="mt-2 text-xs font-semibold text-primary hover:underline"
-                >
-                  + Add another author
-                </button>
-              </div>
+                  </div>
 
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label htmlFor="source-year" className={labelClass}>
-                    Year
-                  </label>
-                  <input
-                    id="source-year"
-                    value={values.year}
-                    onChange={(e) => update('year', e.target.value)}
-                    placeholder="2024"
-                    className={fieldClass}
-                  />
-                </div>
+                  <div>
+                    <label htmlFor="source-title" className={labelClass}>
+                      Title
+                    </label>
+                    <input
+                      id="source-title"
+                      value={values.title}
+                      onChange={(e) => update('title', e.target.value)}
+                      className={fieldClass}
+                      required
+                    />
+                  </div>
 
-                {values.type === 'book' && (
                   <div>
-                    <label htmlFor="source-publisher" className={labelClass}>
-                      Publisher
-                    </label>
-                    <input
-                      id="source-publisher"
-                      value={values.publisher}
-                      onChange={(e) => update('publisher', e.target.value)}
-                      className={fieldClass}
-                    />
+                    <label className={labelClass}>Authors</label>
+                    <div className="space-y-2">
+                      {values.authors.map((author, i) => (
+                        <div key={i} className="flex gap-2">
+                          <input
+                            aria-label={`Author ${i + 1} first name`}
+                            placeholder="First name"
+                            value={author.firstName}
+                            onChange={(e) => updateAuthor(i, 'firstName', e.target.value)}
+                            className={fieldClass}
+                          />
+                          <input
+                            aria-label={`Author ${i + 1} last name`}
+                            placeholder="Last name"
+                            value={author.lastName}
+                            onChange={(e) => updateAuthor(i, 'lastName', e.target.value)}
+                            className={fieldClass}
+                          />
+                          {values.authors.length > 1 && (
+                            <button
+                              type="button"
+                              onClick={() => removeAuthor(i)}
+                              aria-label={`Remove author ${i + 1}`}
+                              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-destructive"
+                            >
+                              ×
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={addAuthor}
+                      className="mt-2 text-xs font-semibold text-primary hover:underline"
+                    >
+                      + Add another author
+                    </button>
                   </div>
-                )}
-              </div>
 
-              {values.type === 'website' && (
-                <>
-                  <div>
-                    <label htmlFor="source-site-name" className={labelClass}>
-                      Site name
-                    </label>
-                    <input
-                      id="source-site-name"
-                      value={values.siteName}
-                      onChange={(e) => update('siteName', e.target.value)}
-                      className={fieldClass}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="source-url" className={labelClass}>
-                      URL
-                    </label>
-                    <input
-                      id="source-url"
-                      type="url"
-                      value={values.url}
-                      onChange={(e) => update('url', e.target.value)}
-                      className={fieldClass}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="source-accessed" className={labelClass}>
-                      Accessed on
-                    </label>
-                    <input
-                      id="source-accessed"
-                      type="date"
-                      value={values.accessedDate}
-                      onChange={(e) => update('accessedDate', e.target.value)}
-                      className={fieldClass}
-                    />
-                  </div>
-                </>
-              )}
-
-              {values.type === 'journal' && (
-                <>
-                  <div>
-                    <label htmlFor="source-journal-name" className={labelClass}>
-                      Journal name
-                    </label>
-                    <input
-                      id="source-journal-name"
-                      value={values.journalName}
-                      onChange={(e) => update('journalName', e.target.value)}
-                      className={fieldClass}
-                    />
-                  </div>
-                  <div className="grid grid-cols-3 gap-3">
+                  <div className="grid grid-cols-2 gap-3">
                     <div>
-                      <label htmlFor="source-volume" className={labelClass}>
-                        Volume
+                      <label htmlFor="source-year" className={labelClass}>
+                        Year
                       </label>
                       <input
-                        id="source-volume"
-                        value={values.volume}
-                        onChange={(e) => update('volume', e.target.value)}
+                        id="source-year"
+                        value={values.year}
+                        onChange={(e) => update('year', e.target.value)}
+                        placeholder="2024"
                         className={fieldClass}
                       />
                     </div>
-                    <div>
-                      <label htmlFor="source-issue" className={labelClass}>
-                        Issue
-                      </label>
-                      <input
-                        id="source-issue"
-                        value={values.issue}
-                        onChange={(e) => update('issue', e.target.value)}
-                        className={fieldClass}
-                      />
-                    </div>
-                    <div>
-                      <label htmlFor="source-pages" className={labelClass}>
-                        Pages
-                      </label>
-                      <input
-                        id="source-pages"
-                        value={values.pages}
-                        onChange={(e) => update('pages', e.target.value)}
-                        placeholder="210-234"
-                        className={fieldClass}
-                      />
-                    </div>
+
+                    {values.type === 'book' && (
+                      <div>
+                        <label htmlFor="source-publisher" className={labelClass}>
+                          Publisher
+                        </label>
+                        <input
+                          id="source-publisher"
+                          value={values.publisher}
+                          onChange={(e) => update('publisher', e.target.value)}
+                          className={fieldClass}
+                        />
+                      </div>
+                    )}
                   </div>
-                </>
-              )}
 
-              {values.type === 'other' && (
-                <div>
-                  <label htmlFor="source-notes" className={labelClass}>
-                    Notes
-                  </label>
-                  <textarea
-                    id="source-notes"
-                    value={values.notes}
-                    onChange={(e) => update('notes', e.target.value)}
-                    rows={2}
-                    className={fieldClass}
-                  />
+                  {values.type === 'website' && (
+                    <>
+                      <div>
+                        <label htmlFor="source-site-name" className={labelClass}>
+                          Site name
+                        </label>
+                        <input
+                          id="source-site-name"
+                          value={values.siteName}
+                          onChange={(e) => update('siteName', e.target.value)}
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="source-url" className={labelClass}>
+                          URL
+                        </label>
+                        <input
+                          id="source-url"
+                          type="url"
+                          value={values.url}
+                          onChange={(e) => update('url', e.target.value)}
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="source-accessed" className={labelClass}>
+                          Accessed on
+                        </label>
+                        <input
+                          id="source-accessed"
+                          type="date"
+                          value={values.accessedDate}
+                          onChange={(e) => update('accessedDate', e.target.value)}
+                          className={fieldClass}
+                        />
+                      </div>
+                    </>
+                  )}
+
+                  {values.type === 'journal' && (
+                    <>
+                      <div>
+                        <label htmlFor="source-journal-name" className={labelClass}>
+                          Journal name
+                        </label>
+                        <input
+                          id="source-journal-name"
+                          value={values.journalName}
+                          onChange={(e) => update('journalName', e.target.value)}
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div className="grid grid-cols-3 gap-3">
+                        <div>
+                          <label htmlFor="source-volume" className={labelClass}>
+                            Volume
+                          </label>
+                          <input
+                            id="source-volume"
+                            value={values.volume}
+                            onChange={(e) => update('volume', e.target.value)}
+                            className={fieldClass}
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="source-issue" className={labelClass}>
+                            Issue
+                          </label>
+                          <input
+                            id="source-issue"
+                            value={values.issue}
+                            onChange={(e) => update('issue', e.target.value)}
+                            className={fieldClass}
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="source-pages" className={labelClass}>
+                            Pages
+                          </label>
+                          <input
+                            id="source-pages"
+                            value={values.pages}
+                            onChange={(e) => update('pages', e.target.value)}
+                            placeholder="210-234"
+                            className={fieldClass}
+                          />
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {values.type === 'other' && (
+                    <div>
+                      <label htmlFor="source-notes" className={labelClass}>
+                        Notes
+                      </label>
+                      <textarea
+                        id="source-notes"
+                        value={values.notes}
+                        onChange={(e) => update('notes', e.target.value)}
+                        rows={2}
+                        className={fieldClass}
+                      />
+                    </div>
+                  )}
+                </CardContent>
+
+                <div className="flex items-center justify-end gap-2 border-t border-border p-4">
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {submitting ? 'Saving...' : initialSource ? 'Save Changes' : 'Add Source'}
+                  </button>
                 </div>
-              )}
-            </CardContent>
-
-            <div className="flex items-center justify-end gap-2 border-t border-border p-4">
-              <button
-                type="button"
-                onClick={requestClose}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {submitting ? 'Saving...' : initialSource ? 'Save Changes' : 'Add Source'}
-              </button>
-            </div>
-          </form>
+              </form>
+            </>
+          )}
         </Card>
       </div>
     </div>

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -14,6 +14,7 @@ import type { Course, ScheduleItem, AssignmentType, Priority } from '@/types/sch
 import { cn } from '@/lib/utils';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useDirtyClose } from '@/hooks/useDirtyClose';
+import { DiscardConfirmCard } from '@/components/ui/DiscardConfirmCard';
 
 const TYPE_OPTIONS: { value: AssignmentType; label: string }[] = [
   { value: 'assignment', label: 'Assignment' },
@@ -148,226 +149,213 @@ export function TaskFormModal({
         className="relative w-full max-w-md outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {confirmingDiscard && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
-              <p className="text-sm font-medium text-foreground">Discard unsaved changes?</p>
-              <p className="text-xs text-muted-foreground">
-                You have changes to this task that haven&apos;t been saved.
-              </p>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelDiscard}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  Keep editing
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmDiscard}
-                  className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
         <Card accent="none">
-          <CardHeader>
-            <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
-            <CardDescription>
-              {initialItem ? 'Update this task’s details.' : 'Add an assignment, exam, or task.'}
-            </CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              {submitError && (
-                <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
-                  {submitError}
-                </div>
-              )}
-
-              {courses.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  Add a course first before creating tasks for it.
-                </p>
-              ) : (
-                <>
-                  <Field
-                    id="title"
-                    label="Title"
-                    value={values.title}
-                    error={errors.title}
-                    onChange={(v) => updateField('title', v)}
-                    placeholder="Programming Assignment 1"
-                  />
-
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="space-y-1.5">
-                      <label htmlFor="courseId" className="text-sm font-medium text-foreground">
-                        Course
-                      </label>
-                      <select
-                        id="courseId"
-                        value={values.courseId}
-                        onChange={(e) => updateField('courseId', e.target.value)}
-                        className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                      >
-                        {courses.map((course) => (
-                          <option key={course.id} value={course.id}>
-                            {course.code}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div className="space-y-1.5">
-                      <label htmlFor="type" className="text-sm font-medium text-foreground">
-                        Type
-                      </label>
-                      <select
-                        id="type"
-                        value={values.type}
-                        onChange={(e) => updateField('type', e.target.value as AssignmentType)}
-                        className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                      >
-                        {TYPE_OPTIONS.map((opt) => (
-                          <option key={opt.value} value={opt.value}>
-                            {opt.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-3">
-                    <Field
-                      id="dueDate"
-                      label="Due Date"
-                      type="date"
-                      value={values.dueDate}
-                      error={errors.dueDate}
-                      onChange={(v) => updateField('dueDate', v)}
-                    />
-                    <Field
-                      id="estimatedHours"
-                      label="Est. Hours"
-                      type="number"
-                      value={values.estimatedHours ?? ''}
-                      error={errors.estimatedHours}
-                      onChange={(v) => updateField('estimatedHours', v)}
-                      placeholder="3"
-                    />
-                  </div>
-
-                  <div className="space-y-1.5">
-                    <span className="text-sm font-medium text-foreground">Priority</span>
-                    <div className="flex gap-2">
-                      {PRIORITY_OPTIONS.map((opt) => (
-                        <button
-                          key={opt.value}
-                          type="button"
-                          onClick={() => updateField('priority', opt.value)}
-                          className={cn(
-                            'flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors',
-                            values.priority === opt.value
-                              ? 'border-primary bg-primary/10 text-primary'
-                              : 'border-border text-muted-foreground hover:bg-accent',
-                          )}
-                        >
-                          {opt.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  {initialItem && (
-                    <div className="space-y-1.5">
-                      <label htmlFor="progress" className="text-sm font-medium text-foreground">
-                        Progress
-                      </label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          id="progress"
-                          type="number"
-                          min={0}
-                          max={100}
-                          step={5}
-                          value={values.progress ?? ''}
-                          placeholder="0"
-                          onChange={(e) => updateField('progress', e.target.value)}
-                          className={cn(
-                            'w-24 rounded-lg border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
-                            errors.progress ? 'border-destructive' : 'border-border',
-                          )}
-                        />
-                        <span className="text-sm text-muted-foreground">% complete</span>
-                      </div>
-                      {errors.progress && (
-                        <p className="text-xs text-destructive">{errors.progress}</p>
-                      )}
+          {confirmingDiscard ? (
+            <DiscardConfirmCard
+              title="Discard unsaved changes?"
+              description="You have changes to this task that haven't been saved."
+              onCancel={cancelDiscard}
+              onConfirm={confirmDiscard}
+            />
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle id="task-form-title">{initialItem ? 'Edit Task' : 'Add Task'}</CardTitle>
+                <CardDescription>
+                  {initialItem
+                    ? 'Update this task’s details.'
+                    : 'Add an assignment, exam, or task.'}
+                </CardDescription>
+              </CardHeader>
+              <form onSubmit={handleSubmit}>
+                <CardContent className="space-y-4">
+                  {submitError && (
+                    <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+                      {submitError}
                     </div>
                   )}
 
-                  <div className="grid grid-cols-2 gap-3">
-                    <Field
-                      id="gradeWeight"
-                      label="Grade Weight (%)"
-                      type="number"
-                      value={values.gradeWeight ?? ''}
-                      error={errors.gradeWeight}
-                      onChange={(v) => updateField('gradeWeight', v)}
-                      placeholder="Optional"
-                    />
-                    <Field
-                      id="gradeCategory"
-                      label="Grade Category"
-                      value={values.gradeCategory ?? ''}
-                      error={errors.gradeCategory}
-                      onChange={(v) => updateField('gradeCategory', v)}
-                      placeholder="e.g. Homework"
-                    />
-                  </div>
+                  {courses.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      Add a course first before creating tasks for it.
+                    </p>
+                  ) : (
+                    <>
+                      <Field
+                        id="title"
+                        label="Title"
+                        value={values.title}
+                        error={errors.title}
+                        onChange={(v) => updateField('title', v)}
+                        placeholder="Programming Assignment 1"
+                      />
 
-                  <Field
-                    id="assignedTo"
-                    label="Assigned To"
-                    value={values.assignedTo ?? ''}
-                    error={errors.assignedTo}
-                    onChange={(v) => updateField('assignedTo', v)}
-                    placeholder="e.g. Priya, or You - visible only to you"
-                  />
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                          <label htmlFor="courseId" className="text-sm font-medium text-foreground">
+                            Course
+                          </label>
+                          <select
+                            id="courseId"
+                            value={values.courseId}
+                            onChange={(e) => updateField('courseId', e.target.value)}
+                            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                          >
+                            {courses.map((course) => (
+                              <option key={course.id} value={course.id}>
+                                {course.code}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
 
-                  <Field
-                    id="notes"
-                    label="Notes"
-                    value={values.notes ?? ''}
-                    error={errors.notes}
-                    onChange={(v) => updateField('notes', v)}
-                    placeholder="Optional"
-                  />
-                </>
-              )}
-            </CardContent>
-            <CardFooter className="justify-end gap-2">
-              <button
-                type="button"
-                onClick={requestClose}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={submitting || courses.length === 0}
-                className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
-              >
-                {submitting ? 'Saving...' : initialItem ? 'Save Changes' : 'Add Task'}
-              </button>
-            </CardFooter>
-          </form>
+                        <div className="space-y-1.5">
+                          <label htmlFor="type" className="text-sm font-medium text-foreground">
+                            Type
+                          </label>
+                          <select
+                            id="type"
+                            value={values.type}
+                            onChange={(e) => updateField('type', e.target.value as AssignmentType)}
+                            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                          >
+                            {TYPE_OPTIONS.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-3">
+                        <Field
+                          id="dueDate"
+                          label="Due Date"
+                          type="date"
+                          value={values.dueDate}
+                          error={errors.dueDate}
+                          onChange={(v) => updateField('dueDate', v)}
+                        />
+                        <Field
+                          id="estimatedHours"
+                          label="Est. Hours"
+                          type="number"
+                          value={values.estimatedHours ?? ''}
+                          error={errors.estimatedHours}
+                          onChange={(v) => updateField('estimatedHours', v)}
+                          placeholder="3"
+                        />
+                      </div>
+
+                      <div className="space-y-1.5">
+                        <span className="text-sm font-medium text-foreground">Priority</span>
+                        <div className="flex gap-2">
+                          {PRIORITY_OPTIONS.map((opt) => (
+                            <button
+                              key={opt.value}
+                              type="button"
+                              onClick={() => updateField('priority', opt.value)}
+                              className={cn(
+                                'flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors',
+                                values.priority === opt.value
+                                  ? 'border-primary bg-primary/10 text-primary'
+                                  : 'border-border text-muted-foreground hover:bg-accent',
+                              )}
+                            >
+                              {opt.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+
+                      {initialItem && (
+                        <div className="space-y-1.5">
+                          <label htmlFor="progress" className="text-sm font-medium text-foreground">
+                            Progress
+                          </label>
+                          <div className="flex items-center gap-2">
+                            <input
+                              id="progress"
+                              type="number"
+                              min={0}
+                              max={100}
+                              step={5}
+                              value={values.progress ?? ''}
+                              placeholder="0"
+                              onChange={(e) => updateField('progress', e.target.value)}
+                              className={cn(
+                                'w-24 rounded-lg border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary',
+                                errors.progress ? 'border-destructive' : 'border-border',
+                              )}
+                            />
+                            <span className="text-sm text-muted-foreground">% complete</span>
+                          </div>
+                          {errors.progress && (
+                            <p className="text-xs text-destructive">{errors.progress}</p>
+                          )}
+                        </div>
+                      )}
+
+                      <div className="grid grid-cols-2 gap-3">
+                        <Field
+                          id="gradeWeight"
+                          label="Grade Weight (%)"
+                          type="number"
+                          value={values.gradeWeight ?? ''}
+                          error={errors.gradeWeight}
+                          onChange={(v) => updateField('gradeWeight', v)}
+                          placeholder="Optional"
+                        />
+                        <Field
+                          id="gradeCategory"
+                          label="Grade Category"
+                          value={values.gradeCategory ?? ''}
+                          error={errors.gradeCategory}
+                          onChange={(v) => updateField('gradeCategory', v)}
+                          placeholder="e.g. Homework"
+                        />
+                      </div>
+
+                      <Field
+                        id="assignedTo"
+                        label="Assigned To"
+                        value={values.assignedTo ?? ''}
+                        error={errors.assignedTo}
+                        onChange={(v) => updateField('assignedTo', v)}
+                        placeholder="e.g. Priya, or You - visible only to you"
+                      />
+
+                      <Field
+                        id="notes"
+                        label="Notes"
+                        value={values.notes ?? ''}
+                        error={errors.notes}
+                        onChange={(v) => updateField('notes', v)}
+                        placeholder="Optional"
+                      />
+                    </>
+                  )}
+                </CardContent>
+                <CardFooter className="justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting || courses.length === 0}
+                    className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold px-4 py-2 transition-opacity hover:opacity-90 disabled:opacity-50"
+                  >
+                    {submitting ? 'Saving...' : initialItem ? 'Save Changes' : 'Add Task'}
+                  </button>
+                </CardFooter>
+              </form>
+            </>
+          )}
         </Card>
       </div>
     </div>

--- a/src/components/ui/DiscardConfirmCard.tsx
+++ b/src/components/ui/DiscardConfirmCard.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { CardContent } from '@/components/ui/Card';
+
+export interface DiscardConfirmCardProps {
+  title: string;
+  description: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Content shown by `useDirtyClose` in place of a form modal's normal body
+ * when the user tries to close with unsaved changes. Rendered as a
+ * replacement for the form inside the same `Card`, not stacked on top of
+ * it - covering the form with an overlay left either a stray rectangle
+ * (opaque) or the form itself dimmed/blurred out from underneath
+ * (translucent); swapping content avoids both.
+ */
+export function DiscardConfirmCard({
+  title,
+  description,
+  onCancel,
+  onConfirm,
+}: DiscardConfirmCardProps) {
+  return (
+    <CardContent className="space-y-4 pt-6">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="text-sm text-muted-foreground">{description}</p>
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent"
+        >
+          Keep editing
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-destructive px-4 text-sm font-semibold text-destructive-foreground transition-colors hover:bg-destructive/90"
+        >
+          Discard
+        </button>
+      </div>
+    </CardContent>
+  );
+}


### PR DESCRIPTION
## What changed

`handleAddContact`/`handleSaveContact` and the objective/material add+edit handlers in `CourseDetailView.tsx` had no catch at all — a failed write on any of these six paths reverted with zero feedback. Added try/catch + `showError` to all six, matching the pattern already used by their sibling delete handlers in the same file.

Also extended the dirty-form discard guard (`useDirtyClose`) to the three form modals that didn't have it: `SourceFormModal`, the inline `ContactFormModal` in `ContactsListView`, and `ScheduleOfficeVisitModal`. Backdrop-click or Cancel used to discard typed input silently; now prompts "Discard unsaved changes?" first, matching `CourseFormModal`/`TaskFormModal`'s existing behavior.

**Follow-up fix (this update):** the discard confirmation itself had a real visual bug. It was `absolute`-positioned to its own form card's wrapper rather than to the viewport, so on any form taller than the screen (Add Contact, Add Source) the confirmation's rounded corners got clipped off-screen, leaving a stark white rectangle with square edges floating over the dimmed backdrop. Fixed by extracting the confirmation into a shared `DiscardConfirmCard` component and swapping it in for the form content within the same `Card`, rather than stacking anything on top of the form — there's nothing left underneath to clip or dim. Applied to all five `useDirtyClose` consumers, including the two that already shipped (`TaskFormModal`, `CourseFormModal`), so the whole app now shares one correct implementation instead of five copies of the same latent bug.

## Why

Found during the toast-notification audit (error handling) and the original mega-audit's confirm-before-destructive-action pass (dirty-close guards). The overlay bug was caught live via screenshot during manual verification of this same PR.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec): 72 files / 643 tests passing (verified against a real `next build`, not a stale dev build)
- **Live-verified** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form:
  - Typed into the Add Contact modal, clicked the backdrop → "Discard unsaved changes?" now appears (previously discarded silently).
  - Forced a real `permission-denied` write (temporarily denied `courses` writes in `firestore.rules`, reverted immediately after — `git diff firestore.rules` is empty) on Add Objective → error toast fires.
  - Confirmed the discard confirmation renders correctly (no stray rectangle) on both a short modal (Schedule Visit) and a scrolling one taller than the viewport (Add Contact).
  - Confirmed "Keep editing" restores the form with the typed value intact, and "Discard" actually closes the modal, on Contacts and Courses.
