### PR TITLE
Fix ICS export, sign-out, and clipboard silent failures

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -246,7 +246,7 @@ type ViewMode = 'month' | 'week' | 'agenda';
 export function MonthCalendar() {
   const { state, dispatch } = useAppState();
   const { user } = useAuth();
-  const { showError } = useToast();
+  const { showSuccess, showError } = useToast();
   const searchParams = useSearchParams();
   // A deep link from the semester heatmap (or any other day-grid) lands here
   // pre-selected and scrolled to that day, instead of the plain "today"
@@ -410,16 +410,28 @@ export function MonthCalendar() {
     const visibleItems = state.scheduleItems.filter(
       (item) => !hiddenCourseIds.has(item.courseId) && (showCompleted || !item.completed),
     );
-    const ics = generateICS(visibleItems, state.courses, new Date());
-    const blob = createICSBlob(ics);
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = buildICSFilename('syllabus-sense-calendar');
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
+    if (visibleItems.length === 0) {
+      showError('Nothing to export', 'No visible items match the current filters.');
+      return;
+    }
+    try {
+      const ics = generateICS(visibleItems, state.courses, new Date());
+      const blob = createICSBlob(ics);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = buildICSFilename('syllabus-sense-calendar');
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+      showSuccess(
+        'Calendar exported',
+        `${visibleItems.length} ${visibleItems.length === 1 ? 'item' : 'items'} saved as .ics.`,
+      );
+    } catch (err) {
+      showError('Could not export calendar', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const selectDay = (day: Date) => {

--- a/src/components/contacts/ContactShareModal.tsx
+++ b/src/components/contacts/ContactShareModal.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { cn } from '@/lib/utils';
+import { useToast } from '@/components/ui/Toast';
 import type { Contact } from '@/types/schedule';
 import { generateVCard, downloadVCardFile, generateContactQrMatrix } from '@/lib/export/vcard';
 
@@ -25,6 +26,7 @@ export function ContactShareModal({
   const [activeTab, setActiveTab] = useState<'qr' | 'vcard'>('qr');
   const [copiedVCard, setCopiedVCard] = useState(false);
   const [copiedSummary, setCopiedSummary] = useState(false);
+  const { showError } = useToast();
 
   const vcardText = useMemo(() => {
     if (!contact) return '';
@@ -40,15 +42,18 @@ export function ContactShareModal({
 
   if (!isOpen || !contact) return null;
 
-  const handleCopyVCard = () => {
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      navigator.clipboard.writeText(vcardText);
+  const handleCopyVCard = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(vcardText);
       setCopiedVCard(true);
       setTimeout(() => setCopiedVCard(false), 2000);
+    } catch {
+      showError('Could not copy', 'Try selecting and copying the vCard text manually.');
     }
   };
 
-  const handleCopySummary = () => {
+  const handleCopySummary = async () => {
     const summary = [
       `${contact.fullName} (${contact.role.toUpperCase()})`,
       contact.title ? `Title: ${contact.title}` : '',
@@ -60,10 +65,13 @@ export function ContactShareModal({
       .filter(Boolean)
       .join('\n');
 
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      navigator.clipboard.writeText(summary);
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(summary);
       setCopiedSummary(true);
       setTimeout(() => setCopiedSummary(false), 2000);
+    } catch {
+      showError('Could not copy', 'Try selecting and copying the contact details manually.');
     }
   };
 

--- a/src/components/contacts/__tests__/ContactShareModal.test.tsx
+++ b/src/components/contacts/__tests__/ContactShareModal.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ContactShareModal } from '../ContactShareModal';
+import { ToastProvider } from '@/components/ui/Toast';
 import type { Contact } from '@/types/schedule';
 
 const MOCK_CONTACT: Contact = {
@@ -18,13 +19,15 @@ const MOCK_CONTACT: Contact = {
 describe('ContactShareModal (Item 45)', () => {
   it('renders modal dialog when open with contact information and QR code SVG', () => {
     render(
-      <ContactShareModal
-        contact={MOCK_CONTACT}
-        courseCode="CS 101"
-        courseTitle="Intro to Computer Science"
-        isOpen={true}
-        onClose={vi.fn()}
-      />,
+      <ToastProvider>
+        <ContactShareModal
+          contact={MOCK_CONTACT}
+          courseCode="CS 101"
+          courseTitle="Intro to Computer Science"
+          isOpen={true}
+          onClose={vi.fn()}
+        />
+      </ToastProvider>,
     );
 
     expect(screen.getByRole('dialog')).toBeDefined();
@@ -36,12 +39,14 @@ describe('ContactShareModal (Item 45)', () => {
 
   it('switches to vCard raw details tab and displays RFC formatted vCard', () => {
     render(
-      <ContactShareModal
-        contact={MOCK_CONTACT}
-        courseCode="CS 101"
-        isOpen={true}
-        onClose={vi.fn()}
-      />,
+      <ToastProvider>
+        <ContactShareModal
+          contact={MOCK_CONTACT}
+          courseCode="CS 101"
+          isOpen={true}
+          onClose={vi.fn()}
+        />
+      </ToastProvider>,
     );
 
     const vcardTab = screen.getByTestId('tab-vcard-text');
@@ -55,12 +60,14 @@ describe('ContactShareModal (Item 45)', () => {
 
   it('provides email direct action with encoded mailto parameters', () => {
     render(
-      <ContactShareModal
-        contact={MOCK_CONTACT}
-        courseCode="CS 101"
-        isOpen={true}
-        onClose={vi.fn()}
-      />,
+      <ToastProvider>
+        <ContactShareModal
+          contact={MOCK_CONTACT}
+          courseCode="CS 101"
+          isOpen={true}
+          onClose={vi.fn()}
+        />
+      </ToastProvider>,
     );
 
     const emailBtn = screen.getByTestId('email-contact-btn');
@@ -71,12 +78,14 @@ describe('ContactShareModal (Item 45)', () => {
   it('calls onClose when close button is clicked', () => {
     const onClose = vi.fn();
     render(
-      <ContactShareModal
-        contact={MOCK_CONTACT}
-        courseCode="CS 101"
-        isOpen={true}
-        onClose={onClose}
-      />,
+      <ToastProvider>
+        <ContactShareModal
+          contact={MOCK_CONTACT}
+          courseCode="CS 101"
+          isOpen={true}
+          onClose={onClose}
+        />
+      </ToastProvider>,
     );
 
     const closeBtn = screen.getByLabelText(/Close share modal/i);
@@ -87,12 +96,14 @@ describe('ContactShareModal (Item 45)', () => {
 
   it('does not render when isOpen is false', () => {
     const { container } = render(
-      <ContactShareModal
-        contact={MOCK_CONTACT}
-        courseCode="CS 101"
-        isOpen={false}
-        onClose={vi.fn()}
-      />,
+      <ToastProvider>
+        <ContactShareModal
+          contact={MOCK_CONTACT}
+          courseCode="CS 101"
+          isOpen={false}
+          onClose={vi.fn()}
+        />
+      </ToastProvider>,
     );
 
     expect(container.firstChild).toBeNull();

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -612,16 +612,28 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   };
 
   const handleExportICS = () => {
-    const ics = generateICS(items, [course], new Date());
-    const blob = createICSBlob(ics);
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = buildICSFilename(course.code);
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
+    if (items.length === 0) {
+      showError('Nothing to export', 'This course has no tasks yet.');
+      return;
+    }
+    try {
+      const ics = generateICS(items, [course], new Date());
+      const blob = createICSBlob(ics);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = buildICSFilename(course.code);
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+      showSuccess(
+        'Calendar exported',
+        `${items.length} ${items.length === 1 ? 'item' : 'items'} saved as .ics.`,
+      );
+    } catch (err) {
+      showError('Could not export calendar', err instanceof Error ? err.message : undefined);
+    }
   };
 
   return (

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
+import { useToast } from '@/components/ui/Toast';
 import type { ScheduleItem } from '@/types/schedule';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
@@ -199,6 +200,7 @@ export default function Navbar({ onCommandPaletteAction }: NavbarProps = {}) {
   const { resolvedTheme, setTheme } = useTheme();
   const { user, signOut } = useAuth();
   const router = useRouter();
+  const { showError } = useToast();
   const [mounted, setMounted] = useState(false);
   const [openPanel, setOpenPanel] = useState<'search' | 'bell' | null>(null);
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
@@ -206,7 +208,11 @@ export default function Navbar({ onCommandPaletteAction }: NavbarProps = {}) {
 
   const handleSignOut = async () => {
     const success = await signOut();
-    if (success) router.push('/login');
+    if (success) {
+      router.push('/login');
+    } else {
+      showError('Could not sign out', 'Please try again in a moment.');
+    }
   };
 
   useEffect(() => {

--- a/src/lib/__tests__/mobileTouchTargets.test.tsx
+++ b/src/lib/__tests__/mobileTouchTargets.test.tsx
@@ -188,9 +188,11 @@ describe('Item 21: Mobile Touch Targets Minimum 44x44px Audit', () => {
     render(
       <ThemeProvider>
         <AuthProvider>
-          <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
-            <Navbar />
-          </AppStateProvider>
+          <ToastProvider>
+            <AppStateProvider initialState={{ courses: mockCourses, scheduleItems: mockItems }}>
+              <Navbar />
+            </AppStateProvider>
+          </ToastProvider>
         </AuthProvider>
       </ThemeProvider>,
     );


### PR DESCRIPTION
## What changed

Four leftover gaps from the toast-notification audit, bundled into one small PR as planned:

- **`CourseDetailView.handleExportICS` / `MonthCalendar.handleExportICS`**: no empty-state guard and no feedback either way. Added a guard for zero exportable items (`Nothing to export`), wrapped the blob/anchor logic in try/catch, and added a success toast (`Calendar exported`) and failure toast (`Could not export calendar`).
- **`Navbar.handleSignOut`**: `signOut()` returning `false` (a real failure path already tracked in `AuthContext`) was silently ignored — the user was just left on the page with no explanation. Added an error toast.
- **`ContactShareModal.handleCopyVCard` / `handleCopySummary`**: both called `navigator.clipboard.writeText(...)` without awaiting it, so "Copied!" showed regardless of whether the write actually succeeded. Now awaited with a catch that shows an error toast instead.

## Why

Deferred from the original 100%-toast-coverage audit as smaller, scattered items to bundle into one PR rather than shipping five near-empty ones.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec), against a real `next build`: 72 files / 643 tests passing
- **Live-verified** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form:
  - Added a task to a course, clicked Export .ics → "Calendar exported" success toast fires.
  - Clicked "vCard/QR" on a contact, clicked "Copy Summary" → clipboard actually contains the expected text, "Copied!" only shows after the real write resolves.
  - Signed out → redirected to `/login` as expected (success path unchanged).
