### PR TITLE
Grade What-If Planner: real data, saved scenarios, honest Semester GPA

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,10 @@ service cloud.firestore {
         match /syllabi/{syllabusId} {
           allow read, write: if request.auth != null && request.auth.uid == userId;
         }
+
+        match /gradeScenarios/{scenarioId} {
+          allow read, write: if request.auth != null && request.auth.uid == userId;
+        }
       }
 
       match /scheduleItems/{itemId} {

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/firestore/scheduleItems';
 import { createContact, updateContact, deleteContact } from '@/lib/firestore/contacts';
 import { CourseFormModal } from '@/components/courses/CourseFormModal';
+import { GradeCalculatorModal } from '@/components/courses/GradeCalculatorModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusUploader } from '@/components/syllabus/SyllabusUploader';
 import { SyllabusList } from '@/components/syllabus/SyllabusList';
@@ -209,6 +210,7 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
   } | null>(null);
 
   const [editCourseOpen, setEditCourseOpen] = useState(false);
+  const [gradeCalculatorOpen, setGradeCalculatorOpen] = useState(false);
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<ScheduleItem | null>(null);
   const [confirmingDeleteCourse, setConfirmingDeleteCourse] = useState(false);
@@ -746,6 +748,22 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
 
             <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border pt-4">
               <CardActionButton onClick={() => setEditCourseOpen(true)}>Edit</CardActionButton>
