### PR TITLE
Burnout early-warning dashboard card

### DIFF
--- a/src/components/dashboard/BurnoutRiskCard.tsx
+++ b/src/components/dashboard/BurnoutRiskCard.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/Card';
+import { useAuth } from '@/context/AuthContext';
+import { computeBurnoutRisk } from '@/lib/burnout/burnoutRisk';
+import { getWorkloadBadgeTokens } from '@/lib/workload';
+import type { MoodEntry } from '@/types/mood';
+import type { ScheduleItem, WorkloadLevel } from '@/types/schedule';
+
+const COPY: Record<WorkloadLevel, { headline: string; subline: string }> = {
+  low: {
+    headline: "You're keeping a good pace",
+    subline: 'No burnout warning signs right now.',
+  },
+  medium: {
+    headline: 'Worth keeping an eye on',
+    subline: 'A few signals are trending the wrong way.',
+  },
+  high: {
+    headline: 'Elevated burnout risk',
+    subline: 'Several signals suggest you might be running low.',
+  },
+  critical: {
+    headline: 'High burnout risk',
+    subline: 'Multiple strong signals at once - consider easing up where you can.',
+  },
+};
+
+/** Same "Monday of this week" grouping WeeklyBriefingCard uses, so a
+ * dismissal naturally clears out at the start of a new week. */
+function weekStartKey(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diffToMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Dismissal is keyed by level, not just week - unlike the weekly briefing,
+ * silently staying hidden while risk climbs from "worth watching" to "high"
+ * would defeat the point of an early-warning card. Dismissing a lower tier
+ * doesn't suppress a later, more severe one. */
+function dismissedStorageKey(uid: string, weekKey: string, level: WorkloadLevel): string {
+  return `burnout-risk-dismissed:${uid}:${weekKey}:${level}`;
+}
+
+export interface BurnoutRiskCardProps {
+  scheduleItems: ScheduleItem[];
+  moodEntries: MoodEntry[];
+}
+
+/** A dismissible early-warning card combining objective workload signals
+ * (heavy days ahead/behind, overdue items) with self-reported mood into one
+ * indicator - entirely client-computed from data already loaded, no
+ * notification backend required (same approach as WeeklyBriefingCard). */
+export function BurnoutRiskCard({ scheduleItems, moodEntries }: BurnoutRiskCardProps) {
+  const { user } = useAuth();
+  const weekKey = useMemo(() => weekStartKey(new Date()), []);
+  const risk = useMemo(
+    () => computeBurnoutRisk(scheduleItems, moodEntries),
+    [scheduleItems, moodEntries],
+  );
+
+  const [dismissedLevel, setDismissedLevel] = useState<WorkloadLevel | null>(() => {
+    if (!user || typeof window === 'undefined') return null;
+    try {
+      for (const level of ['medium', 'high', 'critical'] as const) {
+        if (window.localStorage.getItem(dismissedStorageKey(user.uid, weekKey, level)) === 'true') {
+          return level;
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
+
+  if (risk.level === 'low' || risk.level === dismissedLevel) {
+    return null;
+  }
+
+  const tokens = getWorkloadBadgeTokens(risk.level, { solid: false });
+  const copy = COPY[risk.level];
+
+  const handleDismiss = () => {
+    setDismissedLevel(risk.level);
+    if (!user) return;
+    try {
+      window.localStorage.setItem(dismissedStorageKey(user.uid, weekKey, risk.level), 'true');
+    } catch {
+      // Non-fatal: worst case it reappears next visit.
+    }
+  };
+
+  return (
+    <Card accent="none" className={`rounded-2xl border p-5 ${tokens.chipClass}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2 w-2 shrink-0 rounded-full ${tokens.swatchClass}`}
+              aria-hidden="true"
+            />
+            <h2 className={`text-sm font-bold ${tokens.textClass}`}>{copy.headline}</h2>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{copy.subline}</p>
+
+          {risk.factors.length > 0 && (
+            <ul className="mt-2.5 space-y-1">
+              {risk.factors.map((factor) => (
+                <li
+                  key={factor.key}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                >
+                  <span
+                    className={`h-1 w-1 rounded-full ${tokens.swatchClass}`}
+                    aria-hidden="true"
+                  />
+                  {factor.label}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!risk.hasEnoughMoodData && (
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Log your mood a few more days this week for a fuller picture.
+            </p>
+          )}
+
+          <Link
+            href="/mood"
+            className={`mt-3 inline-flex items-center gap-1 text-xs font-semibold ${tokens.textClass} hover:underline`}
+          >
+            See your mood & workload recap →
+          </Link>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss this burnout warning"
+          className="shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -20,6 +20,7 @@ import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillMod
 import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
 import { MaterialsBudgetCard } from '@/components/dashboard/MaterialsBudgetCard';
 import { MoodCheckInCard } from '@/components/dashboard/MoodCheckInCard';
+import { BurnoutRiskCard } from '@/components/dashboard/BurnoutRiskCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
 import { WORKLOAD_CHIP_CLASS, WORKLOAD_TEXT_CLASS } from '@/lib/workload';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
@@ -532,6 +533,8 @@ export function DashboardView() {
             })}
           </div>
         </Card>
+
+        <BurnoutRiskCard scheduleItems={state.scheduleItems} moodEntries={state.moodEntries} />
 
         <MoodCheckInCard />
 

--- a/src/components/dashboard/__tests__/BurnoutRiskCard.test.tsx
+++ b/src/components/dashboard/__tests__/BurnoutRiskCard.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AuthProvider } from '@/context/AuthContext';
+import { BurnoutRiskCard } from '../BurnoutRiskCard';
+import type { ScheduleItem } from '@/types/schedule';
+import type { MoodEntry } from '@/types/mood';
+
+function renderWithAuth(items: ScheduleItem[], moodEntries: MoodEntry[]) {
+  return render(
+    <AuthProvider>
+      <BurnoutRiskCard scheduleItems={items} moodEntries={moodEntries} />
+    </AuthProvider>,
+  );
+}
+
+function overdueItem(id: string, dueDate: string): ScheduleItem {
+  return {
+    id,
+    courseId: 'course-1',
+    title: 'Overdue thing',
+    type: 'assignment',
+    dueDate,
+    completed: false,
+  };
+}
+
+describe('BurnoutRiskCard', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders nothing when risk is low', () => {
+    const { container } = renderWithAuth([], []);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a warning with contributing factors when risk is elevated', () => {
+    const items = [
+      overdueItem('a', '2000-01-01'),
+      overdueItem('b', '2000-01-02'),
+      overdueItem('c', '2000-01-03'),
+    ];
+    renderWithAuth(items, []);
+
+    expect(screen.getByText('3 overdue items')).toBeDefined();
+  });
+
+  it('dismisses the card and keeps it hidden for that risk level', () => {
+    const items = [
+      overdueItem('a', '2000-01-01'),
+      overdueItem('b', '2000-01-02'),
+      overdueItem('c', '2000-01-03'),
+    ];
+    const { container } = renderWithAuth(items, []);
+
+    const dismissBtn = screen.getByRole('button', { name: /dismiss this burnout warning/i });
+    fireEvent.click(dismissBtn);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/lib/burnout/__tests__/burnoutRisk.test.ts
+++ b/src/lib/burnout/__tests__/burnoutRisk.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { computeBurnoutRisk } from '../burnoutRisk';
+import type { ScheduleItem } from '@/types/schedule';
+import type { MoodEntry } from '@/types/mood';
+
+const REFERENCE_DATE = new Date(2026, 8, 10); // Thursday, September 10, 2026
+
+function item(overrides: Partial<ScheduleItem> & { dueDate: string }): ScheduleItem {
+  return {
+    id: overrides.id ?? `item-${overrides.dueDate}-${Math.random()}`,
+    courseId: 'course-1',
+    title: 'Item',
+    type: 'assignment',
+    completed: false,
+    ...overrides,
+  };
+}
+
+function mood(dateKey: string, value: MoodEntry['mood']): MoodEntry {
+  return { id: dateKey, dateKey, mood: value, createdAt: `${dateKey}T12:00:00.000Z` };
+}
+
+describe('computeBurnoutRisk', () => {
+  it('reports low risk with no factors when there is no data at all', () => {
+    const result = computeBurnoutRisk([], [], REFERENCE_DATE);
+    expect(result.level).toBe('low');
+    expect(result.score).toBe(0);
+    expect(result.factors).toEqual([]);
+    expect(result.hasEnoughMoodData).toBe(false);
+  });
+
+  it('flags overdue items as a factor and raises the level once enough of them pile up', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'a', dueDate: '2026-09-07' }),
+      item({ id: 'b', dueDate: '2026-09-08' }),
+      item({ id: 'c', dueDate: '2026-09-09' }),
+    ];
+    const result = computeBurnoutRisk(items, [], REFERENCE_DATE);
+    const overdueFactor = result.factors.find((f) => f.key === 'overdue');
+    expect(overdueFactor?.label).toBe('3 overdue items');
+    expect(overdueFactor?.points).toBe(24);
+    expect(result.level).toBe('medium');
+  });
+
+  it('does not count a completed item as overdue', () => {
+    const items: ScheduleItem[] = [item({ dueDate: '2026-09-01', completed: true })];
+    const result = computeBurnoutRisk(items, [], REFERENCE_DATE);
+    expect(result.factors.find((f) => f.key === 'overdue')).toBeUndefined();
+  });
+
+  it('flags a heavy stretch of upcoming days', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'crit-1', dueDate: '2026-09-11', estimatedHours: 9 }),
+      item({ id: 'crit-2', dueDate: '2026-09-12', estimatedHours: 9 }),
+    ];
+    const result = computeBurnoutRisk(items, [], REFERENCE_DATE);
+    const upcomingFactor = result.factors.find((f) => f.key === 'upcoming-load');
+    expect(upcomingFactor?.label).toBe('2 heavy days coming up in the next week');
+    expect(upcomingFactor?.points).toBe(14); // 2 critical days x 7 points
+  });
+
+  it('flags a heavy recent stretch using due-date load regardless of completion', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'past-1', dueDate: '2026-09-05', estimatedHours: 6, completed: true }),
+      item({ id: 'past-2', dueDate: '2026-09-06', estimatedHours: 6, completed: true }),
+    ];
+    const result = computeBurnoutRisk(items, [], REFERENCE_DATE);
+    const recentFactor = result.factors.find((f) => f.key === 'recent-load');
+    expect(recentFactor?.label).toBe('2 heavy days over the past week');
+    expect(recentFactor?.points).toBe(6); // 2 high days x 3 points
+    expect(result.factors.find((f) => f.key === 'overdue')).toBeUndefined();
+  });
+
+  it('reports insufficient mood data below the minimum check-in threshold', () => {
+    const entries = [mood('2026-09-09', 1), mood('2026-09-10', 1)];
+    const result = computeBurnoutRisk([], entries, REFERENCE_DATE);
+    expect(result.hasEnoughMoodData).toBe(false);
+    expect(result.factors.find((f) => f.key === 'low-mood')).toBeUndefined();
+  });
+
+  it('flags a low mood average once enough check-ins are logged', () => {
+    const entries = [
+      mood('2026-09-06', 1),
+      mood('2026-09-07', 1),
+      mood('2026-09-08', 2),
+      mood('2026-09-09', 1),
+      mood('2026-09-10', 1),
+    ];
+    const result = computeBurnoutRisk([], entries, REFERENCE_DATE);
+    expect(result.hasEnoughMoodData).toBe(true);
+    const moodFactor = result.factors.find((f) => f.key === 'low-mood');
+    expect(moodFactor?.label).toBe('Average mood has been low this week (1.2/4)');
+    expect(moodFactor?.points).toBe(20);
+  });
+
+  it('flags a declining mood trend within the week separately from the average', () => {
+    const entries = [
+      mood('2026-09-06', 4),
+      mood('2026-09-07', 4),
+      mood('2026-09-08', 2),
+      mood('2026-09-09', 2),
+      mood('2026-09-10', 2),
+    ];
+    const result = computeBurnoutRisk([], entries, REFERENCE_DATE);
+    expect(result.factors.find((f) => f.key === 'declining-mood')?.points).toBe(10);
+  });
+
+  it('escalates to critical when multiple strong signals stack up', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'od-1', dueDate: '2026-09-07' }),
+      item({ id: 'od-2', dueDate: '2026-09-08' }),
+      item({ id: 'od-3', dueDate: '2026-09-09' }),
+      item({ id: 'od-4', dueDate: '2026-09-09' }),
+      item({ id: 'crit-1', dueDate: '2026-09-11', estimatedHours: 9 }),
+      item({ id: 'crit-2', dueDate: '2026-09-12', estimatedHours: 9 }),
+      item({ id: 'crit-3', dueDate: '2026-09-13', estimatedHours: 9 }),
+    ];
+    const entries = [
+      mood('2026-09-06', 1),
+      mood('2026-09-07', 1),
+      mood('2026-09-08', 1),
+      mood('2026-09-09', 1),
+    ];
+    const result = computeBurnoutRisk(items, entries, REFERENCE_DATE);
+    expect(result.level).toBe('critical');
+  });
+
+  it('sorts factors highest-points first', () => {
+    const items: ScheduleItem[] = [
+      item({ id: 'od-1', dueDate: '2026-09-07' }),
+      item({ id: 'crit-1', dueDate: '2026-09-11', estimatedHours: 9 }),
+      item({ id: 'crit-2', dueDate: '2026-09-12', estimatedHours: 9 }),
+      item({ id: 'crit-3', dueDate: '2026-09-13', estimatedHours: 9 }),
+      item({ id: 'crit-4', dueDate: '2026-09-14', estimatedHours: 9 }),
+    ];
+    const result = computeBurnoutRisk(items, [], REFERENCE_DATE);
+    const points = result.factors.map((f) => f.points);
+    expect(points).toEqual([...points].sort((a, b) => b - a));
+  });
+});

