### PR TITLE
refactor: finish the component/utility consolidation queue (8 items)

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -39,6 +39,12 @@ import {
   WORKLOAD_TINT_CLASS,
 } from '@/lib/workload';
 import { buildICSFilename, createICSBlob, generateICS } from '@/lib/export/ics';
+import {
+  MONTH_YEAR_FORMATTER as monthLabelFormatter,
+  WEEKDAY_LONG_DATE_FORMATTER as dayLabelFormatter,
+  WEEKDAY_SHORT_DATE_FORMATTER as agendaDayLabelFormatter,
+  SHORT_DATE_FORMATTER as weekLabelFormatter,
+} from '@/lib/dateFormatters';
 import { generateGoogleCalendarUrl, generateOutlookCalendarUrl } from '@/lib/export/calendarLinks';
 import { courseChipTint, courseSwatch } from '@/lib/courseColors';
 import { useModalA11y } from '@/hooks/useModalA11y';
@@ -54,18 +60,6 @@ const FULL_WEEKDAY_NAMES = [
   'Friday',
   'Saturday',
 ];
-const monthLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
-const dayLabelFormatter = new Intl.DateTimeFormat('en-US', {
-  weekday: 'long',
-  month: 'long',
-  day: 'numeric',
-});
-const agendaDayLabelFormatter = new Intl.DateTimeFormat('en-US', {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-});
-const weekLabelFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 
 /** Semantic icons for the calendar key (course chips / workload / markers),
  * replacing plain dots and squares so each row communicates what it means

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { getWorkloadLevel } from '@/lib/workload';
 import { courseSwatch } from '@/lib/courseColors';
 import type { AssignmentType, Course, ScheduleItem, WorkloadLevel } from '@/types/schedule';
+import { WEEKDAY_SHORT_FORMATTER as dayHeaderFormatter } from '@/lib/dateFormatters';
 
 // #CA-3: same short, uppercase, mobile-lead labels MonthCalendar uses for
 // its day-cell chips - kept in sync so a truncated item reads the same way
@@ -36,8 +37,6 @@ const DEFAULT_SCROLL_HOUR = 7;
 const VISIBLE_HOURS = 13;
 
 const HOUR_LABELS = Array.from({ length: END_HOUR - START_HOUR }, (_, i) => START_HOUR + i);
-
-const dayHeaderFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
 
 const HEAT_TINT_CLASS: Record<WorkloadLevel, string> = {
   low: '',

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -41,8 +41,8 @@ import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { Course, ScheduleItem, Contact, ContactRole, AbsenceRecord } from '@/types/schedule';
+import { SHORT_DATE_FORMATTER as dueDateFormatter } from '@/lib/dateFormatters';
 
-const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
 const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 /** Below this many logged tasks, `progressPct` is too small a sample to read

--- a/src/components/courses/CourseDetailView.tsx
+++ b/src/components/courses/CourseDetailView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { BackLink } from '@/components/ui/BackLink';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
+import { ConfirmDeleteInline } from '@/components/ui/ConfirmDeleteInline';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { TaskRow } from '@/components/ui/TaskRow';
@@ -789,23 +790,13 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
               )}
               <div className="ml-auto">
                 {confirmingDeleteCourse ? (
-                  <div className="flex items-center gap-2 text-xs">
-                    <span className="text-muted-foreground">Delete course and its tasks?</span>
-                    <button
-                      onClick={handleDeleteCourse}
-                      disabled={isDeletingCourse}
-                      className="rounded-full bg-destructive/10 px-3 py-1.5 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                    >
-                      {isDeletingCourse ? 'Deleting…' : 'Confirm'}
-                    </button>
-                    <button
-                      onClick={() => setConfirmingDeleteCourse(false)}
-                      disabled={isDeletingCourse}
-                      className="rounded-full px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-                    >
-                      Cancel
-                    </button>
-                  </div>
+                  <ConfirmDeleteInline
+                    deleting={isDeletingCourse}
+                    onConfirm={handleDeleteCourse}
+                    onCancel={() => setConfirmingDeleteCourse(false)}
+                    size="lg"
+                    message="Delete course and its tasks?"
+                  />
                 ) : (
                   <button
                     onClick={() => setConfirmingDeleteCourse(true)}
@@ -965,22 +956,11 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                             Edit
                           </button>
                           {confirmingDeleteContactId === contact.id ? (
-                            <div className="flex items-center gap-1.5 text-xs">
-                              <button
-                                onClick={() => handleDeleteContact(contact)}
-                                disabled={deletingContactId === contact.id}
-                                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                              >
-                                {deletingContactId === contact.id ? 'Deleting…' : 'Confirm'}
-                              </button>
-                              <button
-                                onClick={() => setConfirmingDeleteContactId(null)}
-                                disabled={deletingContactId === contact.id}
-                                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-                              >
-                                Cancel
-                              </button>
-                            </div>
+                            <ConfirmDeleteInline
+                              deleting={deletingContactId === contact.id}
+                              onConfirm={() => handleDeleteContact(contact)}
+                              onCancel={() => setConfirmingDeleteContactId(null)}
+                            />
                           ) : (
                             <button
                               onClick={() => setConfirmingDeleteContactId(contact.id)}
@@ -1133,24 +1113,11 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     </div>
                     <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                       {confirmingDeleteObjectiveIndex === i ? (
-                        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteObjective(i)}
-                            disabled={deletingObjectiveIndex === i}
-                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                          >
-                            {deletingObjectiveIndex === i ? 'Deleting…' : 'Confirm'}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => setConfirmingDeleteObjectiveIndex(null)}
-                            disabled={deletingObjectiveIndex === i}
-                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-                          >
-                            Cancel
-                          </button>
-                        </div>
+                        <ConfirmDeleteInline
+                          deleting={deletingObjectiveIndex === i}
+                          onConfirm={() => handleDeleteObjective(i)}
+                          onCancel={() => setConfirmingDeleteObjectiveIndex(null)}
+                        />
                       ) : (
                         <>
                           <button
@@ -1336,24 +1303,11 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                     </div>
                     <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
                       {confirmingDeleteMaterialIndex === i ? (
-                        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteMaterial(i)}
-                            disabled={deletingMaterialIndex === i}
-                            className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                          >
-                            {deletingMaterialIndex === i ? 'Deleting…' : 'Confirm'}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => setConfirmingDeleteMaterialIndex(null)}
-                            disabled={deletingMaterialIndex === i}
-                            className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-                          >
-                            Cancel
-                          </button>
-                        </div>
+                        <ConfirmDeleteInline
+                          deleting={deletingMaterialIndex === i}
+                          onConfirm={() => handleDeleteMaterial(i)}
+                          onCancel={() => setConfirmingDeleteMaterialIndex(null)}
+                        />
                       ) : (
                         <>
                           <button
@@ -1543,22 +1497,11 @@ export function CourseDetailView({ courseId }: { courseId: string }) {
                           Edit
                         </button>
                         {confirmingDeleteItemId === item.id ? (
-                          <div className="flex items-center gap-1.5 text-xs">
-                            <button
-                              onClick={() => handleDeleteTask(item)}
-                              disabled={deletingItemId === item.id}
-                              className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                            >
-                              {deletingItemId === item.id ? 'Deleting…' : 'Confirm'}
-                            </button>
-                            <button
-                              onClick={() => setConfirmingDeleteItemId(null)}
-                              disabled={deletingItemId === item.id}
-                              className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-                            >
-                              Cancel
-                            </button>
-                          </div>
+                          <ConfirmDeleteInline
+                            deleting={deletingItemId === item.id}
+                            onConfirm={() => handleDeleteTask(item)}
+                            onCancel={() => setConfirmingDeleteItemId(null)}
+                          />
                         ) : (
                           <button
                             onClick={() => setConfirmingDeleteItemId(item.id)}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -7,6 +7,7 @@ import { CardActionButton } from '@/components/ui/CardAction';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ProgressRing } from '@/components/ui/ProgressRing';
 import { SectionIcon } from '@/components/ui/SectionIcon';
+import { NavIcon } from '@/components/layout/NavIcon';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import { TaskRow } from '@/components/ui/TaskRow';
 import { useToast } from '@/components/ui/Toast';
@@ -378,21 +379,7 @@ export function DashboardView() {
                 <SkeletonCard />
               ) : courseLoad.length === 0 ? (
                 <EmptyState
-                  icon={
-                    <svg
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                      />
-                    </svg>
-                  }
+                  icon={<NavIcon name="courses" className="h-5 w-5" />}
                   title="No courses yet"
                   description="Add one to start tracking your workload."
                   action={{ label: '+ Add Course', onClick: () => setAddCourseOpen(true) }}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -28,9 +28,10 @@ import { cn } from '@/lib/utils';
 import type { CourseFormValues } from '@/lib/validation/course';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { ScheduleItem } from '@/types/schedule';
-
-const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
-const forecastDayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+import {
+  SHORT_DATE_FORMATTER as dueDateFormatter,
+  WEEKDAY_SHORT_FORMATTER as forecastDayFormatter,
+} from '@/lib/dateFormatters';
 
 function getGreeting(hour: number): string {
   if (hour < 5) return 'Working late';

--- a/src/components/degreeCompass/DegreeCourseRow.tsx
+++ b/src/components/degreeCompass/DegreeCourseRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ConfirmDeleteInline } from '@/components/ui/ConfirmDeleteInline';
 import type { DegreeCourse } from '@/types/degreeCompass';
 
 const STATUS_LABEL: Record<DegreeCourse['status'], string> = {
@@ -62,24 +63,11 @@ export function DegreeCourseRow({ course, categoryName, onEdit, onDelete }: Degr
       </div>
       <div className="flex items-center gap-1 shrink-0 opacity-80 transition-opacity group-hover:opacity-100">
         {confirmingDelete ? (
-          <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
-            <button
-              type="button"
-              onClick={handleConfirmDelete}
-              disabled={deleting}
-              className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
-            >
-              {deleting ? 'Deleting…' : 'Confirm'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirmingDelete(false)}
-              disabled={deleting}
-              className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-50"
-            >
-              Cancel
-            </button>
-          </div>
+          <ConfirmDeleteInline
+            deleting={deleting}
+            onConfirm={handleConfirmDelete}
+            onCancel={() => setConfirmingDelete(false)}
+          />
         ) : (
           <>
             <button

--- a/src/components/flashcards/FlashcardDeckCard.tsx
+++ b/src/components/flashcards/FlashcardDeckCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Card } from '@/components/ui/Card';
+import { ConfirmDeleteInline } from '@/components/ui/ConfirmDeleteInline';
 import { CardActionButton } from '@/components/ui/CardAction';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
@@ -162,24 +163,12 @@ export function FlashcardDeckCard({
         )}
         {deckCards.length > 0 &&
           (confirmingDelete ? (
-            <>
-              <button
-                type="button"
-                onClick={handleDeleteDeck}
-                disabled={deleting}
-                className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-destructive/10 px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {deleting ? 'Deleting…' : 'Confirm'}
-              </button>
-              <button
-                type="button"
-                onClick={() => setConfirmingDelete(false)}
-                disabled={deleting}
-                className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs text-muted-foreground transition-colors hover:bg-accent"
-              >
-                Cancel
-              </button>
-            </>
+            <ConfirmDeleteInline
+              deleting={deleting}
+              onConfirm={handleDeleteDeck}
+              onCancel={() => setConfirmingDelete(false)}
+              size="md"
+            />
           ) : (
             <button
               type="button"

--- a/src/components/focus/PomodoroTimer.tsx
+++ b/src/components/focus/PomodoroTimer.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { cn } from '@/lib/utils';
+import { FloatingActionPill } from '@/components/ui/FloatingActionPill';
 import { saveSession } from '@/lib/focus/pomodoroSessions';
 
 const WORK_DURATION = 25 * 60; // 25 minutes
@@ -158,34 +159,32 @@ export function PomodoroTimer({ taskId, openSignal }: PomodoroTimerProps = {}) {
 
   if (!visible) {
     return (
-      <button
+      <FloatingActionPill
         onClick={() => setVisible(true)}
-        aria-label="Open Pomodoro focus timer (Alt+P)"
+        ariaLabel="Open Pomodoro focus timer (Alt+P)"
         title="Focus Timer (Alt+P)"
-        className="fixed bottom-20 left-4 z-50 flex items-center gap-2.5 rounded-full border border-amber-400/30 bg-gradient-to-r from-amber-500 via-amber-600 to-orange-600 px-4 py-2.5 text-xs font-semibold text-white shadow-[0_8px_25px_rgba(245,158,11,0.4)] backdrop-blur-md transition-all duration-300 hover:scale-105 hover:shadow-[0_12px_30px_rgba(245,158,11,0.6)] active:scale-95 focus:outline-none focus:ring-2 focus:ring-amber-400 md:bottom-6 md:left-6 dark:from-slate-900 dark:to-slate-800 dark:text-amber-400 dark:border-amber-500/40 dark:shadow-2xl"
-      >
-        <div className="relative flex h-2 w-2 items-center justify-center">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
-        </div>
-        <svg
-          className="h-4 w-4 text-amber-100 dark:text-amber-400 shrink-0"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-        <span className="font-bold tracking-wide text-white dark:text-amber-300">Focus Timer</span>
-        <span className="hidden rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-mono text-white/90 sm:inline-block dark:bg-amber-500/20 dark:text-amber-300">
-          Alt+P
-        </span>
-      </button>
+        positionClassName="bottom-20 left-4 z-50 md:bottom-6 md:left-6"
+        colorClassName="border-amber-400/30 bg-gradient-to-r from-amber-500 via-amber-600 to-orange-600 shadow-[0_8px_25px_rgba(245,158,11,0.4)] hover:shadow-[0_12px_30px_rgba(245,158,11,0.6)] focus:ring-amber-400 dark:from-slate-900 dark:to-slate-800 dark:text-amber-400 dark:border-amber-500/40 dark:shadow-2xl"
+        icon={
+          <svg
+            className="h-4 w-4 text-amber-100 dark:text-amber-400 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        }
+        label="Focus Timer"
+        labelClassName="text-white dark:text-amber-300"
+        shortcut="Alt+P"
+        shortcutClassName="dark:bg-amber-500/20 dark:text-amber-300"
+      />
     );
   }
 

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -11,6 +11,7 @@ import MobileTabBar from './MobileTabBar';
 import FirestoreSync from './FirestoreSync';
 import OfflineBanner from './OfflineBanner';
 import { SyllabusChatDrawer } from '@/components/syllabus/SyllabusChatDrawer';
+import { FloatingActionPill } from '@/components/ui/FloatingActionPill';
 import { PomodoroTimer } from '@/components/focus/PomodoroTimer';
 import { usePlatformKey } from '@/hooks/usePlatformKey';
 
@@ -83,33 +84,29 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
             {/* Global Floating AI Copilot Drawer Trigger - only on routes with
                 course context; see COPILOT_EXCLUDED_ROUTES above. */}
             {copilotAvailable && (
-              <button
+              <FloatingActionPill
                 onClick={() => setIsChatOpen(true)}
-                aria-label="Open AI Syllabus Copilot Chat"
-                className="fixed bottom-20 right-5 z-40 flex items-center gap-2.5 rounded-full border border-indigo-400/30 bg-gradient-to-r from-violet-600 via-indigo-600 to-purple-600 px-4 py-2.5 text-xs font-semibold text-white shadow-[0_8px_25px_rgba(99,102,241,0.4)] backdrop-blur-md transition-all duration-300 hover:scale-105 hover:shadow-[0_12px_30px_rgba(99,102,241,0.6)] active:scale-95 focus:outline-none focus:ring-2 focus:ring-indigo-400 md:bottom-6 md:right-6"
-              >
-                <div className="relative flex h-2 w-2 items-center justify-center">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-                  <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
-                </div>
-                <svg
-                  className="h-4 w-4 text-violet-200"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M13 10V3L4 14h7v7l9-11h-7z"
-                  />
-                </svg>
-                <span className="font-bold tracking-wide">AI Copilot</span>
-                <span className="hidden rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-mono text-white/90 sm:inline-block">
-                  {modKey}+K
-                </span>
-              </button>
+                ariaLabel="Open AI Syllabus Copilot Chat"
+                positionClassName="bottom-20 right-5 z-40 md:bottom-6 md:right-6"
+                colorClassName="border-indigo-400/30 bg-gradient-to-r from-violet-600 via-indigo-600 to-purple-600 shadow-[0_8px_25px_rgba(99,102,241,0.4)] hover:shadow-[0_12px_30px_rgba(99,102,241,0.6)] focus:ring-indigo-400"
+                icon={
+                  <svg
+                    className="h-4 w-4 text-violet-200"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M13 10V3L4 14h7v7l9-11h-7z"
+                    />
+                  </svg>
+                }
+                label="AI Copilot"
+                shortcut={`${modKey}+K`}
+              />
             )}
 
             <SyllabusChatDrawer isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { NavIcon, DegreeNavIcon } from './NavIcon';
 
 interface TabItem {
   name: string;
@@ -12,211 +13,20 @@ interface TabItem {
 }
 
 const tabItems: TabItem[] = [
-  {
-    name: 'Dashboard',
-    href: '/dashboard',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Courses',
-    href: '/courses',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Tasks',
-    href: '/tasks',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Calendar',
-    href: '/calendar',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-        />
-      </svg>
-    ),
-  },
+  { name: 'Dashboard', href: '/dashboard', icon: <NavIcon name="dashboard" /> },
+  { name: 'Courses', href: '/courses', icon: <NavIcon name="courses" /> },
+  { name: 'Tasks', href: '/tasks', icon: <NavIcon name="tasks" /> },
+  { name: 'Calendar', href: '/calendar', icon: <NavIcon name="calendar" /> },
 ];
 
 const moreItems: TabItem[] = [
-  {
-    name: 'Flashcards',
-    href: '/flashcards',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9 4.5v15m0-15a1.5 1.5 0 011.5-1.5h9A1.5 1.5 0 0121 4.5v10.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 019 15M3 6.75h6M3 12h6m-6 5.25h6"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Quizzes',
-    href: '/quizzes',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Planner',
-    href: '/planner',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10M4 18h7" />
-      </svg>
-    ),
-  },
-  {
-    name: 'Degree',
-    href: '/degree-compass',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <circle cx="12" cy="12" r="9" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l-2 5-5 2 2-5 5-2z" />
-      </svg>
-    ),
-  },
-  {
-    name: 'Mood',
-    href: '/mood',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Profile',
-    href: '/profile',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: 'Contacts',
-    href: '/contacts',
-    icon: (
-      <svg
-        className="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-        />
-      </svg>
-    ),
-  },
+  { name: 'Flashcards', href: '/flashcards', icon: <NavIcon name="flashcards" /> },
+  { name: 'Quizzes', href: '/quizzes', icon: <NavIcon name="quizzes" /> },
+  { name: 'Planner', href: '/planner', icon: <NavIcon name="plannerList" /> },
+  { name: 'Degree', href: '/degree-compass', icon: <DegreeNavIcon /> },
+  { name: 'Mood', href: '/mood', icon: <NavIcon name="mood" /> },
+  { name: 'Profile', href: '/profile', icon: <NavIcon name="profile" /> },
+  { name: 'Contacts', href: '/contacts', icon: <NavIcon name="contacts" /> },
 ];
 
 function TabLink({ item, isActive }: { item: TabItem; isActive: boolean }) {

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { NavIcon, DegreeNavIcon } from './NavIcon';
+import { usePopoverA11y } from '@/hooks/usePopoverA11y';
 
 interface TabItem {
   name: string;
@@ -57,6 +58,7 @@ export default function MobileTabBar() {
   const [isMoreOpen, setIsMoreOpen] = useState(false);
 
   const isMoreActive = moreItems.some((item) => pathname === item.href);
+  usePopoverA11y(isMoreOpen, () => setIsMoreOpen(false));
 
   return (
     <>

--- a/src/components/layout/NavIcon.tsx
+++ b/src/components/layout/NavIcon.tsx
@@ -1,0 +1,37 @@
+import { NAV_ICON_PATHS, type NavIconKey } from '@/lib/icons';
+
+export interface NavIconProps {
+  name: NavIconKey;
+  className?: string;
+}
+
+export function NavIcon({ name, className = 'h-5 w-5' }: NavIconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d={NAV_ICON_PATHS[name]} />
+    </svg>
+  );
+}
+
+/** Degree Compass's icon is a circle + a separate compass-needle path, so it
+ * can't be expressed as the single `d` string every other nav icon uses. */
+export function DegreeNavIcon({ className = 'h-5 w-5' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l-2 5-5 2 2-5 5-2z" />
+    </svg>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@/context/ThemeProvider';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useToast } from '@/components/ui/Toast';
+import { CountBadge } from '@/components/ui/CountBadge';
 import type { ScheduleItem } from '@/types/schedule';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
@@ -109,14 +110,7 @@ function NotificationBell({
         className="relative inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
       >
         <BellIcon />
-        {overdueCount > 0 && (
-          <span
-            className="absolute top-1 right-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground"
-            aria-hidden="true"
-          >
-            {overdueCount > 9 ? '9+' : overdueCount}
-          </span>
-        )}
+        {overdueCount > 0 && <CountBadge count={overdueCount} className="absolute top-1 right-1" />}
       </button>
       {open && (
         <>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useToast } from '@/components/ui/Toast';
 import { CountBadge } from '@/components/ui/CountBadge';
+import { usePopoverA11y } from '@/hooks/usePopoverA11y';
 import type { ScheduleItem } from '@/types/schedule';
 import Logo from './Logo';
 import { TermSwitcher } from './TermSwitcher';
@@ -99,6 +100,7 @@ function NotificationBell({
 }) {
   const { overdueCount, overdue, dueSoon } = useOverdueAndDueSoon();
   const hasAny = overdue.length > 0 || dueSoon.length > 0;
+  usePopoverA11y(open, onClose);
 
   return (
     <div className="relative">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { NavIcon, DegreeNavIcon } from './NavIcon';
 
 interface NavItem {
   name: string;
@@ -15,208 +16,17 @@ export default function Sidebar() {
   const pathname = usePathname();
 
   const navItems: NavItem[] = [
-    {
-      name: 'Dashboard',
-      href: '/dashboard',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Courses',
-      href: '/courses',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Degree',
-      href: '/degree-compass',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <circle cx="12" cy="12" r="9" />
-          <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l-2 5-5 2 2-5 5-2z" />
-        </svg>
-      ),
-    },
-    {
-      name: 'Contacts',
-      href: '/contacts',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Tasks',
-      href: '/tasks',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Flashcards',
-      href: '/flashcards',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 4.5v15m0-15a1.5 1.5 0 011.5-1.5h9A1.5 1.5 0 0121 4.5v10.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 019 15M3 6.75h6M3 12h6m-6 5.25h6"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Quizzes',
-      href: '/quizzes',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Planner',
-      href: '/planner',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10M4 18h7" />
-        </svg>
-      ),
-    },
-    {
-      name: 'Calendar',
-      href: '/calendar',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Mood',
-      href: '/mood',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-      ),
-    },
-    {
-      name: 'Profile',
-      href: '/profile',
-      icon: (
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-          />
-        </svg>
-      ),
-    },
+    { name: 'Dashboard', href: '/dashboard', icon: <NavIcon name="dashboard" /> },
+    { name: 'Courses', href: '/courses', icon: <NavIcon name="courses" /> },
+    { name: 'Degree', href: '/degree-compass', icon: <DegreeNavIcon /> },
+    { name: 'Contacts', href: '/contacts', icon: <NavIcon name="contacts" /> },
+    { name: 'Tasks', href: '/tasks', icon: <NavIcon name="tasks" /> },
+    { name: 'Flashcards', href: '/flashcards', icon: <NavIcon name="flashcards" /> },
+    { name: 'Quizzes', href: '/quizzes', icon: <NavIcon name="quizzes" /> },
+    { name: 'Planner', href: '/planner', icon: <NavIcon name="plannerList" /> },
+    { name: 'Calendar', href: '/calendar', icon: <NavIcon name="calendar" /> },
+    { name: 'Mood', href: '/mood', icon: <NavIcon name="mood" /> },
+    { name: 'Profile', href: '/profile', icon: <NavIcon name="profile" /> },
   ];
 
   return (

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -26,6 +26,7 @@ import {
   computeBestAndWorstDay,
 } from '@/lib/mood/moodStats';
 import { MOOD_OPTIONS, MOOD_SWATCH_CLASS, getMoodOption } from '@/lib/mood/moodScale';
+import { WORKLOAD_RAW_COLOR } from '@/lib/workload/uiClasses';
 import { computeSemesterHeatmap } from '@/lib/planner/semesterHeatmap';
 import { parseDayKey } from '@/lib/calendar/dates';
 import { cn } from '@/lib/utils';
@@ -49,17 +50,15 @@ const WORKLOAD_LEVEL_LABEL: Record<WorkloadLevel, string> = {
   critical: 'Extreme',
 };
 
-/** Same 4-step palette as MOOD_SWATCH_CLASS/WORKLOAD_SWATCH_CLASS, as raw
- * CSS color strings - recharts draws its own SVG and can't consume
- * Tailwind's utility classes, but reading the same `--load-*` custom
- * properties keeps every chart on this page and the workload heatmap
- * drawing from one shared palette. */
-const CHART_COLOR: Record<WorkloadLevel, string> = {
-  low: 'hsl(var(--load-low))',
-  medium: 'hsl(var(--load-medium))',
-  high: 'hsl(var(--load-high))',
-  critical: 'hsl(var(--load-critical))',
+/** Recharts' shared tooltip look, reused by both charts below instead of
+ * two copies of the same object literal. */
+const CHART_TOOLTIP_STYLE = {
+  background: 'hsl(var(--card))',
+  border: '1px solid hsl(var(--border))',
+  borderRadius: 8,
+  fontSize: 12,
 };
+
 export function MoodRecapView() {
   const { state } = useAppState();
   const entries = state.moodEntries;
@@ -188,8 +187,8 @@ export function MoodRecapView() {
             >
               <defs>
                 <linearGradient id="moodTrendFill" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="hsl(var(--load-low))" stopOpacity={0.35} />
-                  <stop offset="95%" stopColor="hsl(var(--load-low))" stopOpacity={0} />
+                  <stop offset="5%" stopColor={WORKLOAD_RAW_COLOR.low} stopOpacity={0.35} />
+                  <stop offset="95%" stopColor={WORKLOAD_RAW_COLOR.low} stopOpacity={0} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
@@ -214,20 +213,15 @@ export function MoodRecapView() {
                   const mood = getMoodOption(Number(value) as MoodValue);
                   return [`${mood.emoji} ${mood.label}`, 'Mood'];
                 }}
-                contentStyle={{
-                  background: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: 8,
-                  fontSize: 12,
-                }}
+                contentStyle={CHART_TOOLTIP_STYLE}
               />
               <Area
                 type="monotone"
                 dataKey="mood"
-                stroke="hsl(var(--load-low))"
+                stroke={WORKLOAD_RAW_COLOR.low}
                 strokeWidth={2}
                 fill="url(#moodTrendFill)"
-                dot={{ r: 3, fill: 'hsl(var(--load-low))', strokeWidth: 0 }}
+                dot={{ r: 3, fill: WORKLOAD_RAW_COLOR.low, strokeWidth: 0 }}
                 activeDot={{ r: 5 }}
               />
             </AreaChart>
@@ -285,12 +279,7 @@ export function MoodRecapView() {
                     'Mood',
                   ];
                 }}
-                contentStyle={{
-                  background: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: 8,
-                  fontSize: 12,
-                }}
+                contentStyle={CHART_TOOLTIP_STYLE}
                 cursor={{ fill: 'hsl(var(--accent))', opacity: 0.5 }}
               />
               <Bar
@@ -309,7 +298,7 @@ export function MoodRecapView() {
                 {byWorkload.map((b) => (
                   <Cell
                     key={b.level}
-                    fill={CHART_COLOR[b.level]}
+                    fill={WORKLOAD_RAW_COLOR[b.level]}
                     fillOpacity={b.count ? 1 : 0.15}
                   />
                 ))}

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -31,14 +31,11 @@ import { parseDayKey } from '@/lib/calendar/dates';
 import { cn } from '@/lib/utils';
 import type { WorkloadLevel } from '@/types/schedule';
 import type { MoodValue } from '@/types/mood';
-
-const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
-const FULL_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-});
-const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short' });
+import {
+  SHORT_DATE_FORMATTER,
+  WEEKDAY_SHORT_DATE_FORMATTER as FULL_DATE_FORMATTER,
+  MONTH_SHORT_FORMATTER as MONTH_FORMATTER,
+} from '@/lib/dateFormatters';
 
 // Same GitHub-contribution-graph convention as the semester heatmap: only
 // every other weekday row gets a label, so the gutter doesn't crowd the

--- a/src/components/mood/MoodRecapView.tsx
+++ b/src/components/mood/MoodRecapView.tsx
@@ -16,6 +16,7 @@ import {
 } from 'recharts';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { StatTile } from '@/components/ui/StatTile';
 import { useAppState } from '@/context/AppStateContext';
 import {
   computeMoodStreak,
@@ -62,18 +63,6 @@ const CHART_COLOR: Record<WorkloadLevel, string> = {
   high: 'hsl(var(--load-high))',
   critical: 'hsl(var(--load-critical))',
 };
-function StatTile({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <Card className="rounded-2xl p-4">
-      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-        {label}
-      </p>
-      <p className="mt-1 text-2xl font-bold text-foreground">{value}</p>
-      {sub && <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p>}
-    </Card>
-  );
-}
-
 export function MoodRecapView() {
   const { state } = useAppState();
   const entries = state.moodEntries;

--- a/src/components/planner/SemesterHeatmapCard.tsx
+++ b/src/components/planner/SemesterHeatmapCard.tsx
@@ -8,13 +8,10 @@ import { computeSemesterHeatmap, type SemesterHeatmapDay } from '@/lib/planner/s
 import { WORKLOAD_SWATCH_CLASS } from '@/lib/workload/uiClasses';
 import { parseDayKey } from '@/lib/calendar/dates';
 import { cn } from '@/lib/utils';
-
-const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short' });
-const DAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-});
+import {
+  MONTH_SHORT_FORMATTER as MONTH_FORMATTER,
+  WEEKDAY_SHORT_DATE_FORMATTER as DAY_FORMATTER,
+} from '@/lib/dateFormatters';
 
 // GitHub's own contribution graph only labels every other weekday row (Mon,
 // Wed, Fri) - a label on all 7 rows crowds the narrow gutter this grid has

--- a/src/components/planner/SmartPlanner.tsx
+++ b/src/components/planner/SmartPlanner.tsx
@@ -23,14 +23,11 @@ import {
 } from '@/lib/planner/computeSmartPlan';
 import { cn } from '@/lib/utils';
 import type { Course, ScheduleItem } from '@/types/schedule';
-
-const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
-const dayLabelFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
-const dayDetailFormatter = new Intl.DateTimeFormat('en-US', {
-  weekday: 'long',
-  month: 'long',
-  day: 'numeric',
-});
+import {
+  SHORT_DATE_FORMATTER as dueDateFormatter,
+  WEEKDAY_SHORT_FORMATTER as dayLabelFormatter,
+  WEEKDAY_LONG_DATE_FORMATTER as dayDetailFormatter,
+} from '@/lib/dateFormatters';
 
 /**
  * Formats a `YYYY-MM-DD` planning key (`PlannedItem.startDate`, always a

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -17,12 +17,7 @@ import { cn } from '@/lib/utils';
 import { GpaGoalRadial } from './GpaGoalRadial';
 import { StudyStreakCard } from './StudyStreakCard';
 import { type LetterGrade } from '@/lib/gpa/gpaMath';
-
-const dateFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'long',
-  day: 'numeric',
-  year: 'numeric',
-});
+import { LONG_DATE_YEAR_FORMATTER as dateFormatter } from '@/lib/dateFormatters';
 
 const DELETE_CONFIRM_PHRASE = 'DELETE';
 

--- a/src/components/quizzes/QuizCard.tsx
+++ b/src/components/quizzes/QuizCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Card } from '@/components/ui/Card';
 import { CardActionButton } from '@/components/ui/CardAction';
+import { ConfirmDeleteInline } from '@/components/ui/ConfirmDeleteInline';
 import { useAuth } from '@/context/AuthContext';
 import { useAppState } from '@/context/AppStateContext';
 import { useSyllabi } from '@/lib/firestore/useSyllabi';
@@ -141,24 +142,12 @@ export function QuizCard({ course, onTake }: { course: Course; onTake: (quiz: Qu
         )}
         {quiz &&
           (confirmingDelete ? (
-            <>
-              <button
-                type="button"
-                onClick={handleDeleteQuiz}
-                disabled={deleting}
-                className="inline-flex min-h-[36px] items-center justify-center rounded-full bg-destructive/10 px-3 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {deleting ? 'Deleting…' : 'Confirm'}
-              </button>
-              <button
-                type="button"
-                onClick={() => setConfirmingDelete(false)}
-                disabled={deleting}
-                className="inline-flex min-h-[36px] items-center justify-center rounded-full px-3 text-xs text-muted-foreground transition-colors hover:bg-accent"
-              >
-                Cancel
-              </button>
-            </>
+            <ConfirmDeleteInline
+              deleting={deleting}
+              onConfirm={handleDeleteQuiz}
+              onCancel={() => setConfirmingDelete(false)}
+              size="md"
+            />
           ) : (
             <button
               type="button"

--- a/src/components/schedule/PlannerView.tsx
+++ b/src/components/schedule/PlannerView.tsx
@@ -16,8 +16,7 @@ import { clampProgress } from '@/lib/taskStatus';
 import { cn } from '@/lib/utils';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { ScheduleItem, AssignmentType, Priority } from '@/types/schedule';
-
-const dueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+import { SHORT_DATE_FORMATTER as dueDateFormatter } from '@/lib/dateFormatters';
 
 type StatusFilter = 'all' | 'pending' | 'completed';
 /** What organizes the list into sections. 'date' buckets by due-date

--- a/src/components/syllabus/SyllabusChatDrawer.tsx
+++ b/src/components/syllabus/SyllabusChatDrawer.tsx
@@ -8,6 +8,11 @@ import { createScheduleItem } from '@/lib/firestore/scheduleItems';
 import { normalizeMaterials } from '@/lib/courses/materials';
 import { useModalA11y } from '@/hooks/useModalA11y';
 import { useToast } from '@/components/ui/Toast';
+import { TIME_FORMATTER } from '@/lib/dateFormatters';
+
+function formatTimestamp(): string {
+  return TIME_FORMATTER.format(new Date());
+}
 
 export interface SuggestedChunk {
   title: string;
@@ -56,7 +61,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
       id: 'welcome-msg',
       sender: 'assistant',
       text: "👋 Hi! I'm your **AI Syllabus & Study Copilot**. Ask me anything about your enrolled course syllabi — such as grading breakdowns, late penalties, exam schedules, or professor office hours!",
-      timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      timestamp: formatTimestamp(),
     },
   ]);
 
@@ -115,7 +120,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
         id: `user-${Date.now()}`,
         sender: 'user',
         text: trimmed,
-        timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        timestamp: formatTimestamp(),
       };
 
       setMessages((prev) => [...prev, userMessage]);
@@ -161,7 +166,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
           text: data.reply || 'Here is the relevant syllabus information.',
           citations: data.citations || [],
           suggestedChunks: data.suggestedChunks || undefined,
-          timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+          timestamp: formatTimestamp(),
         };
 
         setMessages((prev) => [...prev, assistantMessage]);
@@ -174,7 +179,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
             sender: 'assistant',
             text: `I had trouble connecting to the server, but according to **${selectedCourse?.code || 'your course'}** standards: deadlines are strict, office hours are weekly, and attendance is recommended. Please check the course page for full details.`,
             citations: [`[${selectedCourse?.code || 'Course'} Overview]`],
-            timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+            timestamp: formatTimestamp(),
           },
         ]);
       } finally {
@@ -196,7 +201,7 @@ export function SyllabusChatDrawer({ isOpen, onClose, initialCourseId }: Syllabu
         id: 'welcome-msg-reset',
         sender: 'assistant',
         text: `Conversation cleared. What else would you like to know about **${selectedCourse?.code || 'your courses'}**?`,
-        timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        timestamp: formatTimestamp(),
       },
     ]);
   };

--- a/src/components/syllabus/SyllabusList.tsx
+++ b/src/components/syllabus/SyllabusList.tsx
@@ -8,6 +8,7 @@ import {
   getPrimarySyllabus,
 } from '@/lib/firestore/syllabi';
 import { DocumentViewerModal } from '@/components/syllabus/DocumentViewerModal';
+import { ConfirmDeleteInline } from '@/components/ui/ConfirmDeleteInline';
 import { useToast } from '@/components/ui/Toast';
 import type { SyllabusUpload } from '@/types/syllabus';
 
@@ -102,22 +103,12 @@ export function SyllabusList({ userId, courseId }: SyllabusListProps) {
             <span className="text-xs text-muted-foreground">{formatSize(syllabus.sizeBytes)}</span>
           </div>
           {confirmingDeleteId === syllabus.id ? (
-            <div className="flex items-center gap-1.5 text-xs shrink-0">
-              <button
-                onClick={() => handleDelete(syllabus)}
-                disabled={deletingId === syllabus.id}
-                className="rounded-full bg-destructive/10 px-2.5 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {deletingId === syllabus.id ? 'Deleting…' : 'Confirm'}
-              </button>
-              <button
-                onClick={() => setConfirmingDeleteId(null)}
-                disabled={deletingId === syllabus.id}
-                className="rounded-full px-2.5 py-1 text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Cancel
-              </button>
-            </div>
+            <ConfirmDeleteInline
+              deleting={deletingId === syllabus.id}
+              onConfirm={() => handleDelete(syllabus)}
+              onCancel={() => setConfirmingDeleteId(null)}
+              className="shrink-0"
+            />
           ) : (
             <div className="flex items-center gap-1.5 shrink-0">
               {syllabus.id !== primaryId && (

--- a/src/components/tasks/TaskDetailView.tsx
+++ b/src/components/tasks/TaskDetailView.tsx
@@ -18,8 +18,10 @@ import { LatePenaltyAdvisor } from './LatePenaltyAdvisor';
 import type { ScheduleItemFormValues } from '@/lib/validation/scheduleItem';
 import type { AssignmentType, Course, ScheduleItem } from '@/types/schedule';
 import { cn } from '@/lib/utils';
-
-const shortDueDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+import {
+  SHORT_DATE_FORMATTER as shortDueDateFormatter,
+  WEEKDAY_LONG_DATE_YEAR_FORMATTER as dueDateFormatter,
+} from '@/lib/dateFormatters';
 
 /** Plain-English sentence comparing `item`'s grade weight to the rest of
  * its course, so "worth 25%" comes with a sense of scale instead of a bare
@@ -157,13 +159,6 @@ const PROGRESS_STEP = 5;
  * dragging the slider or typing an hour value fires one write instead of
  * one per tick/keystroke. */
 const COMMIT_DEBOUNCE_MS = 400;
-
-const dueDateFormatter = new Intl.DateTimeFormat('en-US', {
-  weekday: 'long',
-  month: 'long',
-  day: 'numeric',
-  year: 'numeric',
-});
 
 /** Which workload-ramp CSS var a given progress percentage should render
  * as, for the slider's fill/thumb color. Quartile-banded rather than a

--- a/src/components/ui/ConfirmDeleteInline.tsx
+++ b/src/components/ui/ConfirmDeleteInline.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+/**
+ * The inline "Confirm / Cancel" pair shown in place of a Delete button once
+ * it's tapped - previously hand-copied at every delete site (Materials,
+ * Learning Objectives, Degree Compass courses, syllabus uploads, flashcard
+ * decks, quizzes) with only the size varying between them.
+ */
+export interface ConfirmDeleteInlineProps {
+  deleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** `sm` (px-2.5 py-1) matches row-level list items; `md` (min-h-[36px]
+   * px-3) matches card-footer action rows; `lg` (px-3 py-1.5) matches
+   * header-level actions like a whole-course delete. */
+  size?: 'sm' | 'md' | 'lg';
+  confirmLabel?: string;
+  confirmingLabel?: string;
+  className?: string;
+  /** Optional confirmation copy shown before the buttons, e.g. "Delete
+   * course and its tasks?" - most call sites rely on the Confirm/Cancel
+   * wording alone and leave this unset. */
+  message?: string;
+}
+
+const SIZE_CLASS = {
+  sm: 'px-2.5 py-1',
+  md: 'min-h-[36px] px-3',
+  lg: 'px-3 py-1.5',
+} as const;
+
+export function ConfirmDeleteInline({
+  deleting,
+  onConfirm,
+  onCancel,
+  size = 'sm',
+  confirmLabel = 'Confirm',
+  confirmingLabel = 'Deleting…',
+  className = '',
+  message,
+}: ConfirmDeleteInlineProps) {
+  const sizeClass = SIZE_CLASS[size];
+  return (
+    <div className={`flex items-center gap-1.5 text-xs whitespace-nowrap ${className}`.trim()}>
+      {message && <span className="text-muted-foreground">{message}</span>}
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={deleting}
+        className={`inline-flex items-center justify-center rounded-full bg-destructive/10 font-semibold text-destructive transition-colors hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50 ${sizeClass}`}
+      >
+        {deleting ? confirmingLabel : confirmLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={deleting}
+        className={`inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 ${sizeClass}`}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/CountBadge.tsx
+++ b/src/components/ui/CountBadge.tsx
@@ -1,0 +1,18 @@
+export interface CountBadgeProps {
+  count: number;
+  /** Counts above this render as "`max`+" instead of the exact number. */
+  max?: number;
+  className?: string;
+}
+
+/** Small circular count indicator, e.g. the Navbar bell's overdue count. */
+export function CountBadge({ count, max = 9, className = '' }: CountBadgeProps) {
+  return (
+    <span
+      className={`flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground ${className}`.trim()}
+      aria-hidden="true"
+    >
+      {count > max ? `${max}+` : count}
+    </span>
+  );
+}

--- a/src/components/ui/FloatingActionPill.tsx
+++ b/src/components/ui/FloatingActionPill.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface FloatingActionPillProps {
+  onClick: () => void;
+  ariaLabel: string;
+  title?: string;
+  /** The button's own fixed position + stacking (e.g.
+   * "bottom-20 right-5 z-40 md:bottom-6 md:right-6") - each instance keeps
+   * its own exact placement rather than assuming a shared symmetric layout,
+   * since the app's existing pills don't actually mirror each other. */
+  positionClassName: string;
+  /** Border/gradient/shadow/focus-ring treatment, e.g.
+   * "border-amber-400/30 bg-gradient-to-r from-amber-500 via-amber-600
+   * to-orange-600 shadow-[...] hover:shadow-[...] focus:ring-amber-400". */
+  colorClassName: string;
+  icon: ReactNode;
+  label: string;
+  labelClassName?: string;
+  shortcut?: string;
+  shortcutClassName?: string;
+  /** The pulsing "live" dot every current instance shows. */
+  showActiveDot?: boolean;
+}
+
+/** The floating pill-shaped trigger pattern shared by the AI Copilot and
+ * Focus Timer buttons - previously two near-identical hand-copied buttons
+ * differing only in color, position, icon, and label. */
+export function FloatingActionPill({
+  onClick,
+  ariaLabel,
+  title,
+  positionClassName,
+  colorClassName,
+  icon,
+  label,
+  labelClassName,
+  shortcut,
+  shortcutClassName,
+  showActiveDot = true,
+}: FloatingActionPillProps) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      title={title}
+      className={cn(
+        'fixed flex items-center gap-2.5 rounded-full border px-4 py-2.5 text-xs font-semibold text-white backdrop-blur-md transition-all duration-300 hover:scale-105 active:scale-95 focus:outline-none focus:ring-2',
+        positionClassName,
+        colorClassName,
+      )}
+    >
+      {showActiveDot && (
+        <div className="relative flex h-2 w-2 items-center justify-center">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
+        </div>
+      )}
+      {icon}
+      <span className={cn('font-bold tracking-wide', labelClassName)}>{label}</span>
+      {shortcut && (
+        <span
+          className={cn(
+            'hidden rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-mono text-white/90 sm:inline-block',
+            shortcutClassName,
+          )}
+        >
+          {shortcut}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/ui/StatTile.tsx
+++ b/src/components/ui/StatTile.tsx
@@ -1,0 +1,21 @@
+import { Card } from '@/components/ui/Card';
+
+export interface StatTileProps {
+  label: string;
+  value: string;
+  sub?: string;
+}
+
+/** A small label/value/sub-line card for a stats row (e.g. the Mood Recap's
+ * Check-ins / Average mood / Streak / Best day grid). */
+export function StatTile({ label, value, sub }: StatTileProps) {
+  return (
+    <Card className="rounded-2xl p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold text-foreground">{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p>}
+    </Card>
+  );
+}

--- a/src/hooks/usePopoverA11y.ts
+++ b/src/hooks/usePopoverA11y.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Lightweight Escape-to-close for a dropdown/popover - deliberately not
+ * useModalA11y: a popover (the notification bell, the mobile "More" menu)
+ * doesn't lock body scroll or trap Tab focus inside itself the way a modal
+ * dialog does, it just needs to dismiss on Escape like every other
+ * transient overlay already does via its backdrop click.
+ */
+export function usePopoverA11y(open: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+}

--- a/src/lib/dateFormatters.ts
+++ b/src/lib/dateFormatters.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared Intl.DateTimeFormat instances. A formatter is stateless once
+ * constructed, so building each recipe once here and importing it wherever
+ * it's needed avoids every consuming file re-declaring its own - several
+ * already had, byte-for-byte, the same recipe under a different local name.
+ */
+
+/** "Sep 6" */
+export const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+/** "Sat" */
+export const WEEKDAY_SHORT_FORMATTER = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+
+/** "Sep" */
+export const MONTH_SHORT_FORMATTER = new Intl.DateTimeFormat('en-US', { month: 'short' });
+
+/** "September 2026" */
+export const MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  year: 'numeric',
+});
+
+/** "Sat, Sep 6" */
+export const WEEKDAY_SHORT_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+
+/** "Saturday, September 6" */
+export const WEEKDAY_LONG_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+});
+
+/** "Saturday, September 6, 2026" */
+export const WEEKDAY_LONG_DATE_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+/** "September 6, 2026" */
+export const LONG_DATE_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+/** "2:30 PM" */
+export const TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  hour: '2-digit',
+  minute: '2-digit',
+});

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -27,3 +27,31 @@ export const ICON_PATHS = {
 } as const;
 
 export type IconKey = keyof typeof ICON_PATHS;
+
+/**
+ * Primary navigation glyphs - shared between Sidebar and MobileTabBar, which
+ * render the same set of icons at different sizes/layouts and previously
+ * each hand-copied every path. Kept separate from ICON_PATHS above (a
+ * different, section-heading-badge icon set with its own `planner` key
+ * already meaning something else - the AI Copilot bolt, not this list icon).
+ */
+export const NAV_ICON_PATHS = {
+  dashboard:
+    'M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z',
+  courses:
+    'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
+  contacts:
+    'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
+  tasks:
+    'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+  flashcards:
+    'M9 4.5v15m0-15a1.5 1.5 0 011.5-1.5h9A1.5 1.5 0 0121 4.5v10.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 019 15M3 6.75h6M3 12h6m-6 5.25h6',
+  quizzes: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  plannerList: 'M4 6h16M4 12h10M4 18h7',
+  calendar:
+    'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+  mood: 'M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+  profile: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+} as const;
+
+export type NavIconKey = keyof typeof NAV_ICON_PATHS;

--- a/src/lib/planner/projectChunker.ts
+++ b/src/lib/planner/projectChunker.ts
@@ -1,4 +1,5 @@
 import type { ScheduleItem } from '@/types/schedule';
+import { WEEKDAY_SHORT_FORMATTER, SHORT_DATE_FORMATTER } from '@/lib/dateFormatters';
 
 export type ChunkableType =
   | 'project'
@@ -193,14 +194,24 @@ export function divideProjectIntoChunks(params: DivideProjectParams): ProjectChu
 
   const totalMinutes = Math.max(30, Math.round(hours * 60));
 
-  const startMs = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate()).getTime();
+  const startMs = new Date(
+    startDate.getFullYear(),
+    startDate.getMonth(),
+    startDate.getDate(),
+  ).getTime();
   const dueMs = new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()).getTime();
 
   const totalDays = Math.max(1, Math.ceil((dueMs - startMs) / (1000 * 60 * 60 * 24)));
 
   const chunkCount =
     pace === 'daily'
-      ? Math.min(totalDays, Math.max(chunkType === 'quiz' || chunkType === 'flashcards' ? 2 : 4, Math.ceil(totalMinutes / 45)))
+      ? Math.min(
+          totalDays,
+          Math.max(
+            chunkType === 'quiz' || chunkType === 'flashcards' ? 2 : 4,
+            Math.ceil(totalMinutes / 45),
+          ),
+        )
       : Math.min(Math.max(1, Math.ceil(totalDays / 7)), Math.max(2, Math.ceil(totalMinutes / 120)));
 
   const baseMinutes = Math.floor(totalMinutes / chunkCount);
@@ -242,10 +253,10 @@ export function divideProjectIntoChunks(params: DivideProjectParams): ProjectChu
 export function shiftTaskDate(
   itemId: string,
   newDateStr: string,
-  scheduleItems: ScheduleItem[]
+  scheduleItems: ScheduleItem[],
 ): ScheduleItem[] {
   return scheduleItems.map((item) =>
-    item.id === itemId ? { ...item, dueDate: newDateStr } : item
+    item.id === itemId ? { ...item, dueDate: newDateStr } : item,
   );
 }
 
@@ -255,7 +266,7 @@ export function shiftTaskDate(
 export function calculateWorkloadBreakdown(
   scheduleItems: ScheduleItem[],
   customChunks: ProjectChunk[] = [],
-  referenceDate: Date | string = new Date()
+  referenceDate: Date | string = new Date(),
 ): WorkloadBreakdown {
   const refDate = parseDateString(referenceDate);
   const refYear = refDate.getFullYear();
@@ -270,8 +281,8 @@ export function calculateWorkloadBreakdown(
   for (let i = -2; i < 7; i++) {
     const d = new Date(refYear, refMonth, refDay + i);
     const dateStr = toLocalDateStr(d);
-    const dayName = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(d);
-    const formattedDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(d);
+    const dayName = WEEKDAY_SHORT_FORMATTER.format(d);
+    const formattedDate = SHORT_DATE_FORMATTER.format(d);
 
     daysMap.set(dateStr, {
       dateStr,
@@ -291,7 +302,11 @@ export function calculateWorkloadBreakdown(
     if (!item.dueDate) continue;
     const itemDate = parseDateString(item.dueDate);
     const dateStr = toLocalDateStr(itemDate);
-    const duration = item.estimatedHours ? Math.round(item.estimatedHours * 60) : (item.type === 'exam' ? 120 : 60);
+    const duration = item.estimatedHours
+      ? Math.round(item.estimatedHours * 60)
+      : item.type === 'exam'
+        ? 120
+        : 60;
 
     // Retroactive completion: if completed, count on original due date regardless of age
     if (item.completed) {

--- a/src/lib/workload/uiClasses.ts
+++ b/src/lib/workload/uiClasses.ts
@@ -71,6 +71,18 @@ export const WORKLOAD_SOLID_BADGE_CLASS: Record<WorkloadLevel, string> = {
   critical: 'bg-load-critical text-white border-transparent',
 };
 
+/** Same 4-step palette as the classes above, as raw CSS color strings - a
+ * charting library (e.g. Recharts) draws its own SVG and can't consume
+ * Tailwind utility classes, so a `fill`/`stroke`/`stopColor` prop needs the
+ * literal value. Reads the same `--load-*` custom properties so a chart's
+ * colors and every Tailwind-class-based workload indicator stay in sync. */
+export const WORKLOAD_RAW_COLOR: Record<WorkloadLevel, string> = {
+  low: 'hsl(var(--load-low))',
+  medium: 'hsl(var(--load-medium))',
+  high: 'hsl(var(--load-high))',
+  critical: 'hsl(var(--load-critical))',
+};
+
 /**
  * Card border + ambient glow that escalates with real severity (globals.css
  * defines the actual .glow-edge* rules) - 'low' stays the calm, static


### PR DESCRIPTION
## Summary

Closes out the queued DRY/consolidation backlog from the earlier structural audit — eight small, mechanical extractions, each preserving existing behavior exactly (verified with `tsc`, `lint`, the full `vitest` suite, a production build, and a live emulator + browser pass after every batch).

### 1. Icon consolidation
Sidebar and MobileTabBar each hand-copied the same 10 SVG nav icons; DashboardView duplicated one more. Moved into `NAV_ICON_PATHS` in `lib/icons.ts` plus a new `NavIcon`/`DegreeNavIcon` component.

### 2. `ConfirmDeleteInline`
The inline Confirm/Cancel pair shown after tapping Delete was hand-copied at 8 call sites across 6 files (Degree Compass, syllabus uploads, flashcard decks, quizzes, and four spots in `CourseDetailView`). Extracted into one component with a `size` prop for the padding variants already in use.

### 3. `StatTile`
Was defined locally inside `MoodRecapView.tsx` despite being a generic label/value/sub card — moved to `components/ui` so it's actually shared, per its own name.

### 4. `FloatingActionPill`
The AI Copilot and Focus Timer floating buttons were two hand-copied ~30-line buttons differing only in color, position, icon, and label. Extracted into one component taking the position/color treatment as props.

### 5. `CountBadge`
The Navbar bell's overdue-count indicator is now a small reusable component instead of inline markup.

### 6. `lib/dateFormatters.ts`
Ten files each independently constructed one of a handful of `Intl.DateTimeFormat` recipes — several byte-for-byte identical under different local names (the "Sep 6" short format alone was redefined 8 times). Also fixes `SyllabusChatDrawer` building a brand-new formatter on every chat message, and `projectChunker` building two new ones on every loop iteration.

### 7. Raw-hsl chart color map
Mood Recap's charts read from a `WorkloadLevel`-keyed raw-color map (Recharts draws SVG and can't consume Tailwind classes) defined locally in that one file. Moved next to its Tailwind-class sibling maps as `WORKLOAD_RAW_COLOR` in `lib/workload/uiClasses.ts`.

### 8. Recharts tooltip + popover a11y
Hoisted a duplicated `contentStyle` object (same two charts) into one `CHART_TOOLTIP_STYLE` constant. Separately, added a lightweight `usePopoverA11y` hook (Escape-to-close only, deliberately without `useModalA11y`'s scroll-lock/focus-trap) and wired it into the notification bell and mobile "More" popovers, which previously only closed on backdrop click.

## Verification

- `tsc --noEmit` — clean, after every commit
- `npm run lint` — clean
- `npm run test` (vitest) — 686/686 passing throughout
- `npm run build` — clean production build
- Live-verified against the real Firebase Local Emulator Suite + a live browser session: nav icons on desktop and mobile, the notification bell and mobile "More" popovers (opened, confirmed real Escape-key close via `aria-expanded`), the floating pills, a full add/confirm-delete cycle on a Degree Compass course, and the Mood Recap charts with a real check-in (confirming `WORKLOAD_RAW_COLOR` and `CHART_TOOLTIP_STYLE` render correctly)

## Test plan

- [x] `tsc`, `lint`, `vitest`, `build` all green locally
- [x] Manually verified end-to-end against the emulator + a live browser session
- [ ] CI green on this PR