### PR TITLE
Add syllabus version history with a primary version

### DIFF
--- a/src/components/courses/CourseAiSummaryCard.tsx
+++ b/src/components/courses/CourseAiSummaryCard.tsx
@@ -6,6 +6,7 @@ import { CardActionButton } from '@/components/ui/CardAction';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
+import { getPrimarySyllabus } from '@/lib/firestore/syllabi';
 import { updateCourse } from '@/lib/firestore/courses';
 import { courseSummarySchema, type CourseSummaryNote } from '@/types/courseSummary';
 import type { Course } from '@/types/schedule';
@@ -37,14 +38,13 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Most recently uploaded syllabus - the one worth summarizing if there's
-  // more than one on file.
-  const latestSyllabus = syllabi
-    .slice()
-    .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
+  // The course's primary syllabus - the one worth summarizing if there's
+  // more than one on file, and the one a student marked current if a later
+  // upload turned out to be a duplicate or a mistake.
+  const primarySyllabus = getPrimarySyllabus(syllabi);
 
   const handleGenerate = async () => {
-    if (!user || !latestSyllabus) return;
+    if (!user || !primarySyllabus) return;
     setGenerating(true);
     setError(null);
     try {
@@ -53,8 +53,8 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({
-          storagePath: latestSyllabus.storagePath,
-          fileName: latestSyllabus.fileName,
+          storagePath: primarySyllabus.storagePath,
+          fileName: primarySyllabus.fileName,
         }),
       });
       const body = await response.json();
@@ -69,7 +69,7 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
           aiSummary: {
             ...parsed,
             generatedAt: new Date().toISOString(),
-            sourceFileName: latestSyllabus.fileName,
+            sourceFileName: primarySyllabus.fileName,
           },
         },
         dispatch,
@@ -86,7 +86,7 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   // it's better to have slightly stale info clearly labeled with its source
   // than to silently discard a real Anthropic result.
   const isStale =
-    !!summary && !!latestSyllabus && summary.sourceFileName !== latestSyllabus.fileName;
+    !!summary && !!primarySyllabus && summary.sourceFileName !== primarySyllabus.fileName;
 
   // CO-4: this card used to return null with no syllabus on file, so a fresh
   // course page showed nothing between the dropzone and Tasks - zero
@@ -95,7 +95,7 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
   // distinct (dashed, muted) from both the populated and the
   // ready-to-generate states below - reads as "not yet" instead of
   // "broken/missing".