--- a/src/lib/burnout/burnoutRisk.ts
+++ b/src/lib/burnout/burnoutRisk.ts
@@ -1,0 +1,170 @@
+import { parseDayKey, toDayKey } from '@/lib/calendar/dates';
+import { computeAverageMood, sortMoodEntries } from '@/lib/mood/moodStats';
+import { computeDayHoursMap, getDayWorkloadLevel } from '@/lib/planner/semesterHeatmap';
+import type { MoodEntry } from '@/types/mood';
+import type { ScheduleItem, WorkloadLevel } from '@/types/schedule';
+
+/** How many days ahead count as "upcoming" when checking for a heavy stretch. */
+const LOOKAHEAD_DAYS = 7;
+/** How many days before today count as "recent", not counting today itself -
+ * today isn't finished yet, so its own load shouldn't count as something
+ * already endured. */
+const LOOKBACK_DAYS = 6;
+/** A mood average needs at least this many check-ins within the trailing
+ * week to say anything - one bad day logged in isolation isn't a trend,
+ * it's a data point, and treating it as a trend would falsely flag a
+ * student who just started checking in. */
+const MIN_MOOD_ENTRIES_FOR_SIGNAL = 3;
+
+function addDaysKey(dayKey: string, delta: number): string {
+  const d = parseDayKey(dayKey);
+  d.setDate(d.getDate() + delta);
+  return toDayKey(d);
+}
+
+export interface BurnoutFactor {
+  key: string;
+  label: string;
+  points: number;
+}
+
+export interface BurnoutRiskResult {
+  /** Reuses WorkloadLevel's 4-tier scale (and its shared color tokens) rather
+   * than inventing a parallel one - a burnout risk badge should read on the
+   * same visual language as every other load indicator in the app. */
+  level: WorkloadLevel;
+  score: number;
+  /** Only the factors that actually contributed points, highest first - an
+   * empty array means nothing measurable is currently elevated. */
+  factors: BurnoutFactor[];
+  /** False when there aren't enough recent mood check-ins to say anything
+   * about mood - callers should show this as "not enough data yet" rather
+   * than silently treating no data as "mood is fine". */
+  hasEnoughMoodData: boolean;
+}
+
+const LEVEL_THRESHOLDS: { level: WorkloadLevel; min: number }[] = [
+  { level: 'critical', min: 65 },
+  { level: 'high', min: 40 },
+  { level: 'medium', min: 20 },
+  { level: 'low', min: 0 },
+];
+
+function scoreToLevel(score: number): WorkloadLevel {
+  return LEVEL_THRESHOLDS.find((t) => score >= t.min)!.level;
+}
+
+/**
+ * Combines objective workload signals (upcoming and recent heavy days,
+ * overdue items) with self-reported mood into a single early-warning
+ * indicator. Deliberately transparent rather than a black box: every point
+ * on the score traces back to a `BurnoutFactor` a UI can list out, so a
+ * student sees *why* the indicator moved, not just that it did.
+ *
+ * `scheduleItems` and `moodEntries` are taken as-is from whatever scope the
+ * caller already has loaded (typically the whole account, unscoped by term -
+ * the same choice `computeSemesterHeatmap` makes, since burnout doesn't
+ * reset at a term boundary).
+ */
+export function computeBurnoutRisk(
+  scheduleItems: ScheduleItem[],
+  moodEntries: MoodEntry[],
+  referenceDate: Date = new Date(),
+): BurnoutRiskResult {
+  const dayHours = computeDayHoursMap(scheduleItems);
+  const todayKey = toDayKey(referenceDate);
+
+  let upcomingHigh = 0;
+  let upcomingCritical = 0;
+  for (let i = 0; i < LOOKAHEAD_DAYS; i++) {
+    const level = getDayWorkloadLevel(addDaysKey(todayKey, i), dayHours);
+    if (level === 'critical') upcomingCritical++;
+    else if (level === 'high') upcomingHigh++;
+  }
+
+  let recentHigh = 0;
+  let recentCritical = 0;
+  for (let i = 1; i <= LOOKBACK_DAYS; i++) {
+    const level = getDayWorkloadLevel(addDaysKey(todayKey, -i), dayHours);
+    if (level === 'critical') recentCritical++;
+    else if (level === 'high') recentHigh++;
+  }
+
+  const overdueCount = scheduleItems.filter(
+    (item) =>
+      !item.completed &&
+      parseDayKey(toDayKey(item.dueDate)).getTime() < parseDayKey(todayKey).getTime(),
+  ).length;
+
+  const factors: BurnoutFactor[] = [];
+  let score = 0;
+
+  const upcomingHeavyDays = upcomingHigh + upcomingCritical;
+  const upcomingPoints = Math.min(upcomingHigh * 4 + upcomingCritical * 7, 28);
+  if (upcomingPoints > 0) {
+    score += upcomingPoints;
+    factors.push({
+      key: 'upcoming-load',
+      label: `${upcomingHeavyDays} heavy day${upcomingHeavyDays === 1 ? '' : 's'} coming up in the next week`,
+      points: upcomingPoints,
+    });
+  }
+
+  const recentHeavyDays = recentHigh + recentCritical;
+  const recentPoints = Math.min(recentHigh * 3 + recentCritical * 6, 24);
+  if (recentPoints > 0) {
+    score += recentPoints;
+    factors.push({
+      key: 'recent-load',
+      label: `${recentHeavyDays} heavy day${recentHeavyDays === 1 ? '' : 's'} over the past week`,
+      points: recentPoints,
+    });
+  }
+
+  const overduePoints = Math.min(overdueCount, 4) * 8;
+  if (overduePoints > 0) {
+    score += overduePoints;
+    factors.push({
+      key: 'overdue',
+      label: `${overdueCount} overdue item${overdueCount === 1 ? '' : 's'}`,
+      points: overduePoints,
+    });
+  }
+
+  const windowStartKey = addDaysKey(todayKey, -(LOOKAHEAD_DAYS - 1));
+  const recentMoodEntries = sortMoodEntries(moodEntries).filter(
+    (e) => e.dateKey >= windowStartKey && e.dateKey <= todayKey,
+  );
+  const hasEnoughMoodData = recentMoodEntries.length >= MIN_MOOD_ENTRIES_FOR_SIGNAL;
+
+  if (hasEnoughMoodData) {
+    const avg = computeAverageMood(recentMoodEntries) as number;
+    const moodPoints = avg <= 1.5 ? 20 : avg <= 2.2 ? 12 : avg <= 2.8 ? 5 : 0;
+    if (moodPoints > 0) {
+      score += moodPoints;
+      factors.push({
+        key: 'low-mood',
+        label: `Average mood has been low this week (${avg.toFixed(1)}/4)`,
+        points: moodPoints,
+      });
+    }
+
+    const mid = Math.floor(recentMoodEntries.length / 2);
+    if (mid > 0) {
+      const firstAvg = computeAverageMood(recentMoodEntries.slice(0, mid)) as number;
+      const secondAvg = computeAverageMood(recentMoodEntries.slice(mid)) as number;
+      if (firstAvg - secondAvg >= 0.5) {
+        score += 10;
+        factors.push({
+          key: 'declining-mood',
+          label: 'Mood has been trending downward this week',
+          points: 10,
+        });
+      }
+    }
+  }
+
+  factors.sort((a, b) => b.points - a.points);
+
+  return { level: scoreToLevel(score), score, factors, hasEnoughMoodData };
+}


