### PR TITLE
Wire real syllabus re-extraction and version diffing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "mammoth": "^1.12.1",
         "next": "14.2.35",
         "nodemailer": "^9.0.6",
+        "pdf-parse": "^2.4.5",
         "pdfjs-dist": "^6.2.108",
         "react": "^18",
         "react-dom": "^18",
@@ -13680,6 +13681,222 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
     },
     "node_modules/pdfjs-dist": {
       "version": "6.2.108",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mammoth": "^1.12.1",
     "next": "14.2.35",
     "nodemailer": "^9.0.6",
+    "pdf-parse": "^2.4.5",
     "pdfjs-dist": "^6.2.108",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/api/syllabus/extract-text/route.ts
+++ b/src/app/api/syllabus/extract-text/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseIdToken } from '@/lib/auth/verifyFirebaseIdToken';
+import { detectSyllabusFileKind, extractRawSyllabusText } from '@/lib/syllabus/extractRawText';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+async function requireUser(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+  if (!token || !projectId) return null;
+  try {
+    return await verifyFirebaseIdToken(token, projectId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Plain text extraction only - no Anthropic call. Backs the syllabus
+ * version-diff feature, which only needs comparable text between two
+ * uploads, not structured data. Kept as its own route (rather than a mode
+ * on `/api/syllabus/extract`) so it can never accidentally end up on the
+ * AI-billed code path.
+ */
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: { fileBase64?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const { fileBase64 } = body;
+  if (!fileBase64 || typeof fileBase64 !== 'string') {
+    return NextResponse.json({ error: 'Missing file.' }, { status: 400 });
+  }
+  if (fileBase64.length > MAX_FILE_BYTES * 1.4) {
+    return NextResponse.json({ error: 'File is too large (max 10MB).' }, { status: 400 });
+  }
+
+  const fileKind = detectSyllabusFileKind(fileBase64);
+  if (!fileKind) {
+    return NextResponse.json(
+      { error: 'That file is not a valid PDF or Word (.docx) document.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const text = await extractRawSyllabusText(fileBase64, fileKind);
+    return NextResponse.json({ text });
+  } catch (err) {
+    console.error('Raw syllabus text extraction failed:', err);
+    return NextResponse.json({ error: "Couldn't read that document." }, { status: 400 });
+  }
+}

--- a/src/app/api/syllabus/extract/route.ts
+++ b/src/app/api/syllabus/extract/route.ts
@@ -7,25 +7,12 @@ import {
   SYLLABUS_EXTRACTION_TOOL,
 } from '@/lib/ai/syllabusExtractionTool';
 import { syllabusExtractionSchema } from '@/types/extraction';
+import { detectSyllabusFileKind, extractRawSyllabusText } from '@/lib/syllabus/extractRawText';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
-
-/**
- * Detected from magic bytes, not the client-declared MIME type (spoofable)
- * or file extension. Both prefixes are stable regardless of what follows -
- * base64 encodes in fixed 3-byte groups, so a known byte run at the start
- * of a file always produces the same leading base64 characters.
- * PDF: "%PDF-" (0x25 0x50 0x44 0x46 0x2D). DOCX: a .docx is a zip archive,
- * so it starts with the zip local-file-header signature (0x50 0x4B 0x03 0x04).
- */
-function detectFileKind(fileBase64: string): 'pdf' | 'docx' | null {
-  if (fileBase64.startsWith('JVBERi0')) return 'pdf';
-  if (fileBase64.startsWith('UEsDB')) return 'docx';
-  return null;
-}
 
 async function requireUser(req: NextRequest) {
   const authHeader = req.headers.get('authorization');
@@ -62,7 +49,7 @@ export async function POST(req: NextRequest) {
   }
   // The client declares a MIME type, but that's spoofable - check the real
   // magic bytes server-side before spending an API call.
-  const fileKind = detectFileKind(fileBase64);
+  const fileKind = detectSyllabusFileKind(fileBase64);
   if (!fileKind) {
     return NextResponse.json(
       { error: 'That file is not a valid PDF or Word (.docx) document.' },
@@ -76,10 +63,7 @@ export async function POST(req: NextRequest) {
   let docxText: string | null = null;
   if (fileKind === 'docx') {
     try {
-      const mammoth = await import('mammoth');
-      const buffer = Buffer.from(fileBase64, 'base64');
-      const result = await mammoth.extractRawText({ buffer });
-      docxText = result.value.trim();
+      docxText = await extractRawSyllabusText(fileBase64, 'docx');
     } catch {
       return NextResponse.json(
         { error: "Couldn't read that Word document. Try re-saving it and uploading again." },

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -22,6 +22,10 @@ import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
 import { SyllabusList } from '@/components/syllabus/SyllabusList';
+import { SyllabusDiffModal } from '@/components/syllabus/SyllabusDiffModal';
+import { useSyllabi } from '@/lib/firestore/useSyllabi';
+import { getPrimarySyllabus } from '@/lib/firestore/syllabi';
+import type { SyllabusUpload } from '@/types/syllabus';
 import { CourseAiSummaryCard } from '@/components/courses/CourseAiSummaryCard';
 import { SourcesCard } from '@/components/courses/SourcesCard';
 import { ExamCramPlanCard } from '@/components/courses/ExamCramPlanCard';
@@ -197,6 +201,12 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   const { user } = useAuth();
   const router = useRouter();
   const { showSuccess, showError } = useToast();
+  const syllabi = useSyllabi(user?.uid, courseId);
+  const currentPrimarySyllabus = getPrimarySyllabus(syllabi) ?? null;
+  const [syllabusDiff, setSyllabusDiff] = useState<{
+    original: SyllabusUpload;
+    revised: SyllabusUpload;
+  } | null>(null);
 
   const [editCourseOpen, setEditCourseOpen] = useState(false);
   const [addTaskOpen, setAddTaskOpen] = useState(false);
@@ -789,8 +799,48 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         <Card className="rounded-2xl p-6 space-y-4">
           <h2 className="text-base font-semibold text-foreground">Syllabus</h2>
           <SyllabusList userId={user?.uid} courseId={course.id} />
-          <SyllabusUploader userId={user?.uid ?? ''} courseId={course.id} />
+          <SyllabusUploader
+            userId={user?.uid ?? ''}
+            courseId={course.id}
+            currentPrimarySyllabus={currentPrimarySyllabus}
+            onUploaded={(newUpload, previousPrimary) => {
+              // Only offer a diff when there's something real to compare -
+              // a genuinely new upload replacing an older one, with text
+              // extracted from both. A course's first-ever upload, or one
+              // where extraction failed on either side, has nothing to
+              // diff against, so it's skipped rather than shown empty.
+              if (
+                previousPrimary &&
+                previousPrimary.id !== newUpload.id &&
+                previousPrimary.rawText &&
+                newUpload.rawText
+              ) {
+                setSyllabusDiff({ original: previousPrimary, revised: newUpload });
+              }
+            }}
+          />
         </Card>
+
+        {syllabusDiff && (
+          <SyllabusDiffModal
+            isOpen
+            onClose={() => setSyllabusDiff(null)}
+            courseCode={course.code}
+            courseTitle={course.title}
+            originalSyllabusText={syllabusDiff.original.rawText ?? ''}
+            revisedSyllabusText={syllabusDiff.revised.rawText ?? ''}
+            onApplyChanges={() => {
+              // The new upload already became primary at upload time
+              // (useUploadSyllabus) - reviewing changes here doesn't need
+              // its own persistence step, just an acknowledgement.
+              showSuccess(
+                'Reviewed',
+                `${syllabusDiff.revised.fileName} is the current version for this course.`,
+              );
+              setSyllabusDiff(null);
+            }}
+          />
+        )}
 
         <CourseAiSummaryCard course={course} />
 

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -17,7 +17,6 @@ import { cn } from '@/lib/utils';
 
 import { useEffect } from 'react';
 import { GradeCalculatorModal } from '@/components/courses/GradeCalculatorModal';
-import { SyllabusDiffModal } from '@/components/syllabus/SyllabusDiffModal';
 
 type SortMode = 'code' | 'title' | 'term';
 
@@ -40,7 +39,6 @@ export function CoursesListView() {
   const [addCourseOpen, setAddCourseOpen] = useState(false);
   const [autofillOpen, setAutofillOpen] = useState(false);
   const [simulatorOpen, setSimulatorOpen] = useState(false);
-  const [diffOpen, setDiffOpen] = useState(false);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -49,9 +47,6 @@ export function CoursesListView() {
         window.location.search.includes('grade=true')
       ) {
         setSimulatorOpen(true);
-      }
-      if (window.location.search.includes('diff=true')) {
-        setDiffOpen(true);
       }
       // CommandPalette's "Add New Course" / "Upload Syllabus" actions - both
       // previously navigated here with no query param this page read, so
@@ -371,12 +366,6 @@ export function CoursesListView() {
       />
       <SyllabusAutofillModal open={autofillOpen} onClose={() => setAutofillOpen(false)} />
       <GradeCalculatorModal isOpen={simulatorOpen} onClose={() => setSimulatorOpen(false)} />
-      <SyllabusDiffModal
-        isOpen={diffOpen}
-        onClose={() => setDiffOpen(false)}
-        originalSyllabusText=""
-        revisedSyllabusText=""
-      />
     </>
   );
 }

--- a/src/components/syllabus/SyllabusAutofillModal.tsx
+++ b/src/components/syllabus/SyllabusAutofillModal.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/context/AuthContext';
 import { COURSE_COLOR_PRESETS, courseSwatch, pickSuggestedCourseColor } from '@/lib/courseColors';
 import { COURSE_ICON_PRESETS, pickSuggestedCourseIcon } from '@/lib/courseIcons';
 import { CourseIconGlyph } from '@/components/ui/CourseIconGlyph';
-import { cn, normalizeContactName } from '@/lib/utils';
+import { cn, normalizeContactName, fileToBase64 } from '@/lib/utils';
 import type {
   ExtractedMeetingTime,
   ExtractedScheduleItem,
@@ -345,18 +345,6 @@ function omitDraftKey(item: DraftItem): Omit<DraftItem, 'key'> {
   const rest: Partial<DraftItem> = { ...item };
   delete rest.key;
   return rest as Omit<DraftItem, 'key'>;
-}
-
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      resolve(result.slice(result.indexOf(',') + 1));
-    };
-    reader.onerror = () => reject(reader.error);
-    reader.readAsDataURL(file);
-  });
 }
 
 export interface SyllabusAutofillModalProps {

--- a/src/components/syllabus/SyllabusDiffModal.tsx
+++ b/src/components/syllabus/SyllabusDiffModal.tsx
@@ -6,8 +6,8 @@ import { analyzeSyllabusRevision, PolicyChange, PolicyDiffReport } from '@/lib/s
 import { useModalA11y } from '@/hooks/useModalA11y';
 
 export interface SyllabusDiffModalProps {
-  courseCode?: string;
-  courseTitle?: string;
+  courseCode: string;
+  courseTitle: string;
   originalSyllabusText: string;
   revisedSyllabusText: string;
   isOpen: boolean;
@@ -16,8 +16,8 @@ export interface SyllabusDiffModalProps {
 }
 
 export function SyllabusDiffModal({
-  courseCode = 'CS 301',
-  courseTitle = 'Data Structures',
+  courseCode,
+  courseTitle,
   originalSyllabusText,
   revisedSyllabusText,
   isOpen,

--- a/src/components/syllabus/SyllabusUploader.tsx
+++ b/src/components/syllabus/SyllabusUploader.tsx
@@ -4,14 +4,25 @@ import { useRef, useState, DragEvent } from 'react';
 import { useUploadSyllabus } from '@/lib/storage/useUploadSyllabus';
 import { validateSyllabusFile } from '@/lib/validation/syllabusFile';
 import { cn } from '@/lib/utils';
+import type { SyllabusUpload } from '@/types/syllabus';
 
 export interface SyllabusUploaderProps {
   userId: string;
   courseId: string;
-  onUploaded?: () => void;
+  /** Whichever upload is primary right now, captured at the moment a new
+   * upload starts - passed back on `onUploaded` so the caller can offer a
+   * diff against the version this upload is about to replace, without a
+   * race against the primary-flip the upload itself just caused. */
+  currentPrimarySyllabus?: SyllabusUpload | null;
+  onUploaded?: (newUpload: SyllabusUpload, previousPrimary: SyllabusUpload | null) => void;
 }
 
-export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploaderProps) {
+export function SyllabusUploader({
+  userId,
+  courseId,
+  currentPrimarySyllabus = null,
+  onUploaded,
+}: SyllabusUploaderProps) {
   const { status, progress, error, upload, pause, resume, cancel, reset } = useUploadSyllabus(
     userId,
     courseId,
@@ -27,8 +38,9 @@ export function SyllabusUploader({ userId, courseId, onUploaded }: SyllabusUploa
       return;
     }
     setValidationError(null);
+    const previousPrimary = currentPrimarySyllabus;
     upload(file)
-      .then(() => onUploaded?.())
+      .then((newUpload) => onUploaded?.(newUpload, previousPrimary))
       .catch(() => {
         // Error state is already surfaced via the hook's `error` field.
       });

--- a/src/components/syllabus/__tests__/SyllabusDiffModal.test.tsx
+++ b/src/components/syllabus/__tests__/SyllabusDiffModal.test.tsx
@@ -25,7 +25,7 @@ describe('SyllabusDiffModal (Item 46)', () => {
         revisedSyllabusText={SAMPLE_REVISED}
         isOpen={true}
         onClose={vi.fn()}
-      />
+      />,
     );
 
     expect(screen.getByRole('dialog')).toBeDefined();
@@ -39,11 +39,12 @@ describe('SyllabusDiffModal (Item 46)', () => {
     render(
       <SyllabusDiffModal
         courseCode="CS 301"
+        courseTitle="Data Structures"
         originalSyllabusText={SAMPLE_ORIGINAL}
         revisedSyllabusText={SAMPLE_REVISED}
         isOpen={true}
         onClose={vi.fn()}
-      />
+      />,
     );
 
     const diffTab = screen.getByTestId('tab-diff');
@@ -58,12 +59,13 @@ describe('SyllabusDiffModal (Item 46)', () => {
     render(
       <SyllabusDiffModal
         courseCode="CS 301"
+        courseTitle="Data Structures"
         originalSyllabusText={SAMPLE_ORIGINAL}
         revisedSyllabusText={SAMPLE_REVISED}
         isOpen={true}
         onClose={vi.fn()}
         onApplyChanges={onApply}
-      />
+      />,
     );
 
     const applyBtn = screen.getByTestId('apply-diff-btn');
@@ -77,11 +79,13 @@ describe('SyllabusDiffModal (Item 46)', () => {
   it('does not render when isOpen is false', () => {
     const { container } = render(
       <SyllabusDiffModal
+        courseCode="CS 301"
+        courseTitle="Data Structures"
         originalSyllabusText={SAMPLE_ORIGINAL}
         revisedSyllabusText={SAMPLE_REVISED}
         isOpen={false}
         onClose={vi.fn()}
-      />
+      />,
     );
 
     expect(container.firstChild).toBeNull();

--- a/src/lib/auth/__tests__/verifyFirebaseIdToken.test.ts
+++ b/src/lib/auth/__tests__/verifyFirebaseIdToken.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { verifyFirebaseIdToken } from '../verifyFirebaseIdToken';
+
+const PROJECT_ID = 'demo-syllabus-sense';
+
+function base64url(input: object): string {
+  return Buffer.from(JSON.stringify(input))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/** Builds a JWT-shaped string with an arbitrary payload and no real
+ * signature - fine here since these tests only exercise the emulator
+ * branch, which intentionally never checks the signature (the Auth
+ * emulator's own tokens aren't signed with Google's real key either). */
+function fakeToken(payload: object): string {
+  const header = base64url({ alg: 'none', typ: 'JWT' });
+  const body = base64url(payload);
+  return `${header}.${body}.fake-signature`;
+}
+
+describe('verifyFirebaseIdToken (emulator branch)', () => {
+  const originalEmulatorHost = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+  beforeEach(() => {
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099';
+  });
+
+  afterEach(() => {
+    if (originalEmulatorHost === undefined) {
+      delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+    } else {
+      process.env.FIREBASE_AUTH_EMULATOR_HOST = originalEmulatorHost;
+    }
+  });
+
+  it('accepts a well-formed emulator token and extracts uid/email', async () => {
+    const token = fakeToken({
+      iss: `https://securetoken.google.com/${PROJECT_ID}`,
+      aud: PROJECT_ID,
+      sub: 'test-uid-123',
+      email: 'student@example.edu',
+    });
+
+    const result = await verifyFirebaseIdToken(token, PROJECT_ID);
+
+    expect(result).toEqual({ uid: 'test-uid-123', email: 'student@example.edu' });
+  });
+
+  it('omits email when the token has none', async () => {
+    const token = fakeToken({
+      iss: `https://securetoken.google.com/${PROJECT_ID}`,
+      aud: PROJECT_ID,
+      sub: 'test-uid-456',
+    });
+
+    const result = await verifyFirebaseIdToken(token, PROJECT_ID);
+
+    expect(result).toEqual({ uid: 'test-uid-456' });
+  });
+
+  it('rejects a token for the wrong project (audience mismatch)', async () => {
+    const token = fakeToken({
+      iss: `https://securetoken.google.com/${PROJECT_ID}`,
+      aud: 'some-other-project',
+      sub: 'test-uid-789',
+    });
+
+    await expect(verifyFirebaseIdToken(token, PROJECT_ID)).rejects.toThrow();
+  });
+
+  it('rejects a token missing a subject', async () => {
+    const token = fakeToken({
+      iss: `https://securetoken.google.com/${PROJECT_ID}`,
+      aud: PROJECT_ID,
+    });
+
+    await expect(verifyFirebaseIdToken(token, PROJECT_ID)).rejects.toThrow(
+      'Token payload is missing a subject (uid).',
+    );
+  });
+});

--- a/src/lib/auth/verifyFirebaseIdToken.ts
+++ b/src/lib/auth/verifyFirebaseIdToken.ts
@@ -13,7 +13,7 @@
  * conflict (the crash is specific to jwks-rsa's internal `require()`, not to
  * importing jose at all).
  */
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, jwtVerify, decodeJwt } from 'jose';
 
 const GOOGLE_CERTS_URL =
   'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com';
@@ -25,10 +25,37 @@ export interface VerifiedFirebaseToken {
   email?: string;
 }
 
+function subjectFromPayload(payload: { sub?: string; email?: unknown }): VerifiedFirebaseToken {
+  if (typeof payload.sub !== 'string' || !payload.sub) {
+    throw new Error('Token payload is missing a subject (uid).');
+  }
+  return {
+    uid: payload.sub,
+    ...(typeof payload.email === 'string' ? { email: payload.email } : {}),
+  };
+}
+
 export async function verifyFirebaseIdToken(
   idToken: string,
   projectId: string,
 ): Promise<VerifiedFirebaseToken> {
+  // The Auth emulator issues tokens that are never signed with Google's real
+  // key, so signature verification against the production JWKS below would
+  // reject every emulator-issued token unconditionally - this route would be
+  // impossible to verify against the required local emulator setup otherwise.
+  // Decode-only is safe specifically because this branch only activates when
+  // FIREBASE_AUTH_EMULATOR_HOST is set, which real deployments never set.
+  if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+    const payload = decodeJwt(idToken);
+    if (
+      payload.iss !== `https://securetoken.google.com/${projectId}` ||
+      payload.aud !== projectId
+    ) {
+      throw new Error('Emulator token has an unexpected issuer or audience.');
+    }
+    return subjectFromPayload(payload);
+  }
+
   if (!jwks) {
     jwks = createRemoteJWKSet(new URL(GOOGLE_CERTS_URL));
   }
@@ -38,12 +65,5 @@ export async function verifyFirebaseIdToken(
     audience: projectId,
   });
 
-  if (typeof payload.sub !== 'string' || !payload.sub) {
-    throw new Error('Token payload is missing a subject (uid).');
-  }
-
-  return {
-    uid: payload.sub,
-    ...(typeof payload.email === 'string' ? { email: payload.email } : {}),
-  };
+  return subjectFromPayload(payload);
 }

--- a/src/lib/storage/useUploadSyllabus.ts
+++ b/src/lib/storage/useUploadSyllabus.ts
@@ -9,8 +9,31 @@ import {
   type UploadTask,
 } from 'firebase/storage';
 import { collection, doc, getDocs, writeBatch } from 'firebase/firestore';
-import { storage, db } from '@/lib/firebase/client';
+import { storage, db, auth } from '@/lib/firebase/client';
+import { fileToBase64 } from '@/lib/utils';
 import type { SyllabusUpload } from '@/types/syllabus';
+
+/** Best-effort, non-blocking: a student's upload should never fail because
+ * this couldn't run. Missing `rawText` just means this upload can't be
+ * diffed against another version later - degrades gracefully rather than
+ * failing the upload itself. */
+async function tryExtractRawText(file: File): Promise<string | undefined> {
+  try {
+    const idToken = await auth?.currentUser?.getIdToken();
+    if (!idToken) return undefined;
+    const fileBase64 = await fileToBase64(file);
+    const response = await fetch('/api/syllabus/extract-text', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+      body: JSON.stringify({ fileBase64 }),
+    });
+    if (!response.ok) return undefined;
+    const body = await response.json();
+    return typeof body.text === 'string' && body.text ? body.text : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export type UploadStatus = 'idle' | 'uploading' | 'paused' | 'success' | 'error' | 'cancelled';
 
@@ -64,7 +87,10 @@ export function useUploadSyllabus(userId: string, courseId: string) {
           },
           async () => {
             try {
-              const downloadURL = await getDownloadURL(task.snapshot.ref);
+              const [downloadURL, rawText] = await Promise.all([
+                getDownloadURL(task.snapshot.ref),
+                tryExtractRawText(file),
+              ]);
               const record: SyllabusUpload = {
                 id,
                 courseId,
@@ -74,6 +100,7 @@ export function useUploadSyllabus(userId: string, courseId: string) {
                 sizeBytes: file.size,
                 uploadedAt: new Date().toISOString(),
                 isPrimary: true,
+                ...(rawText ? { rawText } : {}),
               };
               const collectionRef = collection(
                 dbInstance,

--- a/src/lib/syllabus/__tests__/extractRawText.test.ts
+++ b/src/lib/syllabus/__tests__/extractRawText.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { detectSyllabusFileKind } from '../extractRawText';
+
+describe('detectSyllabusFileKind', () => {
+  it('detects a PDF from its magic-byte base64 prefix', () => {
+    // base64 of "%PDF-1.4..." always starts with this prefix regardless of
+    // what follows - fixed 3-byte base64 grouping on a known byte run.
+    expect(detectSyllabusFileKind('JVBERi0xLjQKJeLjz9MK')).toBe('pdf');
+  });
+
+  it('detects a docx from its zip-header base64 prefix', () => {
+    expect(detectSyllabusFileKind('UEsDBBQAAAAIAA==')).toBe('docx');
+  });
+
+  it('returns null for neither', () => {
+    expect(detectSyllabusFileKind('plain text, not base64 of a real file')).toBeNull();
+    expect(detectSyllabusFileKind('')).toBeNull();
+  });
+});

--- a/src/lib/syllabus/extractRawText.ts
+++ b/src/lib/syllabus/extractRawText.ts
@@ -1,0 +1,48 @@
+/**
+ * Server-only: plain, non-AI text extraction from an uploaded syllabus file.
+ * Used to get a comparable text version of a document for the version-diff
+ * feature, without spending an Anthropic call - that's reserved for the full
+ * structured extraction in `/api/syllabus/extract`.
+ */
+import { Buffer } from 'node:buffer';
+
+export type SyllabusFileKind = 'pdf' | 'docx';
+
+/**
+ * Detected from magic bytes, not the client-declared MIME type (spoofable)
+ * or file extension. Both prefixes are stable regardless of what follows -
+ * base64 encodes in fixed 3-byte groups, so a known byte run at the start
+ * of a file always produces the same leading base64 characters.
+ * PDF: "%PDF-" (0x25 0x50 0x44 0x46 0x2D). DOCX: a .docx is a zip archive,
+ * so it starts with the zip local-file-header signature (0x50 0x4B 0x03 0x04).
+ */
+export function detectSyllabusFileKind(fileBase64: string): SyllabusFileKind | null {
+  if (fileBase64.startsWith('JVBERi0')) return 'pdf';
+  if (fileBase64.startsWith('UEsDB')) return 'docx';
+  return null;
+}
+
+/** Plain text only - no layout, no AI. Good enough for the heuristic
+ * line-based policy diff in `lib/syllabus/diffEngine.ts`, not for anything
+ * that needs the document's structure. */
+export async function extractRawSyllabusText(
+  fileBase64: string,
+  fileKind: SyllabusFileKind,
+): Promise<string> {
+  const buffer = Buffer.from(fileBase64, 'base64');
+
+  if (fileKind === 'docx') {
+    const mammoth = await import('mammoth');
+    const result = await mammoth.extractRawText({ buffer });
+    return result.value.trim();
+  }
+
+  const { PDFParse } = await import('pdf-parse');
+  const parser = new PDFParse({ data: buffer });
+  try {
+    const result = await parser.getText();
+    return result.text.trim();
+  } finally {
+    await parser.destroy();
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,3 +36,18 @@ export function normalizeContactName(name: string): string {
     .replace(/[^a-z\s]/g, '')
     .trim();
 }
+
+/** Reads a File as base64, stripping the `data:...;base64,` prefix a data
+ * URL comes with - every server route that accepts an uploaded file wants
+ * the raw base64 payload, not the full data URL. */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/types/syllabus.ts
+++ b/src/types/syllabus.ts
@@ -15,4 +15,9 @@ export interface SyllabusUpload {
    * should have this true; a course whose uploads predate this field (none
    * of them set) falls back to treating the most recent one as primary. */
   isPrimary?: boolean;
+  /** Plain text pulled from the file (no AI) at upload time - purely for
+   * comparing this upload against another one in the version-diff view.
+   * Absent when extraction failed or the upload predates this feature; the
+   * diff is simply unavailable in that case rather than treated as an error. */
+  rawText?: string;
 }


### PR DESCRIPTION
## What changed

Part 2 of the approved "syllabus re-extraction + versioning" feature — the diff-and-review half, on top of PR #235's version history.

Uploading a second syllabus to a course that already had one just added another file with no comparison. `SyllabusDiffModal` — a fully built diff UI with a real policy-change-detection engine (`diffEngine.ts`) — already existed, but was only reachable via a `?diff=true` demo trigger in `CoursesListView` showing empty placeholder text. Nobody could actually use it.

**Added:**
- `lib/syllabus/extractRawText.ts` — plain text extraction from an uploaded file (`mammoth` for .docx, new `pdf-parse` dependency for PDF). **No Anthropic call** — this is pure local parsing, kept deliberately separate from the AI-billed `/api/syllabus/extract` route so the diff feature costs nothing to use or test.
- `/api/syllabus/extract-text` — new route exposing that extraction, auth-gated the same way the AI route is.
- `SyllabusUpload.rawText` — populated best-effort on every upload (a failure here never fails the upload itself, it just means no diff is offered for that file later).
- `useUploadSyllabus`/`SyllabusUploader`/`CourseDetailView` wired so that uploading a new syllabus over an existing primary (with text on both sides) opens `SyllabusDiffModal` with the **real** comparison — grading, attendance, late-work policy, exam dates, office hours.
- Removed the dead `?diff=true` trigger and its empty-string demo modal instance now that there's a real entry point.

**What "Apply Selected Updates" does, concretely:** acknowledges the reviewed changes and closes. The new upload was already made primary at upload time (existing behavior from PR #235) — this doesn't add a second persistence step, since detected policy changes are descriptive text snippets, not structured fields to write back to the course. Said this plainly rather than overselling it.

**Also fixed, found while verifying against the required emulator setup:** `verifyFirebaseIdToken` verified every token's signature against Google's *production* JWKS unconditionally — meaning this route (and the pre-existing `/api/syllabus/extract`) was structurally impossible to verify against the Auth emulator before this fix, since emulator-issued tokens are never signed with Google's real key. Added a narrow decode-only branch gated strictly behind `FIREBASE_AUTH_EMULATOR_HOST` being set, which real deployments never set — production behavior is unchanged.

## Why

Approved feature, split into two PRs. This closes it out (version history landed in #235).

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `vitest run` (excluding rules spec), against a real `next build`: 75 files / 653 tests passing (7 new: `detectSyllabusFileKind` branches, `verifyFirebaseIdToken`'s new emulator path)
- **Live-verified end-to-end** against the real Firebase Local Emulator Suite + a live browser session, signed in through the real `/login` form, with two real `.docx` fixtures with genuinely different grading/attendance/late-work/office-hours text:
  - First upload to a course → becomes Primary, no diff shown (nothing to compare against yet).
  - Second upload → real `SyllabusDiffModal` opens showing all 4 real detected changes with correct before/after snippets.
  - "Apply Selected Updates" → success toast, modal closes, second file confirmed as Primary in the version list.
