### PR TITLE
feat: Degree Compass (Path + Ledger views)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,6 +43,14 @@ service cloud.firestore {
       match /moodEntries/{entryId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /degreeProfile/{profileId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      match /degreeCourses/{courseId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/src/app/(app)/degree-compass/page.tsx
+++ b/src/app/(app)/degree-compass/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { DegreeCompassView } from '@/components/degreeCompass/DegreeCompassView';
+
+export const metadata: Metadata = {
+  title: 'Degree Compass | Syllabus Sense',
+  description: 'Track your progress toward graduation across every term.',
+};
+
+export default function DegreeCompassPage() {
+  return (
+    <div className="max-w-6xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground tracking-tight">Degree Compass</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Your whole degree, one plan - past, current, and planned courses against what&rsquo;s
+          still required.
+        </p>
+      </div>
+      <DegreeCompassView />
+    </div>
+  );
+}

--- a/src/components/degreeCompass/CategoryProgressBar.tsx
+++ b/src/components/degreeCompass/CategoryProgressBar.tsx
@@ -1,0 +1,26 @@
+import type { CategoryProgress } from '@/lib/degreeCompass/progress';
+
+export function CategoryProgressBar({ progress }: { progress: CategoryProgress }) {
+  const { category, creditsCompleted, creditsInProgress } = progress;
+  const total = category.creditsRequired || 1;
+  const completedPct = Math.min(100, (creditsCompleted / total) * 100);
+  const inProgressPct = Math.min(100 - completedPct, (creditsInProgress / total) * 100);
+  const earned = creditsCompleted + creditsInProgress;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <span className="font-medium text-foreground">{category.name}</span>
+        <span className="text-muted-foreground shrink-0">
+          {earned} / {category.creditsRequired} cr
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-accent">
+        <div className="flex h-full">
+          <div className="h-full bg-primary" style={{ width: `${completedPct}%` }} />
+          <div className="h-full bg-primary/40" style={{ width: `${inProgressPct}%` }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/degreeCompass/DegreeCompassView.tsx
+++ b/src/components/degreeCompass/DegreeCompassView.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/components/ui/Toast';
+import { useDegreeProfile, useDegreeCourses } from '@/lib/firestore/useDegreeCompass';
+import {
+  saveDegreeProfile,
+  saveDegreeCourse,
+  deleteDegreeCourse,
+} from '@/lib/firestore/degreeCompass';
+import { computeOverallProgress } from '@/lib/degreeCompass/progress';
+import { DegreeSetupForm, type DegreeSetupValues } from './DegreeSetupForm';
+import { DegreeCourseFormModal, type DegreeCourseFormValues } from './DegreeCourseFormModal';
+import { CardActionButton } from '@/components/ui/CardAction';
+import { PathView } from './PathView';
+import { LedgerView } from './LedgerView';
+import type { DegreeCourse } from '@/types/degreeCompass';
+import { cn } from '@/lib/utils';
+
+type ViewMode = 'path' | 'ledger';
+
+export function DegreeCompassView() {
+  const { user } = useAuth();
+  const { showError, showSuccess } = useToast();
+  const { profile, loading } = useDegreeProfile(user?.uid);
+  const courses = useDegreeCourses(user?.uid);
+
+  const [viewMode, setViewMode] = useState<ViewMode>('path');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingCourse, setEditingCourse] = useState<DegreeCourse | undefined>(undefined);
+
+  const handleSetupSubmit = async (values: DegreeSetupValues) => {
+    if (!user) throw new Error('You must be signed in.');
+    try {
+      await saveDegreeProfile(user.uid, values);
+    } catch (err) {
+      showError("Couldn't set up Degree Compass", 'Please try again.');
+      throw err;
+    }
+  };
+
+  const openAddCourse = () => {
+    setEditingCourse(undefined);
+    setModalOpen(true);
+  };
+
+  const openEditCourse = (course: DegreeCourse) => {
+    setEditingCourse(course);
+    setModalOpen(true);
+  };
+
+  const handleCourseSubmit = async (values: DegreeCourseFormValues) => {
+    if (!user) throw new Error('You must be signed in.');
+    try {
+      await saveDegreeCourse(user.uid, { ...values, id: editingCourse?.id });
+      showSuccess(editingCourse ? 'Course updated' : 'Course added');
+    } catch (err) {
+      showError("Couldn't save that course", 'Please try again.');
+      throw err;
+    }
+  };
+
+  const handleDeleteCourse = async (course: DegreeCourse) => {
+    if (!user) return;
+    try {
+      await deleteDegreeCourse(user.uid, course.id);
+      showSuccess('Course removed');
+    } catch (err) {
+      showError("Couldn't remove that course", 'Please try again.');
+      throw err;
+    }
+  };
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">Loading Degree Compass…</div>;
+  }
+
+  if (!profile) {
+    return <DegreeSetupForm onSubmit={handleSetupSubmit} />;
+  }
+
+  const overall = computeOverallProgress(profile.categories, courses);
+  const earned = overall.creditsCompleted + overall.creditsInProgress;
+  const overallPct = overall.creditsRequired
+    ? Math.min(100, Math.round((earned / overall.creditsRequired) * 100))
+    : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-foreground">
+            <span className="font-semibold">{profile.majorName}</span>
+            {profile.minorName && (
+              <span className="text-muted-foreground"> · minor in {profile.minorName}</span>
+            )}
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {earned} / {overall.creditsRequired} credits ({overallPct}%)
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center rounded-full border border-border p-0.5">
+            <button
+              type="button"
+              onClick={() => setViewMode('path')}
+              className={cn(
+                'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+                viewMode === 'path'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              aria-pressed={viewMode === 'path'}
+            >
+              Path
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('ledger')}
+              className={cn(
+                'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+                viewMode === 'ledger'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              aria-pressed={viewMode === 'ledger'}
+            >
+              Ledger
+            </button>
+          </div>
+          <CardActionButton variant="solid" withPlus onClick={openAddCourse}>
+            Add course
+          </CardActionButton>
+        </div>
+      </div>
+
+      {viewMode === 'path' ? (
+        <PathView
+          categories={profile.categories}
+          courses={courses}
+          onEditCourse={openEditCourse}
+          onDeleteCourse={handleDeleteCourse}
+        />
+      ) : (
+        <LedgerView
+          categories={profile.categories}
+          courses={courses}
+          onEditCourse={openEditCourse}
+          onDeleteCourse={handleDeleteCourse}
+        />
+      )}
+
+      <DegreeCourseFormModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={handleCourseSubmit}
+        categories={profile.categories}
+        initialCourse={editingCourse}
+      />
+    </div>
+  );
+}

--- a/src/components/degreeCompass/DegreeCourseFormModal.tsx
+++ b/src/components/degreeCompass/DegreeCourseFormModal.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState, useEffect, type FormEvent } from 'react';
+import { useModalA11y } from '@/hooks/useModalA11y';
+import type {
+  DegreeCourse,
+  DegreeCourseStatus,
+  DegreeRequirementCategory,
+} from '@/types/degreeCompass';
+
+const inputClass =
+  'w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+const STATUS_OPTIONS: { value: DegreeCourseStatus; label: string }[] = [
+  { value: 'completed', label: 'Completed' },
+  { value: 'in-progress', label: 'In progress' },
+  { value: 'planned', label: 'Planned' },
+];
+
+export interface DegreeCourseFormValues {
+  term: string;
+  code: string;
+  title: string;
+  credits: number;
+  categoryId: string;
+  status: DegreeCourseStatus;
+}
+
+export interface DegreeCourseFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: DegreeCourseFormValues) => Promise<void>;
+  categories: DegreeRequirementCategory[];
+  initialCourse?: DegreeCourse;
+}
+
+function toFormValues(
+  course: DegreeCourse | undefined,
+  categories: DegreeRequirementCategory[],
+): DegreeCourseFormValues {
+  return {
+    term: course?.term ?? '',
+    code: course?.code ?? '',
+    title: course?.title ?? '',
+    credits: course?.credits ?? 3,
+    categoryId: course?.categoryId ?? categories[0]?.id ?? '',
+    status: course?.status ?? 'planned',
+  };
+}
+
+export function DegreeCourseFormModal({
+  open,
+  onClose,
+  onSubmit,
+  categories,
+  initialCourse,
+}: DegreeCourseFormModalProps) {
+  const containerRef = useModalA11y<HTMLDivElement>(open, onClose);
+  const [values, setValues] = useState<DegreeCourseFormValues>(() =>
+    toFormValues(initialCourse, categories),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setValues(toFormValues(initialCourse, categories));
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialCourse]);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!values.term.trim() || !values.code.trim() || !values.categoryId) {
+      setError('Term, course code, and category are required.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit(values);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save that course.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="degree-course-modal-title"
+    >
+      <div
+        ref={containerRef}
+        className="w-full max-w-md rounded-glass-lg border border-border bg-card p-5 shadow-card"
+      >
+        <h2 id="degree-course-modal-title" className="text-base font-bold text-foreground">
+          {initialCourse ? 'Edit course' : 'Add course'}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label htmlFor="degree-course-term" className="text-xs font-medium text-foreground">
+                Term
+              </label>
+              <input
+                id="degree-course-term"
+                value={values.term}
+                onChange={(e) => setValues({ ...values, term: e.target.value })}
+                className={inputClass}
+                placeholder="Fall 2026"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="degree-course-code" className="text-xs font-medium text-foreground">
+                Course code
+              </label>
+              <input
+                id="degree-course-code"
+                value={values.code}
+                onChange={(e) => setValues({ ...values, code: e.target.value })}
+                className={inputClass}
+                placeholder="CS 301"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="degree-course-title" className="text-xs font-medium text-foreground">
+              Title (optional)
+            </label>
+            <input
+              id="degree-course-title"
+              value={values.title}
+              onChange={(e) => setValues({ ...values, title: e.target.value })}
+              className={inputClass}
+              placeholder="Algorithms"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="degree-course-credits"
+                className="text-xs font-medium text-foreground"
+              >
+                Credits
+              </label>
+              <input
+                id="degree-course-credits"
+                type="number"
+                min={0}
+                step={0.5}
+                value={values.credits}
+                onChange={(e) => setValues({ ...values, credits: Number(e.target.value) })}
+                className={inputClass}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="degree-course-status" className="text-xs font-medium text-foreground">
+                Status
+              </label>
+              <select
+                id="degree-course-status"
+                value={values.status}
+                onChange={(e) =>
+                  setValues({ ...values, status: e.target.value as DegreeCourseStatus })
+                }
+                className={inputClass}
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="degree-course-category" className="text-xs font-medium text-foreground">
+              Counts toward
+            </label>
+            <select
+              id="degree-course-category"
+              value={values.categoryId}
+              onChange={(e) => setValues({ ...values, categoryId: e.target.value })}
+              className={inputClass}
+            >
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg px-3.5 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : initialCourse ? 'Save changes' : 'Add course'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/degreeCompass/DegreeCourseRow.tsx
+++ b/src/components/degreeCompass/DegreeCourseRow.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import type { DegreeCourse } from '@/types/degreeCompass';
+
+const STATUS_LABEL: Record<DegreeCourse['status'], string> = {
+  completed: 'Completed',
+  'in-progress': 'In progress',
+  planned: 'Planned',
+};
+
+const STATUS_CLASS: Record<DegreeCourse['status'], string> = {
+  completed: 'bg-primary/10 text-primary',
+  'in-progress': 'bg-load-medium/10 text-load-medium',
+  planned: 'bg-muted text-muted-foreground',
+};
+
+export interface DegreeCourseRowProps {
+  course: DegreeCourse;
+  categoryName?: string;
+  onEdit: (course: DegreeCourse) => void;
+  onDelete: (course: DegreeCourse) => Promise<void>;
+}
+
+export function DegreeCourseRow({ course, categoryName, onEdit, onDelete }: DegreeCourseRowProps) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleConfirmDelete = async () => {
+    setDeleting(true);
+    try {
+      await onDelete(course);
+    } finally {
+      setDeleting(false);
+      setConfirmingDelete(false);
+    }
+  };
+
+  return (
+    <li className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 text-sm text-foreground transition-colors hover:border-primary/30">
+      <div className="min-w-0 space-y-0.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{course.code}</span>
+          {course.title && (
+            <span className="text-muted-foreground break-words">{course.title}</span>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>{course.credits} cr</span>
+          <span aria-hidden="true">·</span>
+          <span>{course.term}</span>
+          {categoryName && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{categoryName}</span>
+            </>
+          )}
+          <span className={`rounded-full px-2 py-0.5 font-semibold ${STATUS_CLASS[course.status]}`}>
+            {STATUS_LABEL[course.status]}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
+        {confirmingDelete ? (
+          <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+            >
+              {deleting ? 'Deleting…' : 'Confirm'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(false)}
+              disabled={deleting}
+              className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => onEdit(course)}
+              className="rounded-full px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="rounded-full px-2.5 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+            >
+              Delete
+            </button>
+          </>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/components/degreeCompass/DegreeSetupForm.tsx
+++ b/src/components/degreeCompass/DegreeSetupForm.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { Card } from '@/components/ui/Card';
+import { buildDefaultCategories } from '@/types/degreeCompass';
+import type { DegreeRequirementCategory } from '@/types/degreeCompass';
+
+const inputClass =
+  'w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+export interface DegreeSetupValues {
+  majorName: string;
+  minorName?: string;
+  categories: DegreeRequirementCategory[];
+}
+
+export interface DegreeSetupFormProps {
+  onSubmit: (values: DegreeSetupValues) => Promise<void>;
+}
+
+export function DegreeSetupForm({ onSubmit }: DegreeSetupFormProps) {
+  const [majorName, setMajorName] = useState('');
+  const [hasMinor, setHasMinor] = useState(false);
+  const [minorName, setMinorName] = useState('');
+  const [categories, setCategories] = useState<DegreeRequirementCategory[]>(() =>
+    buildDefaultCategories(false),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleMinor = (checked: boolean) => {
+    setHasMinor(checked);
+    setCategories(buildDefaultCategories(checked));
+  };
+
+  const updateCategoryCredits = (id: string, creditsRequired: number) => {
+    setCategories((prev) => prev.map((cat) => (cat.id === id ? { ...cat, creditsRequired } : cat)));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!majorName.trim()) {
+      setError('Your major is required.');
+      return;
+    }
+    if (hasMinor && !minorName.trim()) {
+      setError('Enter your minor, or uncheck "I have a minor".');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        majorName: majorName.trim(),
+        minorName: hasMinor ? minorName.trim() : undefined,
+        categories,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not set up Degree Compass.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const totalCredits = categories.reduce((sum, c) => sum + c.creditsRequired, 0);
+
+  return (
+    <Card className="rounded-2xl p-6 space-y-5 max-w-xl">
+      <div>
+        <h2 className="text-base font-bold text-foreground">Set up Degree Compass</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Track your progress toward graduation across every term - past, current, and planned.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <label htmlFor="degree-setup-major" className="text-xs font-medium text-foreground">
+            Major
+          </label>
+          <input
+            id="degree-setup-major"
+            value={majorName}
+            onChange={(e) => setMajorName(e.target.value)}
+            className={inputClass}
+            placeholder="Computer Science"
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="flex items-center gap-2 text-xs font-medium text-foreground">
+            <input
+              type="checkbox"
+              checked={hasMinor}
+              onChange={(e) => toggleMinor(e.target.checked)}
+              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+            />
+            I have a minor
+          </label>
+          {hasMinor && (
+            <input
+              id="degree-setup-minor"
+              value={minorName}
+              onChange={(e) => setMinorName(e.target.value)}
+              className={inputClass}
+              placeholder="Mathematics"
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-foreground">
+            Requirement categories ({totalCredits} credits total)
+          </p>
+          <p className="text-xs text-muted-foreground">
+            These are a starting point - you can adjust the credit targets to match your
+            program&rsquo;s actual requirements.
+          </p>
+          <ul className="space-y-2">
+            {categories.map((cat) => (
+              <li
+                key={cat.id}
+                className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+              >
+                <span className="text-sm text-foreground">{cat.name}</span>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={cat.creditsRequired}
+                    onChange={(e) => updateCategoryCredits(cat.id, Number(e.target.value))}
+                    className="w-20 rounded-lg border border-border bg-input px-2 py-1.5 text-sm text-foreground text-right focus:outline-none focus:ring-2 focus:ring-primary"
+                    aria-label={`Credits required for ${cat.name}`}
+                  />
+                  <span className="text-xs text-muted-foreground">credits</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-load-critical/30 bg-load-critical/10 px-3 py-2 text-sm text-load-critical">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {saving ? 'Setting up…' : 'Start tracking my degree'}
+        </button>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/degreeCompass/LedgerView.tsx
+++ b/src/components/degreeCompass/LedgerView.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { DegreeCourseRow } from './DegreeCourseRow';
+import { CategoryProgressBar } from './CategoryProgressBar';
+import { computeCategoryProgress, sortCoursesByTerm } from '@/lib/degreeCompass/progress';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+export interface LedgerViewProps {
+  categories: DegreeRequirementCategory[];
+  courses: DegreeCourse[];
+  onEditCourse: (course: DegreeCourse) => void;
+  onDeleteCourse: (course: DegreeCourse) => Promise<void>;
+}
+
+export function LedgerView({ categories, courses, onEditCourse, onDeleteCourse }: LedgerViewProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(categories.map((c) => c.id)));
+  const categoryProgress = computeCategoryProgress(categories, courses);
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {categoryProgress.map((progress) => {
+        const { category } = progress;
+        const categoryCourses = sortCoursesByTerm(
+          courses.filter((c) => c.categoryId === category.id),
+        );
+        const isExpanded = expandedIds.has(category.id);
+
+        return (
+          <Card key={category.id} className="rounded-2xl p-6 space-y-3">
+            <button
+              type="button"
+              onClick={() => toggleExpanded(category.id)}
+              className="flex w-full items-center justify-between gap-4 text-left"
+              aria-expanded={isExpanded}
+            >
+              <div className="flex-1 min-w-0">
+                <CategoryProgressBar progress={progress} />
+              </div>
+              <svg
+                className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            {isExpanded &&
+              (categoryCourses.length > 0 ? (
+                <ul className="flex flex-col gap-2 pt-1">
+                  {categoryCourses.map((course) => (
+                    <DegreeCourseRow
+                      key={course.id}
+                      course={course}
+                      onEdit={onEditCourse}
+                      onDelete={onDeleteCourse}
+                    />
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState
+                  icon={
+                    <svg
+                      className="h-5 w-5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  }
+                  title="No courses in this category yet"
+                />
+              ))}
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/degreeCompass/PathView.tsx
+++ b/src/components/degreeCompass/PathView.tsx
@@ -1,0 +1,78 @@
+import { Card } from '@/components/ui/Card';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { DegreeCourseRow } from './DegreeCourseRow';
+import { CategoryProgressBar } from './CategoryProgressBar';
+import { computeCategoryProgress, groupCoursesByTerm } from '@/lib/degreeCompass/progress';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+export interface PathViewProps {
+  categories: DegreeRequirementCategory[];
+  courses: DegreeCourse[];
+  onEditCourse: (course: DegreeCourse) => void;
+  onDeleteCourse: (course: DegreeCourse) => Promise<void>;
+}
+
+export function PathView({ categories, courses, onEditCourse, onDeleteCourse }: PathViewProps) {
+  const terms = groupCoursesByTerm(courses);
+  const categoryProgress = computeCategoryProgress(categories, courses);
+  const categoryNameById = new Map(categories.map((c) => [c.id, c.name]));
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
+      <div className="space-y-4">
+        {terms.length === 0 ? (
+          <Card className="rounded-2xl p-6">
+            <EmptyState
+              icon={
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              }
+              title="No courses on your path yet"
+              description='Add your first course with "Add course" above.'
+            />
+          </Card>
+        ) : (
+          terms.map((group) => (
+            <Card key={group.term} className="rounded-2xl p-6 space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-base font-semibold text-foreground">{group.term}</h2>
+                <span className="text-xs text-muted-foreground">{group.totalCredits} credits</span>
+              </div>
+              <ul className="flex flex-col gap-2">
+                {group.courses.map((course) => (
+                  <DegreeCourseRow
+                    key={course.id}
+                    course={course}
+                    categoryName={categoryNameById.get(course.categoryId)}
+                    onEdit={onEditCourse}
+                    onDelete={onDeleteCourse}
+                  />
+                ))}
+              </ul>
+            </Card>
+          ))
+        )}
+      </div>
+
+      <Card className="rounded-2xl p-5 space-y-4 h-fit">
+        <h2 className="text-sm font-semibold text-foreground">Requirements</h2>
+        <div className="space-y-4">
+          {categoryProgress.map((progress) => (
+            <CategoryProgressBar key={progress.category.id} progress={progress} />
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/degreeCompass/__tests__/DegreeCompassView.test.tsx
+++ b/src/components/degreeCompass/__tests__/DegreeCompassView.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DegreeCompassView } from '../DegreeCompassView';
+import { ToastProvider } from '@/components/ui/Toast';
+import type { DegreeCourse, DegreeProfile } from '@/types/degreeCompass';
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'user-1', email: 'student@example.com' }, loading: false }),
+}));
+
+const { useDegreeProfileMock, useDegreeCoursesMock } = vi.hoisted(() => ({
+  useDegreeProfileMock: vi.fn(),
+  useDegreeCoursesMock: vi.fn(),
+}));
+
+vi.mock('@/lib/firestore/useDegreeCompass', () => ({
+  useDegreeProfile: useDegreeProfileMock,
+  useDegreeCourses: useDegreeCoursesMock,
+}));
+
+vi.mock('@/lib/firestore/degreeCompass', () => ({
+  saveDegreeProfile: vi.fn(),
+  saveDegreeCourse: vi.fn(),
+  deleteDegreeCourse: vi.fn(),
+}));
+
+const profile: DegreeProfile = {
+  majorName: 'Computer Science',
+  categories: [
+    { id: 'core', name: 'Major Core', creditsRequired: 30 },
+    { id: 'genEd', name: 'General Education', creditsRequired: 36 },
+  ],
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const courses: DegreeCourse[] = [
+  {
+    id: 'c1',
+    term: 'Fall 2025',
+    code: 'CS 101',
+    credits: 4,
+    categoryId: 'core',
+    status: 'completed',
+  },
+];
+
+function renderView() {
+  return render(
+    <ToastProvider>
+      <DegreeCompassView />
+    </ToastProvider>,
+  );
+}
+
+describe('DegreeCompassView', () => {
+  it('shows the setup form when the student has no degree profile yet', () => {
+    useDegreeProfileMock.mockReturnValue({ profile: null, loading: false });
+    useDegreeCoursesMock.mockReturnValue([]);
+
+    renderView();
+
+    expect(screen.getByText('Set up Degree Compass')).toBeDefined();
+  });
+
+  it('shows a loading state while the profile listener has not resolved yet', () => {
+    useDegreeProfileMock.mockReturnValue({ profile: null, loading: true });
+    useDegreeCoursesMock.mockReturnValue([]);
+
+    renderView();
+
+    expect(screen.getByText(/Loading Degree Compass/)).toBeDefined();
+    expect(screen.queryByText('Set up Degree Compass')).toBeNull();
+  });
+
+  it('renders the Path view with overall progress once a profile exists', () => {
+    useDegreeProfileMock.mockReturnValue({ profile, loading: false });
+    useDegreeCoursesMock.mockReturnValue(courses);
+
+    renderView();
+
+    expect(screen.getByText('Computer Science')).toBeDefined();
+    // 4 of 66 required credits completed
+    expect(screen.getByText('4 / 66 credits (6%)')).toBeDefined();
+    expect(screen.getAllByText('Fall 2025').length).toBeGreaterThan(0);
+    expect(screen.getByText('CS 101')).toBeDefined();
+  });
+
+  it('switches to the Ledger view when its toggle is clicked', () => {
+    useDegreeProfileMock.mockReturnValue({ profile, loading: false });
+    useDegreeCoursesMock.mockReturnValue(courses);
+
+    renderView();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ledger' }));
+
+    expect(screen.getByText('Major Core')).toBeDefined();
+    expect(screen.getByText('General Education')).toBeDefined();
+  });
+
+  it('opens the add-course modal from the header action', () => {
+    useDegreeProfileMock.mockReturnValue({ profile, loading: false });
+    useDegreeCoursesMock.mockReturnValue(courses);
+
+    renderView();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add course/ }));
+
+    expect(screen.getByRole('dialog', { name: 'Add course' })).toBeDefined();
+  });
+});

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -145,6 +145,22 @@ const moreItems: TabItem[] = [
     ),
   },
   {
+    name: 'Degree',
+    href: '/degree-compass',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <circle cx="12" cy="12" r="9" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l-2 5-5 2 2-5 5-2z" />
+      </svg>
+    ),
+  },
+  {
     name: 'Mood',
     href: '/mood',
     icon: (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -54,6 +54,22 @@ export default function Sidebar() {
       ),
     },
     {
+      name: 'Degree',
+      href: '/degree-compass',
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <circle cx="12" cy="12" r="9" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l-2 5-5 2 2-5 5-2z" />
+        </svg>
+      ),
+    },
+    {
       name: 'Contacts',
       href: '/contacts',
       icon: (

--- a/src/lib/degreeCompass/__tests__/progress.test.ts
+++ b/src/lib/degreeCompass/__tests__/progress.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeCategoryProgress,
+  computeOverallProgress,
+  groupCoursesByTerm,
+  sortCoursesByTerm,
+} from '../progress';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+const majorCore: DegreeRequirementCategory = {
+  id: 'core',
+  name: 'Major Core',
+  creditsRequired: 12,
+};
+const genEd: DegreeRequirementCategory = {
+  id: 'genEd',
+  name: 'General Education',
+  creditsRequired: 9,
+};
+const categories = [majorCore, genEd];
+
+function course(overrides: Partial<DegreeCourse>): DegreeCourse {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    term: 'Fall 2026',
+    code: 'CS 101',
+    credits: 4,
+    categoryId: majorCore.id,
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('computeCategoryProgress', () => {
+  it('sums completed and in-progress credits separately per category', () => {
+    const courses = [
+      course({ categoryId: majorCore.id, credits: 4, status: 'completed' }),
+      course({ categoryId: majorCore.id, credits: 4, status: 'in-progress' }),
+      course({ categoryId: genEd.id, credits: 3, status: 'completed' }),
+    ];
+
+    const result = computeCategoryProgress(categories, courses);
+
+    const core = result.find((r) => r.category.id === majorCore.id)!;
+    expect(core.creditsCompleted).toBe(4);
+    expect(core.creditsInProgress).toBe(4);
+    expect(core.creditsRemaining).toBe(4); // 12 - 4 - 4
+
+    const gened = result.find((r) => r.category.id === genEd.id)!;
+    expect(gened.creditsCompleted).toBe(3);
+    expect(gened.creditsRemaining).toBe(6);
+  });
+
+  it('excludes planned courses from completed/in-progress totals', () => {
+    const courses = [course({ categoryId: majorCore.id, credits: 4, status: 'planned' })];
+    const result = computeCategoryProgress(categories, courses);
+    const core = result.find((r) => r.category.id === majorCore.id)!;
+    expect(core.creditsCompleted).toBe(0);
+    expect(core.creditsInProgress).toBe(0);
+    expect(core.creditsRemaining).toBe(12);
+  });
+
+  it('never reports negative remaining credits when a category is over-fulfilled', () => {
+    const courses = [course({ categoryId: genEd.id, credits: 20, status: 'completed' })];
+    const result = computeCategoryProgress(categories, courses);
+    const gened = result.find((r) => r.category.id === genEd.id)!;
+    expect(gened.creditsRemaining).toBe(0);
+  });
+
+  it('returns zeroed progress for a category with no matching courses', () => {
+    const result = computeCategoryProgress(categories, []);
+    expect(result).toEqual([
+      { category: majorCore, creditsCompleted: 0, creditsInProgress: 0, creditsRemaining: 12 },
+      { category: genEd, creditsCompleted: 0, creditsInProgress: 0, creditsRemaining: 9 },
+    ]);
+  });
+});
+
+describe('computeOverallProgress', () => {
+  it('aggregates required, completed, and in-progress credits across all categories', () => {
+    const courses = [
+      course({ categoryId: majorCore.id, credits: 4, status: 'completed' }),
+      course({ categoryId: genEd.id, credits: 3, status: 'in-progress' }),
+    ];
+    const result = computeOverallProgress(categories, courses);
+    expect(result).toEqual({ creditsRequired: 21, creditsCompleted: 4, creditsInProgress: 3 });
+  });
+});
+
+describe('groupCoursesByTerm', () => {
+  it('groups courses by term and sums total credits per term', () => {
+    const courses = [
+      course({ term: 'Fall 2026', credits: 4 }),
+      course({ term: 'Fall 2026', credits: 3 }),
+      course({ term: 'Spring 2027', credits: 5 }),
+    ];
+    const groups = groupCoursesByTerm(courses);
+    expect(groups.map((g) => g.term)).toEqual(['Fall 2026', 'Spring 2027']);
+    expect(groups[0].totalCredits).toBe(7);
+    expect(groups[1].totalCredits).toBe(5);
+  });
+
+  it('sorts parseable terms chronologically regardless of input order', () => {
+    const courses = [
+      course({ term: 'Spring 2027', credits: 3 }),
+      course({ term: 'Fall 2025', credits: 3 }),
+      course({ term: 'Fall 2026', credits: 3 }),
+    ];
+    const groups = groupCoursesByTerm(courses);
+    expect(groups.map((g) => g.term)).toEqual(['Fall 2025', 'Fall 2026', 'Spring 2027']);
+  });
+
+  it('sorts an unparseable term label after every dateable term instead of crashing', () => {
+    const courses = [
+      course({ term: 'Someday', credits: 3 }),
+      course({ term: 'Fall 2025', credits: 3 }),
+    ];
+    const groups = groupCoursesByTerm(courses);
+    expect(groups.map((g) => g.term)).toEqual(['Fall 2025', 'Someday']);
+  });
+});
+
+describe('sortCoursesByTerm', () => {
+  it('orders courses chronologically by term regardless of Firestore snapshot order', () => {
+    const courses = [
+      course({ id: 'b', term: 'Spring 2026', code: 'CS 201' }),
+      course({ id: 'a', term: 'Fall 2025', code: 'CS 101' }),
+    ];
+    const sorted = sortCoursesByTerm(courses);
+    expect(sorted.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('breaks ties within the same term by course code', () => {
+    const courses = [
+      course({ id: 'b', term: 'Fall 2025', code: 'CS 201' }),
+      course({ id: 'a', term: 'Fall 2025', code: 'CS 101' }),
+    ];
+    const sorted = sortCoursesByTerm(courses);
+    expect(sorted.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/degreeCompass/progress.ts
+++ b/src/lib/degreeCompass/progress.ts
@@ -1,0 +1,95 @@
+import { estimateTermRange } from '@/lib/calendar/termDates';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+export interface CategoryProgress {
+  category: DegreeRequirementCategory;
+  creditsCompleted: number;
+  creditsInProgress: number;
+  creditsRemaining: number;
+}
+
+/** Only completed and in-progress courses count toward "earned" credits -
+ * a planned course hasn't happened yet, so it shouldn't read as progress
+ * made, only as part of the plan (surfaced separately by the caller). */
+export function computeCategoryProgress(
+  categories: DegreeRequirementCategory[],
+  courses: DegreeCourse[],
+): CategoryProgress[] {
+  return categories.map((category) => {
+    const inCategory = courses.filter((c) => c.categoryId === category.id);
+    const creditsCompleted = inCategory
+      .filter((c) => c.status === 'completed')
+      .reduce((sum, c) => sum + c.credits, 0);
+    const creditsInProgress = inCategory
+      .filter((c) => c.status === 'in-progress')
+      .reduce((sum, c) => sum + c.credits, 0);
+    const creditsRemaining = Math.max(
+      0,
+      category.creditsRequired - creditsCompleted - creditsInProgress,
+    );
+    return { category, creditsCompleted, creditsInProgress, creditsRemaining };
+  });
+}
+
+export interface OverallProgress {
+  creditsRequired: number;
+  creditsCompleted: number;
+  creditsInProgress: number;
+}
+
+export function computeOverallProgress(
+  categories: DegreeRequirementCategory[],
+  courses: DegreeCourse[],
+): OverallProgress {
+  const perCategory = computeCategoryProgress(categories, courses);
+  return {
+    creditsRequired: categories.reduce((sum, c) => sum + c.creditsRequired, 0),
+    creditsCompleted: perCategory.reduce((sum, c) => sum + c.creditsCompleted, 0),
+    creditsInProgress: perCategory.reduce((sum, c) => sum + c.creditsInProgress, 0),
+  };
+}
+
+export interface TermGroup {
+  term: string;
+  courses: DegreeCourse[];
+  totalCredits: number;
+}
+
+/** Orders two term labels chronologically where parseable (estimateTermRange)
+ * and alphabetically otherwise, so an unparseable label never crashes the
+ * sort - it just sorts after every term that could be dated. */
+export function compareTerms(a: string, b: string): number {
+  const aStart = estimateTermRange(a)?.start;
+  const bStart = estimateTermRange(b)?.start;
+  if (aStart && bStart) return aStart.getTime() - bStart.getTime();
+  if (aStart) return -1;
+  if (bStart) return 1;
+  return a.localeCompare(b);
+}
+
+/** Sorts courses chronologically by term (then by code within a term), so a
+ * student's course list reads in the order they'll actually take it rather
+ * than in arbitrary Firestore snapshot order. */
+export function sortCoursesByTerm(courses: DegreeCourse[]): DegreeCourse[] {
+  return [...courses].sort((a, b) => compareTerms(a.term, b.term) || a.code.localeCompare(b.code));
+}
+
+/** Groups courses by term, sorted chronologically. */
+export function groupCoursesByTerm(courses: DegreeCourse[]): TermGroup[] {
+  const byTerm = new Map<string, DegreeCourse[]>();
+  for (const course of sortCoursesByTerm(courses)) {
+    const list = byTerm.get(course.term) ?? [];
+    list.push(course);
+    byTerm.set(course.term, list);
+  }
+
+  const groups: TermGroup[] = Array.from(byTerm.entries()).map(([term, termCourses]) => ({
+    term,
+    courses: termCourses,
+    totalCredits: termCourses.reduce((sum, c) => sum + c.credits, 0),
+  }));
+
+  groups.sort((a, b) => compareTerms(a.term, b.term));
+
+  return groups;
+}

--- a/src/lib/firestore/__tests__/rules.spec.ts
+++ b/src/lib/firestore/__tests__/rules.spec.ts
@@ -84,6 +84,14 @@ const ownedDocPaths: Array<{ label: string; path: (uid: string) => string }> = [
     label: 'mood entry (users/{uid}/moodEntries/{id})',
     path: (uid) => `users/${uid}/moodEntries/2026-09-03`,
   },
+  {
+    label: 'degree profile (users/{uid}/degreeProfile/{id})',
+    path: (uid) => `users/${uid}/degreeProfile/profile`,
+  },
+  {
+    label: 'degree course (users/{uid}/degreeCourses/{id})',
+    path: (uid) => `users/${uid}/degreeCourses/course-1`,
+  },
 ];
 
 describe('firestore.rules: owner-only access', () => {
@@ -143,6 +151,8 @@ describe('firestore.rules: cross-user collection queries', () => {
     { label: 'quizzes', path: (uid) => `users/${uid}/quizzes` },
     { label: 'quizAttempts', path: (uid) => `users/${uid}/quizAttempts` },
     { label: 'moodEntries', path: (uid) => `users/${uid}/moodEntries` },
+    { label: 'degreeProfile', path: (uid) => `users/${uid}/degreeProfile` },
+    { label: 'degreeCourses', path: (uid) => `users/${uid}/degreeCourses` },
   ];
 
   describe.each(collectionPaths)("listing another user's $label", ({ path: collectionPath }) => {

--- a/src/lib/firestore/degreeCompass.ts
+++ b/src/lib/firestore/degreeCompass.ts
@@ -1,0 +1,39 @@
+import { doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import type { DegreeCourse, DegreeProfile } from '@/types/degreeCompass';
+
+/** Singleton doc id - one profile per user, same shape as any other
+ * account-level singleton in this codebase (e.g. preferences.ts). */
+const PROFILE_DOC_ID = 'profile';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+export async function saveDegreeProfile(
+  userId: string,
+  profile: Omit<DegreeProfile, 'updatedAt'>,
+): Promise<DegreeProfile> {
+  const record: DegreeProfile = { ...profile, updatedAt: new Date().toISOString() };
+  // Firestore's setDoc rejects `undefined` field values outright, so a
+  // student with no minor (minorName left unset) must omit the key
+  // entirely rather than write it as undefined.
+  if (!record.minorName) delete record.minorName;
+  await setDoc(doc(requireDb(), 'users', userId, 'degreeProfile', PROFILE_DOC_ID), record);
+  return record;
+}
+
+export async function saveDegreeCourse(
+  userId: string,
+  course: Omit<DegreeCourse, 'id'> & { id?: string },
+): Promise<DegreeCourse> {
+  const id = course.id ?? crypto.randomUUID();
+  const record: DegreeCourse = { ...course, id };
+  await setDoc(doc(requireDb(), 'users', userId, 'degreeCourses', id), record);
+  return record;
+}
+
+export async function deleteDegreeCourse(userId: string, courseId: string): Promise<void> {
+  await deleteDoc(doc(requireDb(), 'users', userId, 'degreeCourses', courseId));
+}

--- a/src/lib/firestore/useDegreeCompass.ts
+++ b/src/lib/firestore/useDegreeCompass.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { doc, collection, onSnapshot, type FirestoreError } from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import { useToast } from '@/components/ui/Toast';
+import type { DegreeCourse, DegreeProfile } from '@/types/degreeCompass';
+
+const PROFILE_DOC_ID = 'profile';
+
+export function useDegreeProfile(userId: string | undefined): {
+  profile: DegreeProfile | null;
+  loading: boolean;
+} {
+  const [profile, setProfile] = useState<DegreeProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { showError } = useToast();
+
+  useEffect(() => {
+    if (!userId || !db) {
+      setLoading(false);
+      return;
+    }
+    const unsubscribe = onSnapshot(
+      doc(db, 'users', userId, 'degreeProfile', PROFILE_DOC_ID),
+      (snapshot) => {
+        setProfile(snapshot.exists() ? (snapshot.data() as DegreeProfile) : null);
+        setLoading(false);
+      },
+      (error: FirestoreError) => {
+        console.error('[useDegreeProfile] listener failed:', error);
+        showError("Couldn't sync your degree profile", 'Try refreshing the page.');
+        setLoading(false);
+      },
+    );
+    return unsubscribe;
+  }, [userId, showError]);
+
+  return { profile, loading };
+}
+
+export function useDegreeCourses(userId: string | undefined): DegreeCourse[] {
+  const [courses, setCourses] = useState<DegreeCourse[]>([]);
+  const { showError } = useToast();
+
+  useEffect(() => {
+    if (!userId || !db) return;
+    const unsubscribe = onSnapshot(
+      collection(db, 'users', userId, 'degreeCourses'),
+      (snapshot) => setCourses(snapshot.docs.map((d) => d.data() as DegreeCourse)),
+      (error: FirestoreError) => {
+        console.error('[useDegreeCourses] listener failed:', error);
+        showError(
+          "Couldn't sync your degree courses",
+          'Your changes may not be saved. Try refreshing the page.',
+        );
+      },
+    );
+    return unsubscribe;
+  }, [userId, showError]);
+
+  return courses;
+}

--- a/src/types/degreeCompass.ts
+++ b/src/types/degreeCompass.ts
@@ -1,0 +1,54 @@
+/**
+ * Degree Compass tracks progress toward graduation across the whole
+ * program, not just the current term - deliberately its own small,
+ * independent record rather than reusing the live `Course` type (which
+ * models one term's syllabus/tasks/grades in detail). A degree course here
+ * is a lightweight ledger entry: a code, a term, a credit count, and which
+ * requirement category it counts toward.
+ */
+export type DegreeCourseStatus = 'completed' | 'in-progress' | 'planned';
+
+export interface DegreeRequirementCategory {
+  id: string;
+  name: string;
+  creditsRequired: number;
+}
+
+/** Singleton per user - the shape of the degree being tracked. */
+export interface DegreeProfile {
+  majorName: string;
+  minorName?: string;
+  categories: DegreeRequirementCategory[];
+  updatedAt: string;
+}
+
+export interface DegreeCourse {
+  id: string;
+  term: string;
+  code: string;
+  title?: string;
+  credits: number;
+  categoryId: string;
+  status: DegreeCourseStatus;
+}
+
+/** Seeded when a student sets up Degree Compass for the first time - the
+ * same five-category, 120-credit structure used throughout the design
+ * exploration (Major Core 30 / Electives 18 / Gen Ed 36 / Minor 18 / Free
+ * Electives 18), editable afterward since real programs vary. */
+export function buildDefaultCategories(includeMinor: boolean): DegreeRequirementCategory[] {
+  const categories: DegreeRequirementCategory[] = [
+    { id: crypto.randomUUID(), name: 'Major Core', creditsRequired: 30 },
+    { id: crypto.randomUUID(), name: 'Major Electives', creditsRequired: 18 },
+    { id: crypto.randomUUID(), name: 'General Education', creditsRequired: 36 },
+  ];
+  if (includeMinor) {
+    categories.push({ id: crypto.randomUUID(), name: 'Minor', creditsRequired: 18 });
+  }
+  categories.push({
+    id: crypto.randomUUID(),
+    name: 'Free Electives',
+    creditsRequired: includeMinor ? 18 : 36,
+  });
+  return categories;
+}


### PR DESCRIPTION
## Summary

Ships Degree Compass as a real, working feature: a multi-semester graduation planner that tracks degree requirement categories (Major Core, Major Electives, General Education, Minor, Free Electives) against courses across terms — independent of the app's per-term syllabus/task system. Both views selected during the earlier design exploration are shipped: **Path** (semester-by-semester timeline with a requirements side panel) and **Ledger** (per-category audit table with expandable course lists).

### What changed, by logical commit

**1. Data layer** (`934b8a6`)
- `src/types/degreeCompass.ts` — `DegreeProfile`, `DegreeRequirementCategory`, `DegreeCourse`, and `buildDefaultCategories()` seeding a 120-credit default structure.
- `src/lib/degreeCompass/progress.ts` — pure functions: `computeCategoryProgress`, `computeOverallProgress`, `groupCoursesByTerm`, `sortCoursesByTerm`/`compareTerms`. Fully unit-tested.
- `src/lib/firestore/degreeCompass.ts` + `useDegreeCompass.ts` — CRUD + live-sync hooks, with toast-on-listener-failure (same fix pattern as the recent audit).
- `firestore.rules` — owner-only rules for the new `degreeProfile`/`degreeCourses` subcollections, plus emulator-backed rules test coverage.

**2. UI layer** (`d9a81ae`)
- `DegreeSetupForm` — onboarding (major, optional minor, editable per-category credit targets).
- `PathView` — term-by-term timeline + requirements panel.
- `LedgerView` — expandable per-category audit table.
- `DegreeCourseFormModal` + `DegreeCourseRow` — shared add/edit modal and row actions, matching the existing pill-style edit/delete pattern used on the course detail page (per the UI-consistency rule — no one-off treatment).
- `DegreeCompassView` — orchestrator wiring hooks, view toggle, and modal together.
- Route at `/degree-compass`; "Degree" added to the sidebar (after Courses) and the mobile "More" menu (after Planner).

### Bug found and fixed during live verification

Setting up a profile with no minor crashed with `Function setDoc() called with invalid data: Unsupported field value: undefined` — Firestore's client SDK rejects `undefined` fields outright. Fixed by omitting the key entirely when no minor is set, and caught only because this was checked against the real emulator, not just unit tests.

Also fixed while there: course ordering within a Ledger category was arbitrary Firestore snapshot order; now sorted chronologically by term (then course code) via a shared `sortCoursesByTerm` helper, consistent with the Path view's ordering.

## Verification

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run test` (vitest) — 686/686 passing, including 15 new tests for progress calculations and the orchestrator's setup/loading/view-toggle/modal branching
- `npm run test:rules` (Firestore Local Emulator) — 118/118 passing, including the new `degreeProfile`/`degreeCourses` owner-only access paths
- `npm run build` — clean production build, `/degree-compass` generated as a static route
- Live verification: Firebase Local Emulator Suite + a real Playwright browser session — signed up a real test user, set up a degree profile, added/edited/deleted courses in both Path and Ledger views, confirmed toasts and progress bars update correctly against real Firestore data (this is what surfaced the `undefined`-field bug above)

## Test plan

- [x] `tsc`, `lint`, `vitest`, `test:rules`, `build` all green
- [x] Manually verified end-to-end against the emulator + a live browser session (setup → add course → edit → delete, both views)
- [ ] CI green on this PR