### PR DESCRIPTION
## Summary

- Adds a new `computeBurnoutRisk(scheduleItems, moodEntries, referenceDate)` in `src/lib/burnout/burnoutRisk.ts` that combines objective workload signals (heavy days coming up in the next week, heavy days over the past week, overdue items) with self-reported mood (weekly average, plus a within-week declining trend) into a single transparent score.
- Deliberately reuses `WorkloadLevel`'s existing 4-tier scale (`low`/`medium`/`high`/`critical`) and its shared color tokens (`getWorkloadBadgeTokens`) instead of inventing a parallel risk scale, so the indicator reads on the same visual language as every other load indicator already in the app (7-Day Load strip, semester heatmap, etc.).
- Every point on the score traces back to a named `BurnoutFactor` the UI lists out (e.g. "3 overdue items", "2 heavy days coming up in the next week", "Average mood has been low this week (1.2/4)") - it's not a black-box number.
- Surfaced as a new dismissible `BurnoutRiskCard` on the dashboard (between the 7-Day Load strip and the mood check-in card), following the same "no notification backend required, client-computed from data already loaded" approach as the existing `WeeklyBriefingCard`. Hidden entirely when risk is `low`.
- Dismissal is scoped per risk tier (not just per week like the weekly briefing) - dismissing a "worth keeping an eye on" warning doesn't suppress a later escalation to "high" or "critical" risk within the same week, since silently staying quiet through an escalation would defeat the point of an early-warning card.
- When there aren't at least 3 mood check-ins in the trailing week, mood is excluded from the score entirely and the card says so, rather than treating missing data as "mood is fine."

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx vitest run --exclude "**/rules.spec.ts"` — 673/673 passing (13 new: 10 for `computeBurnoutRisk`'s scoring/factor logic, 3 for the card's render/dismiss behavior)
- Clean production build (`rm -rf .next && npm run build`) — passing, full suite re-verified against it
- Live-verified against the real Firebase Local Emulator Suite + a real Playwright browser session with real logins: seeded an at-risk student (3 overdue items, 3 upcoming critical-load days, 5 days of mood=1) and confirmed the card renders "High burnout risk" with the correct factor list, dismisses correctly, and stays dismissed across a reload; seeded a doing-fine student (light load, mood=4) and confirmed no card appears at all.

## Scope not touched

- This is the last of the originally-queued Part B features - no further feature work is queued after this.