-  if (!latestSyllabus) {
+  if (!primarySyllabus) {
     return (
       <Card accent="none" className="rounded-2xl border-dashed p-6 opacity-90">
         <div className="flex items-center gap-2.5">
@@ -154,14 +154,14 @@ export function CourseAiSummaryCard({ course }: { course: Course }) {
       {!summary && !generating && !error && (
         <p className="text-sm text-muted-foreground">
           Get a plain-English summary and a list of things to watch out for, generated from{' '}
-          {latestSyllabus.fileName}.
+          {primarySyllabus.fileName}.
         </p>
       )}
 
       {generating && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          Reading {latestSyllabus.fileName}…
+          Reading {primarySyllabus.fileName}…
         </div>
       )}
 

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from 'react';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
-import { deleteSyllabusUpload } from '@/lib/firestore/syllabi';
+import {
+  deleteSyllabusUpload,
+  setPrimarySyllabus,
+  getPrimarySyllabus,
+} from '@/lib/firestore/syllabi';
 import { DocumentViewerModal } from '@/components/syllabus/DocumentViewerModal';
 import { useToast } from '@/components/ui/Toast';
 import type { SyllabusUpload } from '@/types/syllabus';
@@ -32,11 +36,17 @@ function FileTypeIcon({ fileName }: { fileName: string }) {
 }
 
 export function SyllabusList({ userId, courseId }: SyllabusListProps) {
-  const syllabi = useSyllabi(userId, courseId);
+  const syllabiUnsorted = useSyllabi(userId, courseId);
   const { showSuccess, showError } = useToast();
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [settingPrimaryId, setSettingPrimaryId] = useState<string | null>(null);
   const [viewingSyllabus, setViewingSyllabus] = useState<SyllabusUpload | null>(null);
+
+  const syllabi = [...syllabiUnsorted].sort(
+    (a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime(),
+  );
+  const primaryId = getPrimarySyllabus(syllabi)?.id;
 
   const handleDelete = async (syllabus: SyllabusUpload) => {
     if (!userId) return;
@@ -52,6 +62,19 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
     }
   };
 
+  const handleSetPrimary = async (syllabus: SyllabusUpload) => {
+    if (!userId) return;
+    setSettingPrimaryId(syllabus.id);
+    try {
+      await setPrimarySyllabus(userId, courseId, syllabus.id);
+      showSuccess('Primary syllabus updated', `${syllabus.fileName} is now the current version.`);
+    } catch (err) {
+      showError('Could not set primary syllabus', err instanceof Error ? err.message : undefined);
+    } finally {
+      setSettingPrimaryId(null);
+    }
+  };
+
   if (syllabi.length === 0) return null;
 
   return (
@@ -63,12 +86,19 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
         >
           <FileTypeIcon fileName={syllabus.fileName} />
           <div className="min-w-0 flex-1">
-            <button
-              onClick={() => setViewingSyllabus(syllabus)}
-              className="block truncate text-left font-medium text-foreground hover:text-primary hover:underline"
-            >
-              {syllabus.fileName}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setViewingSyllabus(syllabus)}
+                className="truncate text-left font-medium text-foreground hover:text-primary hover:underline"
+              >
+                {syllabus.fileName}
+              </button>
+              {syllabus.id === primaryId && (
+                <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                  Primary
+                </span>
+              )}
+            </div>
             <span className="text-xs text-muted-foreground">{formatSize(syllabus.sizeBytes)}</span>
           </div>
           {confirmingDeleteId === syllabus.id ? (
@@ -89,12 +119,23 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
               </button>
             </div>
           ) : (
-            <button
-              onClick={() => setConfirmingDeleteId(syllabus.id)}
-              className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
-            >
-              Delete
-            </button>
+            <div className="flex items-center gap-1.5 shrink-0">
+              {syllabus.id !== primaryId && (
+                <button
+                  onClick={() => handleSetPrimary(syllabus)}
+                  disabled={settingPrimaryId === syllabus.id}
+                  className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {settingPrimaryId === syllabus.id ? 'Setting…' : 'Set as primary'}
+                </button>
+              )}
+              <button
+                onClick={() => setConfirmingDeleteId(syllabus.id)}
+                className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+              >
+                Delete
+              </button>
+            </div>
           )}
         </div>
       ))}

--- a/src/lib/firestore/__tests__/syllabi.test.ts
+++ b/src/lib/firestore/__tests__/syllabi.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getPrimarySyllabus } from '../syllabi';
+import type { SyllabusUpload } from '@/types/syllabus';
+
+function upload(overrides: Partial<SyllabusUpload>): SyllabusUpload {
+  return {
+    id: 'id',
+    courseId: 'course-1',
+    fileName: 'syllabus.pdf',
+    storagePath: 'path',
+    downloadURL: 'https://example.com/file',
+    sizeBytes: 1024,
+    uploadedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('getPrimarySyllabus', () => {
+  it('returns undefined for an empty list', () => {
+    expect(getPrimarySyllabus([])).toBeUndefined();
+  });
+
+  it('returns the upload explicitly marked primary', () => {
+    const older = upload({ id: 'a', uploadedAt: '2026-01-01T00:00:00.000Z' });
+    const newer = upload({ id: 'b', uploadedAt: '2026-02-01T00:00:00.000Z', isPrimary: true });
+    const newest = upload({ id: 'c', uploadedAt: '2026-03-01T00:00:00.000Z' });
+    expect(getPrimarySyllabus([older, newer, newest])?.id).toBe('b');
+  });
+
+  it('falls back to the most recently uploaded when none are marked primary', () => {
+    const older = upload({ id: 'a', uploadedAt: '2026-01-01T00:00:00.000Z' });
+    const newest = upload({ id: 'b', uploadedAt: '2026-03-01T00:00:00.000Z' });
+    const middle = upload({ id: 'c', uploadedAt: '2026-02-01T00:00:00.000Z' });
+    expect(getPrimarySyllabus([older, newest, middle])?.id).toBe('b');
+  });
+});

--- a/src/lib/firestore/syllabi.ts
+++ b/src/lib/firestore/syllabi.ts
@@ -1,7 +1,47 @@
-import { collection, doc, deleteDoc, getDocs } from 'firebase/firestore';
+import { collection, doc, deleteDoc, getDocs, writeBatch } from 'firebase/firestore';
 import { ref, deleteObject } from 'firebase/storage';
 import { db, storage } from '@/lib/firebase/client';
 import type { SyllabusUpload } from '@/types/syllabus';
+
+/**
+ * The syllabus that represents a course's current state: whichever upload
+ * is marked primary, or - for courses whose uploads all predate the
+ * `isPrimary` field - the most recently uploaded one. The single source of
+ * truth for "which syllabus" across the version list, AI summary, and
+ * re-extraction, so marking an older upload primary is honored everywhere,
+ * not just in the version list's own badge.
+ */
+export function getPrimarySyllabus(syllabi: SyllabusUpload[]): SyllabusUpload | undefined {
+  if (syllabi.length === 0) return undefined;
+  const explicitPrimary = syllabi.find((s) => s.isPrimary);
+  if (explicitPrimary) return explicitPrimary;
+  return [...syllabi].sort(
+    (a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime(),
+  )[0];
+}
+
+/**
+ * Marks one syllabus upload as the course's primary version and demotes any
+ * other upload currently marked primary - at most one `isPrimary: true` per
+ * course at a time.
+ */
+export async function setPrimarySyllabus(
+  userId: string,
+  courseId: string,
+  syllabusId: string,
+): Promise<void> {
+  if (!db) throw new Error('Firestore is not configured.');
+  const collectionRef = collection(db, 'users', userId, 'courses', courseId, 'syllabi');
+  const snap = await getDocs(collectionRef);
+  const batch = writeBatch(db);
+  snap.docs.forEach((d) => {
+    const shouldBePrimary = d.id === syllabusId;
+    if (Boolean((d.data() as SyllabusUpload).isPrimary) !== shouldBePrimary) {
+      batch.update(d.ref, { isPrimary: shouldBePrimary });
+    }
+  });
+  await batch.commit();
+}
 
 export async function deleteSyllabusUpload(
   userId: string,

--- a/src/lib/storage/useUploadSyllabus.ts
+++ b/src/lib/storage/useUploadSyllabus.ts
@@ -8,7 +8,7 @@ import {
   deleteObject,
   type UploadTask,
 } from 'firebase/storage';
-import { doc, setDoc } from 'firebase/firestore';
+import { collection, doc, getDocs, writeBatch } from 'firebase/firestore';
 import { storage, db } from '@/lib/firebase/client';
 import type { SyllabusUpload } from '@/types/syllabus';
 
@@ -73,11 +73,29 @@ export function useUploadSyllabus(userId: string, courseId: string) {
                 downloadURL,
                 sizeBytes: file.size,
                 uploadedAt: new Date().toISOString(),
+                isPrimary: true,
               };
-              await setDoc(
-                doc(dbInstance, 'users', userId, 'courses', courseId, 'syllabi', id),
-                record,
+              const collectionRef = collection(
+                dbInstance,
+                'users',
+                userId,
+                'courses',
+                courseId,
+                'syllabi',
               );
+              // The most recently uploaded syllabus becomes the course's
+              // primary version by default - demote whichever upload held
+              // that spot before, in the same batch as creating the new
+              // record.
+              const existing = await getDocs(collectionRef);
+              const batch = writeBatch(dbInstance);
+              existing.docs.forEach((d) => {
+                if ((d.data() as SyllabusUpload).isPrimary) {
+                  batch.update(d.ref, { isPrimary: false });
+                }
+              });
+              batch.set(doc(collectionRef, id), record);
+              await batch.commit();
               setState({ status: 'success', progress: 100, error: null });
               resolve(record);
             } catch (err) {

--- a/src/types/syllabus.ts
+++ b/src/types/syllabus.ts
@@ -9,4 +9,10 @@ export interface SyllabusUpload {
   downloadURL: string;
   sizeBytes: number;
   uploadedAt: string;
+  /** Whether this is the version currently treated as authoritative for the
+   * course - the one recent uploads get diffed against, and the one shown
+   * as "current" when a course has several. Exactly one upload per course
+   * should have this true; a course whose uploads predate this field (none
+   * of them set) falls back to treating the most recent one as primary. */
+  isPrimary?: boolean;
 }


### PR DESCRIPTION
## What changed

Part 1 of the approved "syllabus re-extraction + versioning" feature: the version-history/"mark one main" half. (Re-extraction against a re-uploaded syllabus — diffing and applying detected changes to an existing course — is a separate, larger follow-up PR.)

Every uploaded syllabus for a course was already kept and listed (`SyllabusList`), but there was no way to distinguish them once a course had more than one:

- No indication of which upload the app actually treats as the course's current version.
- `CourseAiSummaryCard` silently summarized whichever syllabus was uploaded *most recently*, regardless of whether that was actually the right one (e.g. a duplicate re-upload, or a mistaken file that got replaced).

**Added:**
- `isPrimary` field on `SyllabusUpload`. A new upload becomes primary by default; uploading demotes whichever upload previously held that spot, in the same Firestore batch.
- `setPrimarySyllabus(userId, courseId, syllabusId)` — lets a student explicitly override which upload is primary (useful if the most recent upload turns out to be the wrong one).
- `getPrimarySyllabus(syllabi)` — single resolution point (explicit primary, falling back to most-recently-uploaded for courses whose uploads predate this field) now used by **both** the version list's "Primary" badge and the AI Summary card's source file, so they can't disagree with each other the way "most recent" and "main" used to be able to.
- `SyllabusList` now sorts newest-first, shows a "Primary" badge, and exposes a "Set as primary" action on any non-primary row.

## Why

Directly requested: "add an element of VCS so that if I want to revert syllabi, or more likely at least see previous syllabi and click choose main or whatever." Landed as "primary" rather than "main" per a naming preference during review.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec), against a real `next build`: 73 files / 646 tests passing (3 new unit tests for `getPrimarySyllabus`'s branches: empty list, explicit primary, fallback-to-most-recent)
- **Live-verified** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form:
  - Uploaded a first syllabus → immediately shown as Primary.
  - Uploaded a second syllabus → second becomes Primary, first is demoted and gets a "Set as primary" action.
  - Clicked "Set as primary" on the first file → success toast, badge moves back, AI Summary's "generated from ___" text correctly follows the primary file rather than the most-recently-uploaded one.
