### PR TITLE
feat: AI Advisor Copilot (dedicated page + dashboard insight)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -51,6 +51,10 @@ service cloud.firestore {
       match /degreeCourses/{courseId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      match /advisorMessages/{messageId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /{document=**} {

--- a/src/app/(app)/advisor/page.tsx
+++ b/src/app/(app)/advisor/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { AdvisorView } from '@/components/advisor/AdvisorView';
+
+export const metadata: Metadata = {
+  title: 'Advisor | Syllabus Sense',
+  description: 'A standing conversation about your whole degree.',
+};
+
+export default function AdvisorPage() {
+  return (
+    <div className="max-w-6xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground tracking-tight">Advisor</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          A standing conversation about your whole degree - not a per-syllabus drawer.
+        </p>
+      </div>
+      <Suspense fallback={null}>
+        <AdvisorView />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/api/advisor/chat/route.ts
+++ b/src/app/api/advisor/chat/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type Anthropic from '@anthropic-ai/sdk';
+import { requireUser } from '@/lib/auth/requireUser';
+import { checkAndIncrementAiUsage } from '@/lib/ai/aiUsageLimit';
+import { getAnthropicClient, SYLLABUS_EXTRACTION_MODEL } from '@/lib/ai/anthropic';
+import { buildAdvisorSystemPrompt, buildAdvisorTool } from '@/lib/ai/advisorTool';
+import { buildAdvisorContextBlock, type AdvisorContextInput } from '@/lib/advisor/buildContext';
+import { generateOfflineAdvisorReply } from '@/lib/advisor/offlineAdvisor';
+import { advisorReplySchema } from '@/types/advisor';
+import type { DegreeCourse, DegreeProfile } from '@/types/degreeCompass';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const MAX_HISTORY_TURNS = 8;
+
+interface AdvisorChatRequestBody {
+  message?: string;
+  history?: { role: 'user' | 'assistant'; content: string }[];
+  degreeProfile?: DegreeProfile | null;
+  degreeCourses?: DegreeCourse[];
+  courses?: { code: string; title?: string; term?: string }[];
+  pendingTaskCount?: number;
+  overdueTaskCount?: number;
+}
+
+/**
+ * Reasons over the student's own already-loaded Degree Compass/course data
+ * (sent by the client, same trust model as /api/syllabus/chat's syllabus
+ * fields) rather than re-fetching from Firestore server-side - this route
+ * never writes anything, so a client sending its own stale or edited copy
+ * of its own data only affects the answer it gets back, not any other
+ * user's data or the account's actual stored state.
+ */
+export async function POST(req: NextRequest) {
+  const user = await requireUser(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let body: AdvisorChatRequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (!body.message || typeof body.message !== 'string') {
+    return NextResponse.json({ error: 'Missing message parameter.' }, { status: 400 });
+  }
+
+  const usage = await checkAndIncrementAiUsage(user);
+  if (!usage.allowed) {
+    return NextResponse.json(
+      { error: `Daily AI usage limit reached (${usage.limit} requests/day). Try again tomorrow.` },
+      { status: 429 },
+    );
+  }
+
+  const contextInput: AdvisorContextInput = {
+    degreeProfile: body.degreeProfile ?? null,
+    degreeCourses: body.degreeCourses ?? [],
+    courses: body.courses ?? [],
+    pendingTaskCount: body.pendingTaskCount ?? 0,
+    overdueTaskCount: body.overdueTaskCount ?? 0,
+  };
+
+  let anthropic;
+  try {
+    anthropic = getAnthropicClient();
+  } catch {
+    return NextResponse.json(generateOfflineAdvisorReply(body.message, contextInput));
+  }
+
+  const contextBlock = buildAdvisorContextBlock(contextInput);
+  const tool = buildAdvisorTool();
+  const history = (body.history ?? []).slice(-MAX_HISTORY_TURNS);
+  const messages: Anthropic.MessageParam[] = [
+    ...history.map(
+      (turn) => ({ role: turn.role, content: turn.content }) as Anthropic.MessageParam,
+    ),
+    { role: 'user' as const, content: body.message },
+  ];
+
+  try {
+    const response = await anthropic.messages.create({
+      model: SYLLABUS_EXTRACTION_MODEL,
+      max_tokens: 1024,
+      system: buildAdvisorSystemPrompt(contextBlock),
+      tools: [tool],
+      tool_choice: { type: 'tool', name: tool.name },
+      messages,
+    });
+
+    const toolUse = response.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+    );
+    if (!toolUse) {
+      return NextResponse.json(
+        { error: 'The Advisor did not return a structured reply. Try again.' },
+        { status: 502 },
+      );
+    }
+
+    const parsed = advisorReplySchema.safeParse(toolUse.input);
+    if (!parsed.success) {
+      console.error('Advisor reply validation failed:', parsed.error.issues);
+      return NextResponse.json(
+        { error: 'The Advisor returned a malformed reply. Try again.' },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(parsed.data);
+  } catch (err) {
+    console.warn('Anthropic call failed in advisor chat, falling back to offline engine:', err);
+    return NextResponse.json(generateOfflineAdvisorReply(body.message, contextInput));
+  }
+}

--- a/src/components/advisor/AdvisorView.tsx
+++ b/src/components/advisor/AdvisorView.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Card } from '@/components/ui/Card';
+import { useToast } from '@/components/ui/Toast';
+import { useAuth } from '@/context/AuthContext';
+import { useAppState } from '@/context/AppStateContext';
+import { useDegreeProfile, useDegreeCourses } from '@/lib/firestore/useDegreeCompass';
+import { appendAdvisorMessage, useAdvisorMessages } from '@/lib/firestore/advisor';
+import { summarizeAdvisorContext } from '@/lib/advisor/buildContext';
+import type { AdvisorMessage } from '@/types/advisor';
+import { AdvisorWarningCard } from './AdvisorWarningCard';
+import { cn } from '@/lib/utils';
+
+const WELCOME_MESSAGE =
+  "Hi — I'm your AI Advisor. I can reason over your Degree Compass plan, your courses, and your tasks - not just one syllabus. Ask me what to take next, whether you're on track, or what a change would mean for your plan.";
+
+const MAX_HISTORY_SENT = 8;
+const RECENT_QUESTIONS_SHOWN = 3;
+
+function ChatBubble({ message }: { message: AdvisorMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={cn(
+          'max-w-[85%] space-y-3 rounded-2xl px-4 py-3 text-body-sm',
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-accent/60 text-foreground',
+        )}
+      >
+        <p className="whitespace-pre-wrap">{message.content}</p>
+        {message.warning && <AdvisorWarningCard warning={message.warning} />}
+      </div>
+    </div>
+  );
+}
+
+export function AdvisorView() {
+  const { user } = useAuth();
+  const { state } = useAppState();
+  const { showError } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const { profile: degreeProfile, loading: degreeLoading } = useDegreeProfile(user?.uid);
+  const degreeCourses = useDegreeCourses(user?.uid);
+  const { messages, loading: messagesLoading } = useAdvisorMessages(user?.uid);
+
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const autoSentRef = useRef(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const summary = useMemo(
+    () =>
+      summarizeAdvisorContext({
+        degreeProfile,
+        degreeCourses,
+        courses: state.courses,
+        pendingTaskCount: 0,
+        overdueTaskCount: 0,
+      }),
+    [degreeProfile, degreeCourses, state.courses],
+  );
+
+  const recentQuestions = useMemo(() => {
+    const userQuestions = messages.filter((m) => m.role === 'user').map((m) => m.content);
+    const distinct = Array.from(new Set(userQuestions)).reverse();
+    // Skip the most recent question - it's already visible at the bottom of
+    // the transcript, so repeating it in "Recent Questions" would just be
+    // the same text twice on screen at once.
+    return distinct.slice(1, 1 + RECENT_QUESTIONS_SHOWN);
+  }, [messages]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = async (text: string) => {
+    if (!user || !text.trim() || sending) return;
+    setSending(true);
+
+    const userMessage: AdvisorMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: text.trim(),
+      createdAt: new Date().toISOString(),
+    };
+
+    const now = Date.now();
+    const pendingTaskCount = state.scheduleItems.filter((i) => !i.completed).length;
+    const overdueTaskCount = state.scheduleItems.filter(
+      (i) => !i.completed && new Date(i.dueDate).getTime() < now,
+    ).length;
+
+    try {
+      await appendAdvisorMessage(user.uid, userMessage);
+      setInput('');
+
+      const token = await user.getIdToken();
+      const history = [...messages, userMessage]
+        .slice(-MAX_HISTORY_SENT - 1, -1)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const response = await fetch('/api/advisor/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          message: userMessage.content,
+          history,
+          degreeProfile,
+          degreeCourses,
+          courses: state.courses.map((c) => ({ code: c.code, title: c.title, term: c.term })),
+          pendingTaskCount,
+          overdueTaskCount,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'The Advisor request failed.');
+
+      const assistantMessage: AdvisorMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: body.reply,
+        ...(body.highStakes ? { warning: body.highStakes } : {}),
+        createdAt: new Date().toISOString(),
+      };
+      await appendAdvisorMessage(user.uid, assistantMessage);
+    } catch (err) {
+      showError(
+        "Couldn't reach the Advisor",
+        err instanceof Error ? err.message : 'Try again in a moment.',
+      );
+    } finally {
+      setSending(false);
+    }
+  };
+
+  // Direction C's dashboard nudge deep-links here with ?prompt=... - opening
+  // it should ask that exact question immediately, not just pre-fill the
+  // input box and wait for another click. Waiting on `degreeLoading` matters
+  // here specifically: without it, this effect fires as soon as `user` is
+  // set, which is well before the Degree Compass onSnapshot listeners
+  // (subscribed in the same render) have delivered their first snapshot -
+  // the auto-sent question would reason over an empty plan every time,
+  // exactly the case a manually-typed question a few seconds later doesn't
+  // hit.
+  useEffect(() => {
+    const prompt = searchParams.get('prompt');
+    if (prompt && !autoSentRef.current && user && !degreeLoading) {
+      autoSentRef.current = true;
+      sendMessage(prompt);
+      router.replace('/advisor');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, user, degreeLoading]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    sendMessage(input);
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+      <Card className="flex h-[70vh] flex-col rounded-2xl p-4 sm:p-6">
+        <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto pr-1">
+          {!messagesLoading && messages.length === 0 && (
+            <div className="flex justify-start">
+              <div className="max-w-[85%] rounded-2xl bg-accent/60 px-4 py-3 text-body-sm text-foreground">
+                {WELCOME_MESSAGE}
+              </div>
+            </div>
+          )}
+          {messages.map((m) => (
+            <ChatBubble key={m.id} message={m} />
+          ))}
+          {sending && (
+            <div className="flex justify-start">
+              <div className="rounded-2xl bg-accent/60 px-4 py-3 text-body-sm text-muted-foreground">
+                Thinking…
+              </div>
+            </div>
+          )}
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="mt-4 flex items-center gap-2 border-t border-border pt-4"
+        >
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Ask about your degree, GPA, or what to take next…"
+            disabled={sending}
+            className="min-h-[44px] flex-1 rounded-full border border-border bg-background px-4 py-2 text-body-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            disabled={sending || !input.trim()}
+            aria-label="Send"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.5}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 12h15" />
+            </svg>
+          </button>
+        </form>
+      </Card>
+
+      <div className="space-y-4">
+        <Card className="rounded-2xl p-4">
+          <h2 className="mb-3 text-label font-semibold uppercase tracking-wide text-muted-foreground">
+            Reasoning over
+          </h2>
+          <dl className="space-y-2 text-body-sm">
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Degree Compass</dt>
+              <dd
+                className={cn(
+                  'font-semibold',
+                  summary.degreeConnected ? 'text-load-low' : 'text-muted-foreground',
+                )}
+              >
+                {degreeLoading ? '…' : summary.degreeConnected ? 'Connected' : 'Not set up'}
+              </dd>
+            </div>
+            {summary.degreeConnected && (
+              <>
+                <div className="flex items-center justify-between">
+                  <dt className="text-muted-foreground">Completed terms</dt>
+                  <dd className="font-semibold text-foreground">{summary.completedTerms}</dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-muted-foreground">Overall credits</dt>
+                  <dd className="font-semibold text-foreground">
+                    {summary.creditsCompleted + summary.creditsInProgress} /{' '}
+                    {summary.creditsRequired}
+                  </dd>
+                </div>
+              </>
+            )}
+          </dl>
+        </Card>
+
+        {recentQuestions.length > 0 && (
+          <Card className="rounded-2xl p-4">
+            <h2 className="mb-3 text-label font-semibold uppercase tracking-wide text-muted-foreground">
+              Recent questions
+            </h2>
+            <ul className="space-y-2">
+              {recentQuestions.map((q, i) => (
+                <li key={i}>
+                  <button
+                    type="button"
+                    onClick={() => sendMessage(q)}
+                    disabled={sending}
+                    className="w-full rounded-lg px-2 py-1.5 text-left text-caption text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground disabled:opacity-50"
+                  >
+                    &ldquo;{q}&rdquo;
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/advisor/AdvisorWarningCard.tsx
+++ b/src/components/advisor/AdvisorWarningCard.tsx
@@ -1,0 +1,41 @@
+import { CardActionLink } from '@/components/ui/CardAction';
+import type { AdvisorWarning } from '@/types/advisor';
+
+/**
+ * The one UI pattern that applies to every Advisor reply, not just the
+ * high-stakes ones: a visibly distinct callout (load-high, the same amber
+ * this app already uses for "important but not destructive" - see the
+ * Dashboard's "Tight · start today" badge) so a drop/withdraw/graduation
+ * question never reads as just another paragraph of chat text.
+ */
+export function AdvisorWarningCard({ warning }: { warning: AdvisorWarning }) {
+  return (
+    <div className="rounded-2xl border border-load-high/30 bg-load-high/10 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <svg
+          className="h-5 w-5 shrink-0 text-load-high"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <span className="text-label font-semibold text-load-high">{warning.reason}</span>
+      </div>
+      <p className="text-body-sm text-foreground">{warning.detail}</p>
+      <p className="text-caption italic text-muted-foreground">
+        This is a projection from your saved data, not your official transcript - I can be wrong
+        about prerequisite chains or enrollment rules. I&rsquo;m not a substitute for your academic
+        advisor on a decision like this.
+      </p>
+      <CardActionLink href="/contacts" variant="ghost">
+        Message your advisor
+      </CardActionLink>
+    </div>
+  );
+}

--- a/src/components/dashboard/AdvisorInsightCard.tsx
+++ b/src/components/dashboard/AdvisorInsightCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import Link from 'next/link';
+import { Card } from '@/components/ui/Card';
+import { CardActionLink } from '@/components/ui/CardAction';
+import { SectionIcon } from '@/components/ui/SectionIcon';
 import { useAuth } from '@/context/AuthContext';
 import { useDegreeProfile, useDegreeCourses } from '@/lib/firestore/useDegreeCompass';
 import { computeCategoryProgress, computeOverallProgress } from '@/lib/degreeCompass/progress';
@@ -55,33 +57,28 @@ export function AdvisorInsightCard() {
   const prompt = `Why is ${lagging.category.name} falling behind, and what should I do about it?`;
 
   return (
-    <div className="relative overflow-hidden rounded-2xl bg-gradient-brand p-5 text-white shadow-card">
-      <div className="relative z-10 space-y-3">
-        <span className="inline-flex items-center gap-1.5 text-caption font-semibold uppercase tracking-wide text-white/80">
-          <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M13 2L3 14h7v8l10-12h-7z" />
-          </svg>
-          Advisor insight
-        </span>
-        <p className="text-h3 font-bold leading-snug text-white">
-          {lagging.category.name} is falling behind your other requirement categories.
-        </p>
-        <Link
+    <Card accent="none" className="rounded-2xl border-primary/20 bg-primary/5 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <SectionIcon icon="planner" />
+          <div className="min-w-0">
+            <span className="text-caption font-semibold uppercase tracking-wide text-primary">
+              Advisor insight
+            </span>
+            <p className="text-body-sm font-semibold text-foreground">
+              {lagging.category.name} is falling behind your other requirement categories.
+            </p>
+          </div>
+        </div>
+        <CardActionLink
           href={`/advisor?prompt=${encodeURIComponent(prompt)}`}
-          className="inline-flex items-center gap-1.5 rounded-full bg-white px-4 py-2 text-label text-primary shadow-sm transition-transform hover:scale-[1.02]"
+          variant="solid"
+          withChevron
+          className="shrink-0"
         >
           Continue in Advisor
-          <svg
-            className="h-3.5 w-3.5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2.5}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </Link>
+        </CardActionLink>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/components/dashboard/AdvisorInsightCard.tsx
+++ b/src/components/dashboard/AdvisorInsightCard.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { useDegreeProfile, useDegreeCourses } from '@/lib/firestore/useDegreeCompass';
+import { computeCategoryProgress, computeOverallProgress } from '@/lib/degreeCompass/progress';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+/** A category counts as "falling behind" once it trails the overall
+ * completion percentage by more than this - small gaps are normal (not
+ * every category is worked on every term), so only a real gap surfaces a
+ * nudge rather than manufacturing one every time Degree Compass is set up. */
+const LAG_THRESHOLD = 0.15;
+
+interface LaggingCategory {
+  category: DegreeRequirementCategory;
+  categoryPct: number;
+}
+
+function findLaggingCategory(
+  categories: DegreeRequirementCategory[],
+  courses: DegreeCourse[],
+): LaggingCategory | null {
+  const overall = computeOverallProgress(categories, courses);
+  if (overall.creditsRequired === 0) return null;
+  const overallPct =
+    (overall.creditsCompleted + overall.creditsInProgress) / overall.creditsRequired;
+
+  let worst: LaggingCategory | null = null;
+  for (const c of computeCategoryProgress(categories, courses)) {
+    if (c.category.creditsRequired === 0 || c.creditsRemaining === 0) continue;
+    const pct = (c.creditsCompleted + c.creditsInProgress) / c.category.creditsRequired;
+    if (!worst || pct < worst.categoryPct) worst = { category: c.category, categoryPct: pct };
+  }
+
+  if (!worst || overallPct - worst.categoryPct < LAG_THRESHOLD) return null;
+  return worst;
+}
+
+/**
+ * Direction C from the AI Advisor design exploration: a proactive nudge on
+ * the Dashboard, not just a passive chat waiting to be opened. Only renders
+ * when there's a real, computed gap to report - no generic filler insight
+ * for an account with no Degree Compass data or nothing genuinely lagging.
+ */
+export function AdvisorInsightCard() {
+  const { user } = useAuth();
+  const { profile } = useDegreeProfile(user?.uid);
+  const degreeCourses = useDegreeCourses(user?.uid);
+
+  if (!profile) return null;
+  const lagging = findLaggingCategory(profile.categories, degreeCourses);
+  if (!lagging) return null;
+
+  const prompt = `Why is ${lagging.category.name} falling behind, and what should I do about it?`;
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-brand p-5 text-white shadow-card">
+      <div className="relative z-10 space-y-3">
+        <span className="inline-flex items-center gap-1.5 text-caption font-semibold uppercase tracking-wide text-white/80">
+          <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M13 2L3 14h7v8l10-12h-7z" />
+          </svg>
+          Advisor insight
+        </span>
+        <p className="text-h3 font-bold leading-snug text-white">
+          {lagging.category.name} is falling behind your other requirement categories.
+        </p>
+        <Link
+          href={`/advisor?prompt=${encodeURIComponent(prompt)}`}
+          className="inline-flex items-center gap-1.5 rounded-full bg-white px-4 py-2 text-label text-primary shadow-sm transition-transform hover:scale-[1.02]"
+        >
+          Continue in Advisor
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -19,6 +19,7 @@ import { CourseFormModal } from '@/components/courses/CourseFormModal';
 import { TaskFormModal } from '@/components/tasks/TaskFormModal';
 import { SyllabusAutofillModal } from '@/components/syllabus/SyllabusAutofillModal';
 import { WeeklyBriefingCard } from '@/components/dashboard/WeeklyBriefingCard';
+import { AdvisorInsightCard } from '@/components/dashboard/AdvisorInsightCard';
 import { MaterialsBudgetCard } from '@/components/dashboard/MaterialsBudgetCard';
 import { MoodCheckInCard } from '@/components/dashboard/MoodCheckInCard';
 import { computeSmartPlan, getLocalReferenceDate } from '@/lib/planner/computeSmartPlan';
@@ -251,6 +252,8 @@ export function DashboardView() {
             </button>
           </div>
         </div>
+
+        <AdvisorInsightCard />
 
         <WeeklyBriefingCard scheduleItems={state.scheduleItems} />
 

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -21,6 +21,7 @@ const tabItems: TabItem[] = [
 ];
 
 const moreItems: TabItem[] = [
+  { name: 'Advisor', href: '/advisor', icon: <NavIcon name="advisor" /> },
   { name: 'Flashcards', href: '/flashcards', icon: <NavIcon name="flashcards" /> },
   { name: 'Quizzes', href: '/quizzes', icon: <NavIcon name="quizzes" /> },
   { name: 'Planner', href: '/planner', icon: <NavIcon name="plannerList" /> },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ export default function Sidebar() {
   const navItems: NavItem[] = [
     { name: 'Dashboard', href: '/dashboard', icon: <NavIcon name="dashboard" /> },
     { name: 'Courses', href: '/courses', icon: <NavIcon name="courses" /> },
+    { name: 'Advisor', href: '/advisor', icon: <NavIcon name="advisor" /> },
     { name: 'Degree', href: '/degree-compass', icon: <DegreeNavIcon /> },
     { name: 'Contacts', href: '/contacts', icon: <NavIcon name="contacts" /> },
     { name: 'Tasks', href: '/tasks', icon: <NavIcon name="tasks" /> },

--- a/src/lib/advisor/__tests__/buildContext.test.ts
+++ b/src/lib/advisor/__tests__/buildContext.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeAdvisorContext, buildAdvisorContextBlock } from '../buildContext';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+const majorCore: DegreeRequirementCategory = {
+  id: 'core',
+  name: 'Major Core',
+  creditsRequired: 30,
+};
+
+function degreeCourse(overrides: Partial<DegreeCourse>): DegreeCourse {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    term: 'Fall 2026',
+    code: 'CS 101',
+    credits: 4,
+    categoryId: majorCore.id,
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('summarizeAdvisorContext', () => {
+  it('reports not-connected when there is no degree profile', () => {
+    const summary = summarizeAdvisorContext({
+      degreeProfile: null,
+      degreeCourses: [],
+      courses: [],
+      pendingTaskCount: 0,
+      overdueTaskCount: 0,
+    });
+    expect(summary).toEqual({
+      degreeConnected: false,
+      completedTerms: 0,
+      creditsCompleted: 0,
+      creditsInProgress: 0,
+      creditsRequired: 0,
+    });
+  });
+
+  it('sums real credits and distinct completed terms when a profile exists', () => {
+    const summary = summarizeAdvisorContext({
+      degreeProfile: { majorName: 'CS', categories: [majorCore], updatedAt: '2026-01-01' },
+      degreeCourses: [
+        degreeCourse({ term: 'Fall 2025', credits: 15, status: 'completed' }),
+        degreeCourse({ term: 'Fall 2025', credits: 3, status: 'completed' }),
+        degreeCourse({ term: 'Spring 2026', credits: 15, status: 'in-progress' }),
+      ],
+      courses: [],
+      pendingTaskCount: 0,
+      overdueTaskCount: 0,
+    });
+    expect(summary.degreeConnected).toBe(true);
+    expect(summary.completedTerms).toBe(1);
+    expect(summary.creditsCompleted).toBe(18);
+    expect(summary.creditsInProgress).toBe(15);
+    expect(summary.creditsRequired).toBe(30);
+  });
+});
+
+describe('buildAdvisorContextBlock', () => {
+  it('tells the model not to invent a degree plan when none is set up', () => {
+    const block = buildAdvisorContextBlock({
+      degreeProfile: null,
+      degreeCourses: [],
+      courses: [{ code: 'CS 101', title: 'Intro to CS', term: 'Fall 2026' }],
+      pendingTaskCount: 2,
+      overdueTaskCount: 1,
+    });
+    expect(block).toMatch(/not set up yet/i);
+    expect(block).toContain('CS 101');
+    expect(block).toContain('2 pending, 1 overdue');
+  });
+
+  it('includes real category and term data when a profile exists', () => {
+    const block = buildAdvisorContextBlock({
+      degreeProfile: {
+        majorName: 'Computer Science',
+        categories: [majorCore],
+        updatedAt: '2026-01-01',
+      },
+      degreeCourses: [degreeCourse({ credits: 12, status: 'completed' })],
+      courses: [],
+      pendingTaskCount: 0,
+      overdueTaskCount: 0,
+    });
+    expect(block).toContain('Computer Science');
+    expect(block).toContain('Major Core: 12/30 credits (18 remaining)');
+    expect(block).toMatch(/not their official transcript/i);
+  });
+});

--- a/src/lib/advisor/__tests__/offlineAdvisor.test.ts
+++ b/src/lib/advisor/__tests__/offlineAdvisor.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { generateOfflineAdvisorReply } from '../offlineAdvisor';
+import type { AdvisorContextInput } from '../buildContext';
+import type { DegreeCourse, DegreeRequirementCategory } from '@/types/degreeCompass';
+
+const majorCore: DegreeRequirementCategory = {
+  id: 'core',
+  name: 'Major Core',
+  creditsRequired: 30,
+};
+const genEd: DegreeRequirementCategory = {
+  id: 'genEd',
+  name: 'General Education',
+  creditsRequired: 36,
+};
+
+function baseInput(overrides: Partial<AdvisorContextInput> = {}): AdvisorContextInput {
+  return {
+    degreeProfile: null,
+    degreeCourses: [],
+    courses: [],
+    pendingTaskCount: 0,
+    overdueTaskCount: 0,
+    ...overrides,
+  };
+}
+
+function degreeCourse(overrides: Partial<DegreeCourse>): DegreeCourse {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    term: 'Fall 2026',
+    code: 'CS 101',
+    credits: 4,
+    categoryId: majorCore.id,
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('generateOfflineAdvisorReply', () => {
+  it('flags a drop/withdraw question as high-stakes unconditionally', () => {
+    const result = generateOfflineAdvisorReply('Should I drop CHEM 201?', baseInput());
+    expect(result.highStakes).toBeDefined();
+    expect(result.highStakes?.reason).toMatch(/high-stakes/i);
+  });
+
+  it('flags a withdraw question the same way as a drop question', () => {
+    const result = generateOfflineAdvisorReply(
+      'What happens if I withdraw from this class?',
+      baseInput(),
+    );
+    expect(result.highStakes).toBeDefined();
+  });
+
+  it('tells the student to set up Degree Compass when no profile exists', () => {
+    const result = generateOfflineAdvisorReply('Am I on track to graduate?', baseInput());
+    expect(result.reply).toMatch(/haven't set up Degree Compass/i);
+    expect(result.highStakes).toBeUndefined();
+  });
+
+  it('reports real completed-term pace for an on-track question', () => {
+    const input = baseInput({
+      degreeProfile: {
+        majorName: 'Computer Science',
+        categories: [majorCore, genEd],
+        updatedAt: '2026-01-01',
+      },
+      degreeCourses: [
+        degreeCourse({ term: 'Fall 2025', credits: 15, status: 'completed' }),
+        degreeCourse({ term: 'Spring 2026', credits: 15, status: 'completed' }),
+      ],
+    });
+    const result = generateOfflineAdvisorReply(
+      'Am I still on track to graduate in four years?',
+      input,
+    );
+    expect(result.reply).toContain('30 of 66 credits');
+    expect(result.reply).toContain('2 completed terms');
+    expect(result.highStakes).toBeUndefined();
+  });
+
+  it('recommends the category with the most remaining credits for a "what should I take" question', () => {
+    const input = baseInput({
+      degreeProfile: {
+        majorName: 'Computer Science',
+        categories: [majorCore, genEd],
+        updatedAt: '2026-01-01',
+      },
+      degreeCourses: [degreeCourse({ categoryId: majorCore.id, credits: 30, status: 'completed' })],
+    });
+    const result = generateOfflineAdvisorReply('What should I take next semester?', input);
+    expect(result.reply).toContain('General Education: 36 credits still needed');
+    expect(result.reply).not.toContain('Major Core');
+  });
+});

--- a/src/lib/advisor/buildContext.ts
+++ b/src/lib/advisor/buildContext.ts
@@ -1,0 +1,117 @@
+import {
+  computeOverallProgress,
+  computeCategoryProgress,
+  groupCoursesByTerm,
+} from '@/lib/degreeCompass/progress';
+import type { DegreeCourse, DegreeProfile } from '@/types/degreeCompass';
+import type { Course } from '@/types/schedule';
+
+export interface AdvisorReasoningSummary {
+  degreeConnected: boolean;
+  completedTerms: number;
+  creditsCompleted: number;
+  creditsInProgress: number;
+  creditsRequired: number;
+}
+
+/** A trimmed, client-sent summary of a Course - `title`/`term` stay
+ * optional here even though they're required on the real `Course` type,
+ * since the request body this is built from is untyped JSON off the wire. */
+export interface AdvisorCourseSummary extends Pick<Course, 'code'> {
+  title?: string;
+  term?: string;
+}
+
+export interface AdvisorContextInput {
+  degreeProfile: DegreeProfile | null;
+  degreeCourses: DegreeCourse[];
+  courses: AdvisorCourseSummary[];
+  pendingTaskCount: number;
+  overdueTaskCount: number;
+}
+
+function countCompletedTerms(degreeCourses: DegreeCourse[]): number {
+  return new Set(degreeCourses.filter((c) => c.status === 'completed').map((c) => c.term)).size;
+}
+
+/** Small, display-ready numbers for the "Reasoning over" panel - kept
+ * separate from the prose context block below so the UI never has to parse
+ * the model's own text back out to render a stat. */
+export function summarizeAdvisorContext(input: AdvisorContextInput): AdvisorReasoningSummary {
+  if (!input.degreeProfile) {
+    return {
+      degreeConnected: false,
+      completedTerms: 0,
+      creditsCompleted: 0,
+      creditsInProgress: 0,
+      creditsRequired: 0,
+    };
+  }
+  const overall = computeOverallProgress(input.degreeProfile.categories, input.degreeCourses);
+  return {
+    degreeConnected: true,
+    completedTerms: countCompletedTerms(input.degreeCourses),
+    creditsCompleted: overall.creditsCompleted,
+    creditsInProgress: overall.creditsInProgress,
+    creditsRequired: overall.creditsRequired,
+  };
+}
+
+function currentTermBlock(input: AdvisorContextInput): string {
+  const courseLines = input.courses.length
+    ? input.courses
+        .map((c) => `- ${c.code}${c.title ? ` — ${c.title}` : ''} (${c.term ?? 'no term set'})`)
+        .join('\n')
+    : '- none on file';
+  return [
+    'Current syllabus-tracked courses (from Courses, separate from the Degree Compass ledger below):',
+    courseLines,
+    `Tasks: ${input.pendingTaskCount} pending, ${input.overdueTaskCount} overdue.`,
+  ].join('\n');
+}
+
+/**
+ * Renders the student's real data as a plain-text block for the Advisor's
+ * system prompt. The model reasons only over what's written here, never
+ * over a raw Firestore dump - every fact it can cite is one this function
+ * chose to include, and everything it can't see (an official transcript,
+ * a registrar's prerequisite chains, add/drop deadlines) is named as out of
+ * scope so the model doesn't imply it has access it doesn't.
+ */
+export function buildAdvisorContextBlock(input: AdvisorContextInput): string {
+  const { degreeProfile, degreeCourses } = input;
+
+  if (!degreeProfile) {
+    return [
+      "Degree Compass: not set up yet. The student has no saved degree plan - don't invent credit totals, categories, or a graduation timeline. If asked a whole-degree question, say Degree Compass needs to be set up first, then answer whatever you can from the current-term data below.",
+      currentTermBlock(input),
+    ].join('\n\n');
+  }
+
+  const overall = computeOverallProgress(degreeProfile.categories, degreeCourses);
+  const categoryProgress = computeCategoryProgress(degreeProfile.categories, degreeCourses);
+  const termGroups = groupCoursesByTerm(degreeCourses);
+
+  const categoryLines = categoryProgress
+    .map((c) => {
+      const earned = c.creditsCompleted + c.creditsInProgress;
+      return `- ${c.category.name}: ${earned}/${c.category.creditsRequired} credits (${c.creditsRemaining} remaining)`;
+    })
+    .join('\n');
+
+  const termLines = termGroups.length
+    ? termGroups
+        .map((g) => `- ${g.term}: ${g.courses.length} course(s), ${g.totalCredits} credits`)
+        .join('\n')
+    : '- none on file';
+
+  return [
+    `Degree Compass plan: ${degreeProfile.majorName}${degreeProfile.minorName ? ` (minor: ${degreeProfile.minorName})` : ''}.`,
+    `Overall: ${overall.creditsCompleted} completed + ${overall.creditsInProgress} in-progress credits, out of ${overall.creditsRequired} required.`,
+    `Completed terms: ${countCompletedTerms(degreeCourses)}.`,
+    'Requirement categories:\n' + categoryLines,
+    'Terms in the saved plan:\n' + termLines,
+    currentTermBlock(input),
+    "This is the student's own saved plan, not their official transcript - you can be wrong about prerequisite chains, add/drop deadlines, or what actually counts toward graduation. Say so whenever a question depends on those.",
+  ].join('\n\n');
+}

--- a/src/lib/advisor/offlineAdvisor.ts
+++ b/src/lib/advisor/offlineAdvisor.ts
@@ -1,0 +1,93 @@
+import { computeCategoryProgress, computeOverallProgress } from '@/lib/degreeCompass/progress';
+import type { AdvisorReply } from '@/types/advisor';
+import type { AdvisorContextInput } from './buildContext';
+
+/**
+ * Deterministic fallback for when ANTHROPIC_API_KEY isn't configured (local
+ * dev, emulator-only setups) - same role as generateOfflineSyllabusAnswer
+ * for the syllabus chat. Reasons over the same real data the AI path would,
+ * just with keyword matching instead of a model, so the Advisor is still
+ * genuinely useful with zero external dependencies.
+ */
+export function generateOfflineAdvisorReply(
+  message: string,
+  input: AdvisorContextInput,
+): AdvisorReply {
+  const q = message.toLowerCase();
+  const { degreeProfile, degreeCourses } = input;
+
+  // A drop/withdraw question is flagged high-stakes unconditionally - this
+  // engine has no registrar data (add/drop deadlines, prerequisite chains),
+  // so it can never rule out the risk, only warn about it.
+  if (q.includes('drop') || q.includes('withdraw')) {
+    return {
+      reply:
+        "Dropping or withdrawing from a course can affect your full-time status, a prerequisite chain, or your graduation timeline - I don't have access to your official enrollment, add/drop deadlines, or your program's specific prerequisite rules, so I can't confirm what this would actually do. Check with your academic advisor before making the change.",
+      highStakes: {
+        reason: 'High-stakes decision detected',
+        detail:
+          "I can't verify enrollment status, prerequisite chains, or add/drop deadlines from your saved data - confirm with your advisor before dropping a course.",
+      },
+    };
+  }
+
+  if (!degreeProfile) {
+    return {
+      reply:
+        'You haven\'t set up Degree Compass yet, so I can\'t reason about your overall degree progress or graduation timeline. Set it up from the Degree page and I\'ll be able to answer questions like "what should I take next" or "am I on track to graduate."',
+    };
+  }
+
+  const overall = computeOverallProgress(degreeProfile.categories, degreeCourses);
+  const earnedCredits = overall.creditsCompleted + overall.creditsInProgress;
+  const pct = overall.creditsRequired
+    ? Math.round((earnedCredits / overall.creditsRequired) * 100)
+    : 0;
+  const completedTerms = new Set(
+    degreeCourses.filter((c) => c.status === 'completed').map((c) => c.term),
+  ).size;
+
+  if (q.includes('track') || q.includes('graduat') || q.includes('pace') || q.includes('on time')) {
+    const perTerm = completedTerms > 0 ? earnedCredits / completedTerms : 0;
+    const termsRemaining =
+      perTerm > 0 ? Math.ceil((overall.creditsRequired - earnedCredits) / perTerm) : null;
+    const paceLine =
+      completedTerms > 0
+        ? `You've completed ${earnedCredits} of ${overall.creditsRequired} credits (${pct}%) across ${completedTerms} completed term${completedTerms === 1 ? '' : 's'}, averaging ${perTerm.toFixed(1)} credits/term.`
+        : `You've completed ${earnedCredits} of ${overall.creditsRequired} credits (${pct}%), but no term is marked completed yet, so I can't project a pace.`;
+    const projectionLine =
+      termsRemaining !== null
+        ? ` At that pace, you'd need roughly ${termsRemaining} more term${termsRemaining === 1 ? '' : 's'} to finish.`
+        : '';
+    return { reply: paceLine + projectionLine };
+  }
+
+  if (
+    q.includes('next semester') ||
+    q.includes('next term') ||
+    q.includes('take next') ||
+    q.includes('what should i take')
+  ) {
+    const categoryProgress = computeCategoryProgress(degreeProfile.categories, degreeCourses)
+      .filter((c) => c.creditsRemaining > 0)
+      .sort((a, b) => b.creditsRemaining - a.creditsRemaining);
+
+    if (categoryProgress.length === 0) {
+      return {
+        reply:
+          "Every requirement category in your Degree Compass plan is fully covered - looks like you're set. Double check with your advisor before assuming you're done.",
+      };
+    }
+    const lines = categoryProgress
+      .slice(0, 3)
+      .map((c) => `- ${c.category.name}: ${c.creditsRemaining} credits still needed`)
+      .join('\n');
+    return {
+      reply: `Based on your saved Degree Compass plan, these categories have the most remaining credits:\n\n${lines}\n\nI don't have your program's specific course catalog or prerequisite chains, so I can't name exact courses - check your catalog or advisor for what's offered next term in these categories.`,
+    };
+  }
+
+  return {
+    reply: `You've completed ${earnedCredits} of ${overall.creditsRequired} credits (${pct}%) toward ${degreeProfile.majorName}. Ask me things like "what should I take next" or "am I on track to graduate" and I'll reason over your saved Degree Compass plan.`,
+  };
+}

--- a/src/lib/ai/advisorTool.ts
+++ b/src/lib/ai/advisorTool.ts
@@ -1,0 +1,48 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+export function buildAdvisorSystemPrompt(contextBlock: string): string {
+  return `You are the Syllabus Sense AI Advisor - a standing conversation about a student's whole degree, not a per-syllabus drawer. You reason ONLY over the data given below. You have no access to the student's official transcript, their institution's course catalog, registrar records, add/drop deadlines, or real prerequisite chains.
+
+${contextBlock}
+
+Rules:
+- Never invent a specific course number, prerequisite, deadline, or policy that isn't in the data above - if a question needs one, say you don't have it and suggest the student confirm with their advisor or registrar.
+- Flag highStakes whenever the question involves: dropping below full-time status (typically 12 credits/term), a graduation-requirement window, a prerequisite chain that could break, or anything you are not confident about answering from the data you have.
+- Keep replies concise and specific: short paragraphs or a short dash list, plain text (no markdown headers, no code fences).`;
+}
+
+export function buildAdvisorTool(): Anthropic.Tool {
+  return {
+    name: 'record_advisor_reply',
+    description:
+      "Records the Advisor's reply to the student, and whether it touches a high-stakes decision.",
+    input_schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['reply'],
+      properties: {
+        reply: {
+          type: 'string',
+          description: "The Advisor's answer to the student, in plain text.",
+        },
+        highStakes: {
+          type: 'object',
+          description:
+            'Only include when this answer touches a high-stakes decision: dropping below full-time, a graduation-requirement window, a prerequisite chain, or your own low confidence.',
+          additionalProperties: false,
+          required: ['reason', 'detail'],
+          properties: {
+            reason: {
+              type: 'string',
+              description: 'Short label, e.g. "Drops you below full-time".',
+            },
+            detail: {
+              type: 'string',
+              description: 'One or two sentence explanation of the risk.',
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/lib/firestore/__tests__/rules.spec.ts
+++ b/src/lib/firestore/__tests__/rules.spec.ts
@@ -92,6 +92,10 @@ const ownedDocPaths: Array<{ label: string; path: (uid: string) => string }> = [
     label: 'degree course (users/{uid}/degreeCourses/{id})',
     path: (uid) => `users/${uid}/degreeCourses/course-1`,
   },
+  {
+    label: 'advisor message (users/{uid}/advisorMessages/{id})',
+    path: (uid) => `users/${uid}/advisorMessages/message-1`,
+  },
 ];
 
 describe('firestore.rules: owner-only access', () => {
@@ -153,6 +157,7 @@ describe('firestore.rules: cross-user collection queries', () => {
     { label: 'moodEntries', path: (uid) => `users/${uid}/moodEntries` },
     { label: 'degreeProfile', path: (uid) => `users/${uid}/degreeProfile` },
     { label: 'degreeCourses', path: (uid) => `users/${uid}/degreeCourses` },
+    { label: 'advisorMessages', path: (uid) => `users/${uid}/advisorMessages` },
   ];
 
   describe.each(collectionPaths)("listing another user's $label", ({ path: collectionPath }) => {

--- a/src/lib/firestore/advisor.ts
+++ b/src/lib/firestore/advisor.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  type FirestoreError,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase/client';
+import { useToast } from '@/components/ui/Toast';
+import type { AdvisorMessage } from '@/types/advisor';
+
+function requireDb() {
+  if (!db) throw new Error('Firestore is not configured.');
+  return db;
+}
+
+/**
+ * The Advisor is "a standing conversation about your whole degree, not a
+ * per-syllabus drawer" (per the design direction) - the history is real,
+ * persisted Firestore state rather than component state, so it survives a
+ * refresh or a return visit the same way every other collection in this app
+ * does.
+ */
+export async function appendAdvisorMessage(userId: string, message: AdvisorMessage): Promise<void> {
+  const record: AdvisorMessage = { ...message };
+  if (!record.warning) delete record.warning;
+  await setDoc(doc(requireDb(), 'users', userId, 'advisorMessages', record.id), record);
+}
+
+export function useAdvisorMessages(userId: string | undefined): {
+  messages: AdvisorMessage[];
+  loading: boolean;
+} {
+  const [messages, setMessages] = useState<AdvisorMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { showError } = useToast();
+
+  useEffect(() => {
+    if (!userId || !db) {
+      setLoading(false);
+      return;
+    }
+    const q = query(
+      collection(db, 'users', userId, 'advisorMessages'),
+      orderBy('createdAt', 'asc'),
+    );
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        setMessages(snapshot.docs.map((d) => d.data() as AdvisorMessage));
+        setLoading(false);
+      },
+      (error: FirestoreError) => {
+        console.error('[useAdvisorMessages] listener failed:', error);
+        showError("Couldn't load your Advisor conversation", 'Try refreshing the page.');
+        setLoading(false);
+      },
+    );
+    return unsubscribe;
+  }, [userId, showError]);
+
+  return { messages, loading };
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -52,6 +52,10 @@ export const NAV_ICON_PATHS = {
     'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
   mood: 'M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
   profile: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+  /** Same bolt glyph as ICON_PATHS.planner (the AI Copilot mark elsewhere in
+   * the app) - the Advisor is an AI feature, so it reuses the established
+   * "AI" glyph rather than introducing a second one. */
+  advisor: 'M13 10V3L4 14h7v7l9-11h-7z',
 } as const;
 
 export type NavIconKey = keyof typeof NAV_ICON_PATHS;

--- a/src/types/advisor.ts
+++ b/src/types/advisor.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+/**
+ * Surfaced when the Advisor's answer touches a high-stakes decision (drops
+ * the student below full-time, a graduation-requirement window, a
+ * prerequisite chain, or the Advisor's own low confidence) - kept as a
+ * separate, structured field rather than baked into `content` so the UI can
+ * render it as its own warning card instead of relying on the model to
+ * format a callout consistently in prose every time.
+ */
+export interface AdvisorWarning {
+  /** Short label, e.g. "Drops you below full-time". */
+  reason: string;
+  /** One or two sentence explanation of the risk. */
+  detail: string;
+}
+
+export type AdvisorRole = 'user' | 'assistant';
+
+export interface AdvisorMessage {
+  id: string;
+  role: AdvisorRole;
+  content: string;
+  warning?: AdvisorWarning;
+  createdAt: string;
+}
+
+export const advisorWarningSchema = z.object({
+  reason: z.string().min(1),
+  detail: z.string().min(1),
+});
+
+export const advisorReplySchema = z.object({
+  reply: z.string().min(1),
+  highStakes: advisorWarningSchema.optional(),
+});
+
+export type AdvisorReply = z.infer<typeof advisorReplySchema>;


### PR DESCRIPTION
## Summary

Builds the AI Advisor Copilot from the design exploration, scoped to two of its three directions:

- **Direction B (dedicated surface)**: a new `/advisor` page — a standing, Firestore-persisted conversation that reasons over a student's whole Degree Compass plan (categories, terms, credits) plus their current courses/tasks, not just one syllabus. Includes a "Reasoning over" panel, a "Recent questions" list, and a high-stakes warning card (drop/withdraw questions, graduation-window risk, prerequisite-chain uncertainty, or the Advisor's own low confidence) with a disclaimer and a link to Contacts.
- **Direction C (proactive nudge)**: a gradient insight card on the Dashboard that only renders when a real, computed requirement-category gap exists (no filler insight for an empty or on-track plan) and deep-links into the Advisor with that question pre-asked.

Direction A (the per-syllabus drawer toggle) was deliberately left out of this pass.

## What changed, by piece

- **`/api/advisor/chat`**: server route that builds a plain-text context block from the student's own Degree Compass/course/task data (never a raw Firestore dump) and calls Anthropic with a forced tool call (`record_advisor_reply`) so the reply and any high-stakes flag come back as structured data, not parsed prose. Falls back to a deterministic offline engine (real keyword-driven reasoning over the same data) when `ANTHROPIC_API_KEY` isn't configured, matching the existing syllabus-chat route's pattern.
- **Advisor UI** (`AdvisorView`, `AdvisorWarningCard`): chat transcript persisted to `users/{uid}/advisorMessages`, auto-sends a deep-linked question only after the Degree Compass listeners have actually loaded (fixes a real race condition caught during verification — see below).
- **Dashboard nudge** (`AdvisorInsightCard`): compares each requirement category's completion percentage against the plan's overall percentage; only renders when a category trails by a real, meaningful margin.
- **`firestore.rules`** + `rules.spec.ts`: added owner-only rules for the new `advisorMessages` subcollection, with the same owner/cross-user/unauthenticated coverage every other collection gets.
- **Nav**: added an "Advisor" entry to the sidebar and mobile "More" menu, reusing the existing AI-copilot bolt glyph rather than inventing a new icon.

## A bug found and fixed during verification

The dashboard's "Continue in Advisor" link used to fire its question as soon as the Advisor page mounted, before the page's own Degree Compass Firestore listeners had delivered their first snapshot — so the very first (most important) reply reasoned over an empty plan. Fixed by gating the auto-send effect on the Degree Compass profile's own loading state.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean
- `npm run build`: clean production build, `/advisor` and `/api/advisor/chat` present in the route manifest
- `npm run test`: 695/695 passing (added unit tests for the offline advisor engine and the context builder)
- Live-verified against the real Firebase Local Emulator Suite + a real Playwright/Chromium session (a real `ANTHROPIC_API_KEY` was available in this environment's `.env.local`, so this exercised the actual Anthropic tool-use path, not just the offline fallback): signed up a real test user, set up Degree Compass with an intentionally lagging category, confirmed the dashboard nudge computed and displayed the correct real gap, followed the deep link into the Advisor, asked a drop question and confirmed the high-stakes warning card rendered, asked a "what should I take next" question, reloaded the page to confirm the conversation persists, and checked both desktop sidebar and mobile "More" menu nav entries.
- A full review-doc Artifact with screenshots from this verification pass will be published and linked separately before requesting merge approval, per this repo's standing process.

## Test plan

- [x] `tsc`, `lint`, `build`, `vitest` all green locally
- [ ] CI green on this PR
- [ ] Review-doc Artifact published and linked
- [ ] Repo owner's explicit merge go-ahead