+              <CardActionButton onClick={() => setGradeCalculatorOpen(true)}>
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+                Grade Calculator
+              </CardActionButton>
               {items.length > 0 && (
                 <CardActionButton onClick={handleExportICS}>
                   <svg
@@ -1585,6 +1603,11 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
         onClose={() => setEditCourseOpen(false)}
         onSubmit={handleEditCourse}
         initialCourse={course}
+      />
+      <GradeCalculatorModal
+        isOpen={gradeCalculatorOpen}
+        onClose={() => setGradeCalculatorOpen(false)}
+        initialCourseId={course.id}
       />
       <TaskFormModal
         open={addTaskOpen}

--- a/src/components/courses/CoursesListView.tsx
+++ b/src/components/courses/CoursesListView.tsx
@@ -134,6 +134,22 @@ export function CoursesListView() {
             </p>
           </div>
           <div className="flex items-center gap-2">
+            <CardActionButton onClick={() => setSimulatorOpen(true)}>
+              <svg
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+                />
+              </svg>
+              Grade Calculator
+            </CardActionButton>
             <CardActionButton onClick={() => setAutofillOpen(true)}>
               <svg
                 className="h-3.5 w-3.5"

--- a/src/components/courses/GradeCalculatorModal.tsx
+++ b/src/components/courses/GradeCalculatorModal.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useAppState } from '@/context/AppStateContext';
+import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { useModalA11y } from '@/hooks/useModalA11y';
@@ -10,8 +12,12 @@ import {
   calculateCurrentWeightedGrade,
   calculateRequiredFinalScore,
   calculateSemesterGpa,
+  deriveCategoriesFromScheduleItems,
   STANDARD_GRADE_SCALE,
 } from '@/lib/academic/gradeMath';
+import { useGradeScenarios } from '@/lib/firestore/useGradeScenarios';
+import { saveGradeScenario, deleteGradeScenario } from '@/lib/firestore/gradeScenarios';
+import type { ScheduleItem } from '@/types/schedule';
 
 export interface GradeCalculatorModalProps {
   isOpen: boolean;
@@ -19,10 +25,23 @@ export interface GradeCalculatorModalProps {
   initialCourseId?: string;
 }
 
-const DEFAULT_CATEGORIES: GradeCategory[] = [
-  { id: 'cat-1', name: 'Homework & Problem Sets', weight: 25, score: 92 },
-  { id: 'cat-2', name: 'Midterm Exam', weight: 25, score: 86 },
-  { id: 'cat-3', name: 'Projects & Labs', weight: 20, score: 95 },
+/** A friendly, editable starting point for a course with no graded items on
+ * record yet - distinct from `deriveCategoriesFromScheduleItems`'s real
+ * data, which returns an empty array in that case. Labeled generically since
+ * there's nothing course-specific to seed it with. */
+const STARTER_CATEGORIES: GradeCategory[] = [
+  { id: 'starter-1', name: 'Homework & Problem Sets', weight: 25, score: 90 },
+  { id: 'starter-2', name: 'Midterm Exam', weight: 25, score: 90 },
+  { id: 'starter-3', name: 'Projects & Labs', weight: 20, score: 90 },
+];
+
+const CATEGORY_BAR_COLORS = [
+  'bg-primary',
+  'bg-load-medium',
+  'bg-load-low',
+  'bg-load-high',
+  'bg-accent',
+  'bg-load-critical',
 ];
 
 export function GradeCalculatorModal({
@@ -31,20 +50,56 @@ export function GradeCalculatorModal({
   initialCourseId,
 }: GradeCalculatorModalProps) {
   const { state } = useAppState();
+  const { user } = useAuth();
+  const { showSuccess, showError } = useToast();
   const [selectedCourseId, setSelectedCourseId] = useState<string>(initialCourseId || '');
-  const [categories, setCategories] = useState<GradeCategory[]>(DEFAULT_CATEGORIES);
+  const [categories, setCategories] = useState<GradeCategory[]>([]);
   const [finalExamWeight, setFinalExamWeight] = useState<number>(30);
   const [targetPercentage, setTargetPercentage] = useState<number>(93.0); // Target 'A'
   const [activeTab, setActiveTab] = useState<'course' | 'semester'>('course');
+  const [savingScenario, setSavingScenario] = useState(false);
+  const [scenarioNameDraft, setScenarioNameDraft] = useState('');
+  const [deletingScenarioId, setDeletingScenarioId] = useState<string | null>(null);
 
-  // Initialize course selection
+  const scenarios = useGradeScenarios(user?.uid, selectedCourseId);
+
+  // Initialize course selection. Only reacts to `initialCourseId` actually
+  // changing (e.g. opening the modal from a different course's page) or the
+  // course list loading in - never to the user's own dropdown selection,
+  // which would otherwise get immediately overwritten back to
+  // `initialCourseId` on every change.
   useEffect(() => {
     if (initialCourseId) {
       setSelectedCourseId(initialCourseId);
-    } else if (state.courses.length > 0 && !selectedCourseId) {
-      setSelectedCourseId(state.courses[0].id);
+    } else if (state.courses.length > 0) {
+      setSelectedCourseId((prev) => prev || state.courses[0].id);
     }
-  }, [initialCourseId, state.courses, selectedCourseId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialCourseId, state.courses.length]);
+
+  /** A course's real standing, derived from its own graded schedule items -
+   * the actual source of truth the simulator seeds itself from, and what
+   * the Semester tab uses for every course, not just the one being edited. */
+  const realCategoriesFor = (courseId: string): GradeCategory[] =>
+    deriveCategoriesFromScheduleItems(
+      state.scheduleItems.filter((i: ScheduleItem) => i.courseId === courseId),
+    );
+
+  const hasRealDataForSelectedCourse = useMemo(
+    () => realCategoriesFor(selectedCourseId).length > 0,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedCourseId, state.scheduleItems],
+  );
+
+  // Re-seed the working categories from real data whenever the selected
+  // course changes - each course gets its own real starting point rather
+  // than carrying over whatever was being simulated for the last one.
+  useEffect(() => {
+    if (!selectedCourseId) return;
+    const real = realCategoriesFor(selectedCourseId);
+    setCategories(real.length > 0 ? real : STARTER_CATEGORIES);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCourseId]);
 
   const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
 
@@ -62,17 +117,23 @@ export function GradeCalculatorModal({
     return categories.reduce((sum, c) => sum + (c.weight || 0), 0) + finalExamWeight;
   }, [categories, finalExamWeight]);
 
-  // Semester GPA Calculation
+  // Semester GPA Calculation - every enrolled course's REAL current standing
+  // from its own graded items, except the course being actively simulated,
+  // which uses the live what-if numbers so adjusting it here is reflected
+  // immediately in the semester projection too.
   const semesterGpaResult = useMemo(() => {
     const coursesList = state.courses.map((course) => {
       const cr = (course as { credits?: number }).credits ?? 3;
       if (course.id === selectedCourseId) {
         return { credits: cr, percentage: currentGrade.currentPercentage };
       }
-      return { credits: cr, percentage: 88 }; // baseline estimated
+      const real = realCategoriesFor(course.id);
+      if (real.length === 0) return { credits: cr, percentage: undefined };
+      return { credits: cr, percentage: calculateCurrentWeightedGrade(real).currentPercentage };
     });
-    return calculateSemesterGpa(coursesList);
-  }, [state.courses, selectedCourseId, currentGrade.currentPercentage]);
+    return calculateSemesterGpa(coursesList.filter((c) => c.percentage !== undefined));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.courses, state.scheduleItems, selectedCourseId, currentGrade.currentPercentage]);
 
   // Category handlers
   const handleUpdateCategory = (
@@ -107,9 +168,49 @@ export function GradeCalculatorModal({
   };
 
   const handleReset = () => {
-    setCategories(DEFAULT_CATEGORIES);
+    const real = realCategoriesFor(selectedCourseId);
+    setCategories(real.length > 0 ? real : STARTER_CATEGORIES);
     setFinalExamWeight(30);
     setTargetPercentage(93.0);
+  };
+
+  const handleSaveScenario = async () => {
+    if (!user || !selectedCourseId || !scenarioNameDraft.trim()) return;
+    setSavingScenario(true);
+    try {
+      await saveGradeScenario(user.uid, selectedCourseId, {
+        name: scenarioNameDraft.trim(),
+        categories,
+        finalExamWeight,
+        targetPercentage,
+      });
+      showSuccess('Scenario saved', `"${scenarioNameDraft.trim()}" is ready to reload anytime.`);
+      setScenarioNameDraft('');
+    } catch (err) {
+      showError('Could not save this scenario', err instanceof Error ? err.message : undefined);
+    } finally {
+      setSavingScenario(false);
+    }
+  };
+
+  const handleLoadScenario = (scenarioId: string) => {
+    const scenario = scenarios.find((s) => s.id === scenarioId);
+    if (!scenario) return;
+    setCategories(scenario.categories);
+    setFinalExamWeight(scenario.finalExamWeight);
+    setTargetPercentage(scenario.targetPercentage);
+  };
+
+  const handleDeleteScenario = async (scenarioId: string) => {
+    if (!user || !selectedCourseId) return;
+    setDeletingScenarioId(scenarioId);
+    try {
+      await deleteGradeScenario(user.uid, selectedCourseId, scenarioId);
+    } catch (err) {
+      showError('Could not delete this scenario', err instanceof Error ? err.message : undefined);
+    } finally {
+      setDeletingScenarioId(null);
+    }
   };
 
   if (!isOpen) return null;
@@ -223,6 +324,88 @@ export function GradeCalculatorModal({
         <div className="max-h-[65vh] overflow-y-auto p-5 space-y-5">
           {activeTab === 'course' ? (
             <>
+              {/* Data provenance - is this the student's real standing, or a
+                  starter template they haven't customized yet? */}
+              <div
+                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium ${
+                  hasRealDataForSelectedCourse
+                    ? 'border-load-low/30 bg-load-low/10 text-load-low'
+                    : 'border-load-medium/30 bg-load-medium/10 text-load-medium'
+                }`}
+              >
+                <span
+                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                    hasRealDataForSelectedCourse ? 'bg-load-low' : 'bg-load-medium'
+                  }`}
+                  aria-hidden="true"
+                />
+                {hasRealDataForSelectedCourse
+                  ? 'Seeded from your actual graded work for this course - edit anything below to simulate a change.'
+                  : "No graded scores on record for this course yet - showing an editable starter template. Enter scores on graded tasks and they'll appear here automatically."}
+              </div>
+
+              {/* Saved Scenarios */}
+              <div className="rounded-xl border border-border/40 bg-muted/10 p-3.5 space-y-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                    Saved Scenarios
+                  </span>
+                </div>
+                {scenarios.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {scenarios.map((scenario) => (
+                      <div
+                        key={scenario.id}
+                        className="flex items-center gap-1 rounded-full border border-border bg-card pl-3 pr-1 py-1"
+                      >
+                        <button
+                          onClick={() => handleLoadScenario(scenario.id)}
+                          className="text-xs font-semibold text-foreground hover:text-primary"
+                        >
+                          {scenario.name}
+                        </button>
+                        <button
+                          onClick={() => handleDeleteScenario(scenario.id)}
+                          disabled={deletingScenarioId === scenario.id}
+                          aria-label={`Delete scenario ${scenario.name}`}
+                          className="rounded-full p-1 text-muted-foreground hover:bg-destructive/15 hover:text-destructive transition-colors disabled:opacity-50"
+                        >
+                          <svg
+                            className="h-3 w-3"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2.5}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={scenarioNameDraft}
+                    onChange={(e) => setScenarioNameDraft(e.target.value)}
+                    placeholder='Name this scenario, e.g. "Best case"'
+                    className="flex-1 rounded-lg border border-border/60 bg-card px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                  <button
+                    onClick={handleSaveScenario}
+                    disabled={!scenarioNameDraft.trim() || savingScenario}
+                    className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {savingScenario ? 'Saving…' : 'Save current'}
+                  </button>
+                </div>
+              </div>
+
               {/* Current Standing & Target Result Overview */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
                 {/* Current Standing Card */}
@@ -328,6 +511,49 @@ export function GradeCalculatorModal({
                     </CardActionButton>
                   </div>
                 </div>
+
+                {/* Segmented bar - each category's share of the grade
+                    computed so far, at a glance before reading the table. */}
+                {categories.length > 0 && (
+                  <div className="space-y-1.5">
+                    <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted">
+                      {categories.map((cat, idx) => (
+                        <div
+                          key={cat.id || idx}
+                          className={CATEGORY_BAR_COLORS[idx % CATEGORY_BAR_COLORS.length]}
+                          style={{
+                            width: `${totalWeight > 0 ? ((cat.weight || 0) / totalWeight) * 100 : 0}%`,
+                          }}
+                          title={`${cat.name}: ${cat.weight}% weight`}
+                        />
+                      ))}
+                      <div
+                        className="bg-border"
+                        style={{
+                          width: `${totalWeight > 0 ? (finalExamWeight / totalWeight) * 100 : 0}%`,
+                        }}
+                        title={`Final Exam: ${finalExamWeight}% weight`}
+                      />
+                    </div>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      {categories.map((cat, idx) => (
+                        <span
+                          key={cat.id || idx}
+                          className="flex items-center gap-1 text-[11px] text-muted-foreground"
+                        >
+                          <span
+                            className={`h-2 w-2 rounded-full ${CATEGORY_BAR_COLORS[idx % CATEGORY_BAR_COLORS.length]}`}
+                          />
+                          {cat.name}
+                        </span>
+                      ))}
+                      <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                        <span className="h-2 w-2 rounded-full bg-border" />
+                        Final Exam
+                      </span>
+                    </div>
+                  </div>
+                )}
 
                 <div className="space-y-2">
                   {categories.map((cat, idx) => (
@@ -480,9 +706,15 @@ export function GradeCalculatorModal({
                 {state.courses.map((course) => {
                   const isCurrent = course.id === selectedCourseId;
                   const credits = (course as { credits?: number }).credits ?? 3;
-                  const percent = isCurrent ? currentGrade.currentPercentage : 88;
-                  const letter = isCurrent ? currentGrade.letterGrade : 'B+';
-                  const gpaPts = isCurrent ? currentGrade.gpaPoints : 3.3;
+                  const real = isCurrent ? null : realCategoriesFor(course.id);
+                  const realGrade =
+                    real && real.length > 0 ? calculateCurrentWeightedGrade(real) : null;
+                  const hasData = isCurrent || realGrade !== null;
+                  const percent = isCurrent
+                    ? currentGrade.currentPercentage
+                    : realGrade?.currentPercentage;
+                  const letter = isCurrent ? currentGrade.letterGrade : realGrade?.letterGrade;
+                  const gpaPts = isCurrent ? currentGrade.gpaPoints : realGrade?.gpaPoints;
 
                   return (
                     <div
@@ -500,16 +732,26 @@ export function GradeCalculatorModal({
                         </p>
                       </div>
                       <div className="flex items-center gap-3 text-right">
-                        <div>
-                          <span className="text-sm font-extrabold text-foreground">{percent}%</span>
-                          <p className="text-xs font-semibold text-primary">
-                            {letter} ({gpaPts} pts)
-                          </p>
-                        </div>
+                        {hasData ? (
+                          <div>
+                            <span className="text-sm font-extrabold text-foreground">
+                              {percent}%
+                            </span>
+                            <p className="text-xs font-semibold text-primary">
+                              {letter} ({gpaPts} pts)
+                            </p>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">No grades yet</span>
+                        )}
                       </div>
                     </div>
                   );
                 })}
+                <p className="pt-1 text-[11px] text-muted-foreground">
+                  Courses with no graded work yet are excluded from the GPA above rather than
+                  guessed at.
+                </p>
               </div>
             </div>
           )}

--- a/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
+++ b/src/components/courses/__tests__/GradeCalculatorModal.test.tsx
@@ -4,7 +4,34 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { GradeCalculatorModal } from '../GradeCalculatorModal';
 import { AppStateProvider, AppState } from '@/context/AppStateContext';
 import { ThemeProvider } from '@/context/ThemeProvider';
-import type { Course } from '@/types/schedule';
+import { AuthProvider } from '@/context/AuthContext';
+import { ToastProvider } from '@/components/ui/Toast';
+import type { Course, ScheduleItem } from '@/types/schedule';
+
+const gradedItems: ScheduleItem[] = [
+  {
+    id: 'item-1',
+    courseId: 'course-1',
+    title: 'Homework 1',
+    type: 'assignment',
+    dueDate: '2026-09-10',
+    completed: true,
+    gradeCategory: 'Homework',
+    gradeWeight: 40,
+    earnedScore: 88,
+  },
+  {
+    id: 'item-2',
+    courseId: 'course-1',
+    title: 'Midterm',
+    type: 'exam',
+    dueDate: '2026-10-10',
+    completed: true,
+    gradeCategory: 'Exams',
+    gradeWeight: 30,
+    earnedScore: 92,
+  },
+];
 
 const mockCourses: Course[] = [
   {
@@ -34,7 +61,11 @@ function renderWithProviders(ui: React.ReactElement, stateOverrides: Partial<App
 
   return render(
     <ThemeProvider>
-      <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+      <AuthProvider>
+        <ToastProvider>
+          <AppStateProvider initialState={initialState as AppState}>{ui}</AppStateProvider>
+        </ToastProvider>
+      </AuthProvider>
     </ThemeProvider>,
   );
 }
@@ -109,5 +140,44 @@ describe('GradeCalculatorModal (Item 36)', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the starter-template banner when the course has no graded work on record', () => {
+    renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/No graded scores on record for this course yet/i)).toBeDefined();
+  });
+
+  it('seeds categories from real graded schedule items and shows the seeded-data banner', () => {
+    renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={vi.fn()} />, {
+      scheduleItems: gradedItems,
+    });
+
+    expect(screen.getByText(/Seeded from your actual graded work/i)).toBeDefined();
+    expect(screen.getByDisplayValue('Homework')).toBeDefined();
+    expect(screen.getByDisplayValue('Exams')).toBeDefined();
+  });
+
+  it('shows "No grades yet" in the Semester GPA tab for a course with no graded items', () => {
+    renderWithProviders(
+      <GradeCalculatorModal isOpen={true} onClose={vi.fn()} initialCourseId="course-1" />,
+      { scheduleItems: gradedItems },
+    );
+
+    fireEvent.click(screen.getByText('Semester GPA Impact'));
+
+    expect(screen.getByText('No grades yet')).toBeDefined();
+  });
+
+  it('enables the Save Scenario button only once a scenario name is entered', () => {
+    renderWithProviders(<GradeCalculatorModal isOpen={true} onClose={vi.fn()} />);
+
+    const saveButton = screen.getByText('Save current').closest('button') as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    const nameInput = screen.getByPlaceholderText(/Name this scenario/i);
+    fireEvent.change(nameInput, { target: { value: 'Best case' } });
+
+    expect(saveButton.disabled).toBe(false);
   });
 });

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -54,10 +54,14 @@ function GradeImpactPanel({
   item,
   course,
   courseItems,
+  scoreText,
+  onScoreChange,
 }: {
   item: ScheduleItem;
   course: Course | undefined;
   courseItems: ScheduleItem[];
+  scoreText: string;
+  onScoreChange: (raw: string) => void;
 }) {
   if (item.gradeWeight === undefined) return null;
 
@@ -95,6 +99,25 @@ function GradeImpactPanel({
             <p className="mt-2 text-sm text-foreground">
               {describeGradeImpact(item, courseItems, courseLabel)}
             </p>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-3 border-t border-primary/10 pt-3">
+          <label htmlFor="earned-score" className="text-sm font-medium text-foreground">
+            Score received
+          </label>
+          <div className="flex items-center gap-1.5">
+            <input
+              id="earned-score"
+              type="number"
+              min={0}
+              inputMode="decimal"
+              placeholder="Not graded yet"
+              value={scoreText}
+              onChange={(e) => onScoreChange(e.target.value)}
+              className="w-28 rounded-lg border border-border bg-card px-2.5 py-1.5 text-right text-sm font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <span className="text-sm text-muted-foreground">%</span>
           </div>
         </div>
       </div>
@@ -195,6 +218,9 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
    * doesn't get coerced mid-keystroke. null once the debounced write lands. */
   const [hoursDraft, setHoursDraft] = useState<string | null>(null);
   const hoursCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Same pattern again, for the "score received" field on a graded item. */
+  const [scoreDraft, setScoreDraft] = useState<string | null>(null);
+  const scoreCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const item = state.scheduleItems.find((i) => i.id === taskId);
   const course = item ? state.courses.find((c) => c.id === item.courseId) : undefined;
@@ -270,6 +296,41 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
       setHoursDraft(null);
     }, COMMIT_DEBOUNCE_MS);
   };
+
+  const handleSetEarnedScore = async (value: number | undefined) => {
+    if (!user) return;
+    try {
+      const next = { ...item } as ScheduleItem;
+      if (value === undefined) {
+        delete next.earnedScore;
+      } else {
+        next.earnedScore = value;
+      }
+      await updateScheduleItem(user.uid, item, next, dispatch);
+    } catch (err) {
+      console.error('Failed to update earned score:', err);
+      showError("Couldn't save that score. Try again in a moment.");
+    }
+  };
+
+  const handleScoreInputChange = (raw: string) => {
+    setScoreDraft(raw);
+    if (scoreCommitTimer.current) clearTimeout(scoreCommitTimer.current);
+    scoreCommitTimer.current = setTimeout(() => {
+      if (raw.trim() === '') {
+        handleSetEarnedScore(undefined);
+      } else {
+        const parsed = Number(raw);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+          handleSetEarnedScore(Math.round(parsed * 10) / 10);
+        }
+      }
+      scoreCommitTimer.current = null;
+      setScoreDraft(null);
+    }, COMMIT_DEBOUNCE_MS);
+  };
+
+  const displayScoreText = scoreDraft ?? (item.earnedScore != null ? String(item.earnedScore) : '');
 
   const progressPct = clampProgress(item.progress ?? 0);
   // The slider's own value while dragging/settling, so the ring, the %
@@ -612,7 +673,13 @@ export function TaskDetailView({ taskId }: { taskId: string }) {
             </div>
           </dl>
 
-          <GradeImpactPanel item={item} course={course} courseItems={courseItems} />
+          <GradeImpactPanel
+            item={item}
+            course={course}
+            courseItems={courseItems}
+            scoreText={displayScoreText}
+            onScoreChange={handleScoreInputChange}
+          />
 
           <div className="border-t border-border">
             <LatePenaltyAdvisor

--- a/src/lib/academic/__tests__/gradeMath.test.ts
+++ b/src/lib/academic/__tests__/gradeMath.test.ts
@@ -5,8 +5,22 @@ import {
   calculateCurrentWeightedGrade,
   calculateRequiredFinalScore,
   calculateSemesterGpa,
+  deriveCategoriesFromScheduleItems,
   GradeCategory,
 } from '../gradeMath';
+import type { ScheduleItem } from '@/types/schedule';
+
+function item(overrides: Partial<ScheduleItem>): ScheduleItem {
+  return {
+    id: overrides.id ?? 'item',
+    courseId: 'course-1',
+    title: 'Item',
+    type: 'assignment',
+    dueDate: '2026-09-10',
+    completed: true,
+    ...overrides,
+  };
+}
 
 describe('Academic Grade Math (Item 36)', () => {
   it('converts percentages to letter grades correctly across boundaries', () => {
@@ -83,9 +97,7 @@ describe('Academic Grade Math (Item 36)', () => {
   });
 
   it('detects already achieved / guaranteed grades (<=0% required on final)', () => {
-    const categories: GradeCategory[] = [
-      { name: 'Coursework', weight: 90, score: 98 },
-    ];
+    const categories: GradeCategory[] = [{ name: 'Coursework', weight: 90, score: 98 }];
     // Final is 10% weight, target 70% (C-)
     const result = calculateRequiredFinalScore(categories, 10, 70.0);
     expect(result.requiredFinalScore).toBeLessThanOrEqual(0);
@@ -107,5 +119,45 @@ describe('Academic Grade Math (Item 36)', () => {
     expect(result.totalCredits).toBe(10);
     expect(result.gpa).toBe(3.61);
     expect(result.qualityPoints).toBe(36.1);
+  });
+
+  it('derives grade categories from graded schedule items, grouped by category', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'a', gradeCategory: 'Homework', gradeWeight: 10, earnedScore: 90 }),
+      item({ id: 'b', gradeCategory: 'Homework', gradeWeight: 10, earnedScore: 80 }),
+      item({ id: 'c', gradeCategory: 'Exams', gradeWeight: 30, earnedScore: 88 }),
+    ];
+
+    const categories = deriveCategoriesFromScheduleItems(items);
+
+    const homework = categories.find((c) => c.name === 'Homework');
+    const exams = categories.find((c) => c.name === 'Exams');
+    expect(homework?.weight).toBe(20);
+    // (10*90 + 10*80) / 20 = 85
+    expect(homework?.score).toBe(85);
+    expect(exams?.weight).toBe(30);
+    expect(exams?.score).toBe(88);
+  });
+
+  it('excludes items missing a weight or score, and falls back to "Other" for an uncategorized item', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'no-score', gradeCategory: 'Homework', gradeWeight: 10 }),
+      item({ id: 'no-weight', gradeCategory: 'Homework', earnedScore: 90 }),
+      item({ id: 'uncategorized', gradeWeight: 15, earnedScore: 70 }),
+    ];
+
+    const categories = deriveCategoriesFromScheduleItems(items);
+
+    expect(categories).toHaveLength(1);
+    expect(categories[0].name).toBe('Other');
+    expect(categories[0].weight).toBe(15);
+    expect(categories[0].score).toBe(70);
+  });
+
+  it('returns an empty array when no schedule items have both a weight and a score', () => {
+    expect(deriveCategoriesFromScheduleItems([])).toEqual([]);
+    expect(
+      deriveCategoriesFromScheduleItems([item({ id: 'ungraded', gradeCategory: 'Homework' })]),
+    ).toEqual([]);
   });
 });

--- a/src/lib/academic/gradeMath.ts
+++ b/src/lib/academic/gradeMath.ts
@@ -5,6 +5,8 @@
  * final exam target score solving, and cumulative semester GPA modeling.
  */
 
+import type { ScheduleItem } from '@/types/schedule';
+
 export interface GradeCategory {
   id?: string;
   name: string;
@@ -99,6 +101,41 @@ export function calculateCurrentWeightedGrade(categories: GradeCategory[]): {
   };
 }
 
+/**
+ * Turns a course's real, graded schedule items into `GradeCategory` rows -
+ * the actual standing to seed the what-if calculator with, instead of a
+ * fictional starting point the student has to re-enter by hand every time.
+ * An item only counts once it has both a weight and a received score;
+ * grading category defaults to "Other" for an item with a weight but no
+ * category name on record, rather than silently dropping its weight from
+ * the total. Multiple items in the same category are combined into one row
+ * (weight summed, score weighted by each item's own weight).
+ */
+export function deriveCategoriesFromScheduleItems(items: ScheduleItem[]): GradeCategory[] {
+  const graded = items.filter(
+    (item) => typeof item.gradeWeight === 'number' && typeof item.earnedScore === 'number',
+  );
+
+  const byCategory = new Map<string, { weight: number; weightedScore: number }>();
+  for (const item of graded) {
+    const name = item.gradeCategory?.trim() || 'Other';
+    const weight = item.gradeWeight ?? 0;
+    const score = item.earnedScore ?? 0;
+    const existing = byCategory.get(name) ?? { weight: 0, weightedScore: 0 };
+    byCategory.set(name, {
+      weight: existing.weight + weight,
+      weightedScore: existing.weightedScore + weight * score,
+    });
+  }
+
+  return Array.from(byCategory.entries()).map(([name, { weight, weightedScore }]) => ({
+    id: `real-${name}`,
+    name,
+    weight: Math.round(weight * 100) / 100,
+    score: weight > 0 ? Math.round((weightedScore / weight) * 100) / 100 : 0,
+  }));
+}
+
 export type TargetScoreStatus = 'already_achieved' | 'achievable' | 'challenging' | 'impossible';
 
 export interface FinalExamTargetResult {
@@ -122,7 +159,7 @@ export interface FinalExamTargetResult {
 export function calculateRequiredFinalScore(
   nonFinalCategories: GradeCategory[],
   finalExamWeight: number,
-  targetPercentage: number
+  targetPercentage: number,
 ): FinalExamTargetResult {
   const targetGrade = percentageToLetterGrade(targetPercentage);
   const finalWeight = Math.max(0.1, finalExamWeight);
@@ -145,7 +182,7 @@ export function calculateRequiredFinalScore(
   const targetTotalPoints = (targetPercentage * totalCourseWeight) / 100;
 
   const pointsNeededFromFinal = targetTotalPoints - nonFinalPoints;
-  const rawRequiredFinalScore = (pointsNeededFromFinal / (finalWeight / 100));
+  const rawRequiredFinalScore = pointsNeededFromFinal / (finalWeight / 100);
   const roundedRequired = Math.round(rawRequiredFinalScore * 10) / 10;
 
   let status: TargetScoreStatus = 'achievable';
@@ -191,7 +228,7 @@ export interface SemesterCourseProjection {
  * Calculates term GPA weighted by credit hours.
  */
 export function calculateSemesterGpa(
-  courses: { credits?: number; gpaPoints?: number; percentage?: number }[]
+  courses: { credits?: number; gpaPoints?: number; percentage?: number }[],
 ): {
   gpa: number;
   totalCredits: number;

--- a/src/lib/firestore/gradeScenarios.ts
+++ b/src/lib/firestore/gradeScenarios.ts
@@ -1,0 +1,29 @@
+import { doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { GradeScenario } from '@/types/gradeScenario';
+
+export async function saveGradeScenario(
+  userId: string,
+  courseId: string,
+  scenario: Omit<GradeScenario, 'id' | 'createdAt' | 'courseId'>,
+): Promise<GradeScenario> {
+  if (!db) throw new Error('Firestore is not configured.');
+  const id = crypto.randomUUID();
+  const record: GradeScenario = {
+    ...scenario,
+    id,
+    courseId,
+    createdAt: new Date().toISOString(),
+  };
+  await setDoc(doc(db, 'users', userId, 'courses', courseId, 'gradeScenarios', id), record);
+  return record;
+}
+
+export async function deleteGradeScenario(
+  userId: string,
+  courseId: string,
+  scenarioId: string,
+): Promise<void> {
+  if (!db) throw new Error('Firestore is not configured.');
+  await deleteDoc(doc(db, 'users', userId, 'courses', courseId, 'gradeScenarios', scenarioId));
+}

--- a/src/lib/firestore/useGradeScenarios.ts
+++ b/src/lib/firestore/useGradeScenarios.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { GradeScenario } from '@/types/gradeScenario';
+
+export function useGradeScenarios(userId: string | undefined, courseId: string) {
+  const [scenarios, setScenarios] = useState<GradeScenario[]>([]);
+
+  useEffect(() => {
+    if (!userId || !courseId || !db) return;
+    const unsubscribe = onSnapshot(
+      collection(db, 'users', userId, 'courses', courseId, 'gradeScenarios'),
+      (snapshot) => setScenarios(snapshot.docs.map((d) => d.data() as GradeScenario)),
+    );
+    return unsubscribe;
+  }, [userId, courseId]);
+
+  return scenarios;
+}

--- a/src/types/gradeScenario.ts
+++ b/src/types/gradeScenario.ts
@@ -1,0 +1,17 @@
+import type { GradeCategory } from '@/lib/academic/gradeMath';
+
+/**
+ * A saved what-if grade simulation for a course - the inputs to the
+ * calculator (category weights/scores, final exam weight, target
+ * percentage), named and persisted so a student can come back to "Best
+ * case" or "If I bomb the final" without re-entering every number.
+ */
+export interface GradeScenario {
+  id: string;
+  courseId: string;
+  name: string;
+  categories: GradeCategory[];
+  finalExamWeight: number;
+  targetPercentage: number;
+  createdAt: string;
+}

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -196,6 +196,12 @@ export interface ScheduleItem {
   gradeWeight?: number;
   /** Grading category this item falls under, e.g. 'Homework', 'Exam' */
   gradeCategory?: string;
+  /** The score actually received on this item, as a percentage (0-100+,
+   * so extra credit isn't clipped). Distinct from `gradeWeight` - weight is
+   * planned before the fact, this is entered once the grade comes back.
+   * Only meaningful alongside `gradeWeight`; an item with a score but no
+   * weight has nothing for the grade calculator to weight it by. */
+  earnedScore?: number;
   /** Free-text name of who owns this sub-task on a group project - a
    * private label only the signed-in user sees, not a shared assignment
    * system. Lets a chunked group project ("Literature review", "Data


### PR DESCRIPTION
## Summary

- Rebuilds the grade calculator from a fake-data demo into a real, persistent planner. It now seeds itself from a course's actual graded schedule items via a new `earnedScore` field on `ScheduleItem` and `deriveCategoriesFromScheduleItems`, and shows an explicit banner telling the student whether they're looking at real standing or an editable starter template.
- Adds a Firestore-backed named-scenario system (`gradeScenarios` subcollection, mirroring the existing `syllabi` pattern) so a what-if scenario can be saved, reloaded, and deleted instead of being lost on close.
- Fixes the Semester GPA tab, which previously showed a hardcoded 88%/B+/3.3 for every course except the one being edited — it now shows each course's real standing and an honest "No grades yet" for ungraded courses, excluding them from the aggregate GPA rather than guessing.
- Adds a "Score received" input to the task detail view's grade-impact panel so grades can be entered where the rest of a task's info already lives.
- Adds visible "Grade Calculator" entry points to both the Courses list and course detail headers (previously only reachable via the command palette), plus a category-contribution bar for at-a-glance weighting.
- Fixes a real bug found during live verification: the course selector inside the modal would silently snap back to `initialCourseId` on every change because of a stale effect dependency.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx vitest run --exclude "**/rules.spec.ts"` — 660/660 passing (added new coverage for `deriveCategoriesFromScheduleItems` and the modal's real-data seeding, provenance banner, honest Semester GPA state, and scenario-save gating)
- Clean production build (`rm -rf .next && npm run build`) — passing, and the full test suite re-verified against that build (including the hardcoded-UID production-leak security gate)
- Live-verified against the real Firebase Local Emulator Suite + a real Playwright browser session with a real login: seeded real graded/ungraded courses, confirmed the seeded-data and starter-template banners, confirmed the Semester GPA tab's honest per-course state, confirmed saving/loading a scenario persists in real Firestore across a reload, confirmed entering a score on a task persists and feeds the calculator, and confirmed both new entry-point buttons open the modal.
